### PR TITLE
Fix badge link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Causal Abstraction for Mechanistic Interpretability
 
-[![Tests](https://github.com/goodfire-ai/causalab/actions/workflows/test.yml/badge.svg)](https://github.com/goodfire-ai/causalab/actions/workflows/test.yml)
+[![Tests](https://github.com/goodfire-ai/causalab/actions/workflows/test.yml/badge.svg)
 
 This repository supports mechanistic interpretability experiments that reverse engineer what algorithm a neural network implements with causal abstraction.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Causal Abstraction for Mechanistic Interpretability
 
-![Tests](https://github.com/goodfire-ai/causalab-internal/workflows/Tests/badge.svg)
+[![Tests](https://github.com/goodfire-ai/causalab/actions/workflows/test.yml/badge.svg)](https://github.com/goodfire-ai/causalab/actions/workflows/test.yml)
 
 This repository supports mechanistic interpretability experiments that reverse engineer what algorithm a neural network implements with causal abstraction.
 


### PR DESCRIPTION
Current badge doesn't render properly, correcting with status badge from https://github.com/goodfire-ai/causalab/actions/workflows/test.yml

Reference https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge#using-the-ui