### PR TITLE
Fixes get_task automatically fetching private dataset from HF

### DIFF
--- a/tasks/ARC/ARC.py
+++ b/tasks/ARC/ARC.py
@@ -76,7 +76,7 @@ def load_hf_dataset(dataset_path, split, hf_token=None, size=None, name=None, pa
 
     return datasets
 
-def get_task(hf=True, size=None):
+def get_task(hf=True, size=None, include_private: bool = False):
     # Load dataset from HuggingFace with customized parsing
     datasets = {}
     for split in ["train", "validation", "test"]:
@@ -87,13 +87,15 @@ def get_task(hf=True, size=None):
             size=size
         )
         datasets.update(temp)
-    private = load_hf_dataset(
-        dataset_path="mech-interp-bench/arc_easy_private_test",
-        split="test",
-        parse_fn=parse_arc_easy_example,
-        size=size
-    )
-    datasets.update({k+"private":v for k,v in private.items()})
+
+    if include_private:
+        private = load_hf_dataset(
+            dataset_path="mech-interp-bench/arc_easy_private_test",
+            split="test",
+            parse_fn=parse_arc_easy_example,
+            size=size
+        )
+        datasets.update({k+"private":v for k,v in private.items()})
     
     # Build a prompt-to-answerKey lookup dictionary for efficient searching
     prompt_to_answerkey = {}

--- a/tasks/IOI_task/ioi_task.py
+++ b/tasks/IOI_task/ioi_task.py
@@ -21,7 +21,7 @@ def get_data(path):
         data = json.load(f)
     return data
 
-def get_task(hf=True, size=None):
+def get_task(hf=True, size=None, include_private: bool = False):
     variables = ["output_position", "output_token", "template", "name_A", "name_B", "name_C", "place", "object", "logit_diff"]
 
     name_path = os.path.join("tasks", os.path.join("IOI_task", 'names.json'))
@@ -213,14 +213,16 @@ def get_task(hf=True, size=None):
                 ignore_names=["random", "abc"]
             )
             datasets.update(temp)
-        private = model.load_hf_dataset(
-            dataset_path="mech-interp-bench/ioi_private_test",
-            split="test",
-            parse_fn=input_parser,
-            size=size,
-            ignore_names=["random", "abc"]
-        )
-        datasets.update({k+"private":v for k,v in private.items()})
+
+        if include_private:
+            private = model.load_hf_dataset(
+                dataset_path="mech-interp-bench/ioi_private_test",
+                split="test",
+                parse_fn=input_parser,
+                size=size,
+                ignore_names=["random", "abc"]
+            )
+            datasets.update({k+"private":v for k,v in private.items()})
 
     return Task(model, datasets, input_dumper, output_dumper,input_parser, id=f"ioi_task")
 

--- a/tasks/RAVEL/ravel.py
+++ b/tasks/RAVEL/ravel.py
@@ -43,7 +43,7 @@ def generate_prompt_to_template(task):
   return prompt_to_template
 
 
-def get_task(hf=True, size=None):
+def get_task(hf=True, size=None, include_private: bool = False):
     if not _CITY_ENTITY:
         _CITY_ENTITY.update(json.load(open(os.path.join(_RAVEL_DATA_DIR, 'ravel_city_entity.json'))))
 
@@ -118,14 +118,16 @@ def get_task(hf=True, size=None):
                 shuffle=True
             )
             datasets.update(temp)
-        private = model.load_hf_dataset(
-            dataset_path="yiksiu/mib_ravel_private_test",
-            split="test",
-            parse_fn=parse_ravel_example,
-            size=size,
-            shuffle=True
-        )
-        datasets.update({k+"private":v for k,v in private.items()})
+
+        if include_private:
+            private = model.load_hf_dataset(
+                dataset_path="yiksiu/mib_ravel_private_test",
+                split="test",
+                parse_fn=parse_ravel_example,
+                size=size,
+                shuffle=True
+            )
+            datasets.update({k+"private":v for k,v in private.items()})
 
         return Task(model, datasets, input_dumper, output_dumper, id="RAVEL_task")
 

--- a/tasks/simple_MCQA/simple_MCQA.py
+++ b/tasks/simple_MCQA/simple_MCQA.py
@@ -17,7 +17,7 @@ from model_units.LM_units import TokenPosition, get_last_token_index
 import re
 
 
-def get_task(hf=True, size=None):
+def get_task(hf=True, size=None, include_private: bool = False):
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'object_color_pairs.json')
     #Load grandparent directory
     with open(path, 'r') as f:
@@ -102,15 +102,17 @@ def get_task(hf=True, size=None):
                 ignore_names=["noun", "color", "symbol"]
             )
             datasets.update(temp)
-        private = model.load_hf_dataset(
-            dataset_path="mech-interp-bench/copycolors_mcqa_private_test",
-            split="test",
-            name=f"{NUM_CHOICES}_answer_choices",
-            parse_fn=parse_mcqa_example,
-            size=size,
-            ignore_names=["noun", "color", "symbol"]
-        )
-        datasets.update({k+"private":v for k,v in private.items()})
+
+        if include_private:
+            private = model.load_hf_dataset(
+                dataset_path="mech-interp-bench/copycolors_mcqa_private_test",
+                split="test",
+                name=f"{NUM_CHOICES}_answer_choices",
+                parse_fn=parse_mcqa_example,
+                size=size,
+                ignore_names=["noun", "color", "symbol"]
+            )
+            datasets.update({k+"private":v for k,v in private.items()})
 
         return Task(model, datasets, input_dumper, output_dumper,input_parser, id=f"{NUM_CHOICES}_answer_MCQA")
 

--- a/tasks/two_digit_addition_task/arithmetic.py
+++ b/tasks/two_digit_addition_task/arithmetic.py
@@ -14,7 +14,7 @@ from model_units.LM_units import TokenPosition, get_last_token_index
 import re
 import random
 
-def get_task(hf=True, size=None):
+def get_task(hf=True, size=None, include_private: bool = False):
     variables = [
         "op1_tens", "op1_ones",
         "op2_tens", "op2_ones",
@@ -85,14 +85,15 @@ def get_task(hf=True, size=None):
             )
             datasets.update(temp)
 
-        private = model.load_hf_dataset(
-            dataset_path="mech-interp-bench/arithmetic_addition_private_test",
-            split="test",
-            size=size,
-            parse_fn=parse_arithmetic_example,
-            ignore_names=["ones_op1", "ones_op2", "tens_op1", "tens_op2", "tens_carry"]
-        )
-        datasets.update({k+"private":v for k,v in private.items()})
+        if include_private:
+            private = model.load_hf_dataset(
+                dataset_path="mech-interp-bench/arithmetic_addition_private_test",
+                split="test",
+                size=size,
+                parse_fn=parse_arithmetic_example,
+                ignore_names=["ones_op1", "ones_op2", "tens_op1", "tens_op2", "tens_carry"]
+            )
+            datasets.update({k+"private":v for k,v in private.items()})
 
         return Task(model, datasets, input_dumper, output_dumper, id="arithmetic")
 


### PR DESCRIPTION
As mentioned in #2, `get_task(...)` tries to always fetch the private dataset from HF. This PR adds a parameter `include_private: bool = False` to get_task() to explicitly include the private dataset.