### PR TITLE
Add causalab/methods/path_patching: exact edge-level path patching (engine, guards, pyvene twin, K/V surface)

### DIFF
--- a/causalab/analyses/activation_manifold/main.py
+++ b/causalab/analyses/activation_manifold/main.py
@@ -129,6 +129,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
             device=cfg.model.device,
             dtype=cfg.model.get("dtype"),
             eager_attn=cfg.model.get("eager_attn"),
+            attn_implementation=cfg.model.get("attn_implementation"),
         )
         logger.info("Model loading: %.1fs", _time.time() - _t)
 

--- a/causalab/analyses/attention_pattern/main.py
+++ b/causalab/analyses/attention_pattern/main.py
@@ -144,6 +144,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
         device=cfg.model.device,
         dtype=cfg.model.get("dtype"),
         eager_attn=cfg.model.get("eager_attn"),
+        attn_implementation=cfg.model.get("attn_implementation"),
     )
 
     # --- Generate correct examples ---

--- a/causalab/analyses/baseline/main.py
+++ b/causalab/analyses/baseline/main.py
@@ -196,6 +196,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
         device=cfg.model.device,
         dtype=cfg.model.get("dtype"),
         eager_attn=cfg.model.get("eager_attn"),
+        attn_implementation=cfg.model.get("attn_implementation"),
     )
     score_token_ids, n_score_tokens = get_output_token_ids(task, pipeline)
     n_classes = (

--- a/causalab/analyses/locate/main.py
+++ b/causalab/analyses/locate/main.py
@@ -341,6 +341,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
         device=cfg.model.device,
         dtype=cfg.model.get("dtype"),
         eager_attn=cfg.model.get("eager_attn"),
+        attn_implementation=cfg.model.get("attn_implementation"),
     )
 
     # Optionally load a source pipeline for cross-model patching.
@@ -360,6 +361,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
             device=cfg.model.device,
             dtype=cfg.model.get("dtype"),
             eager_attn=cfg.model.get("eager_attn"),
+            attn_implementation=cfg.model.get("attn_implementation"),
         )
 
     logger.info("Locate scan over variables: %s", target_variables)

--- a/causalab/analyses/output_manifold/main.py
+++ b/causalab/analyses/output_manifold/main.py
@@ -157,6 +157,7 @@ def _build_belief_artifacts(cfg: DictConfig, out_root: str, batch_size: int) -> 
             device=cfg.model.device,
             dtype=cfg.model.get("dtype"),
             eager_attn=cfg.model.get("eager_attn"),
+            attn_implementation=cfg.model.get("attn_implementation"),
         )
         score_token_ids, _ = get_output_token_ids(task, pipeline)
         if score_token_ids is None or not task.intervention_values:

--- a/causalab/analyses/path_steering/main.py
+++ b/causalab/analyses/path_steering/main.py
@@ -233,6 +233,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
             device=cfg.model.device,
             dtype=cfg.model.get("dtype"),
             eager_attn=cfg.model.get("eager_attn"),
+            attn_implementation=cfg.model.get("attn_implementation"),
         )
 
     # Build graph-edge metadata for visualization on graph_walk tasks

--- a/causalab/analyses/pullback/main.py
+++ b/causalab/analyses/pullback/main.py
@@ -360,6 +360,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
         device=cfg.model.device,
         dtype=cfg.model.get("dtype"),
         eager_attn=cfg.model.get("eager_attn"),
+        attn_implementation=cfg.model.get("attn_implementation"),
     )
     model = pipeline.model
     tokenizer = pipeline.tokenizer

--- a/causalab/analyses/subspace/main.py
+++ b/causalab/analyses/subspace/main.py
@@ -1113,6 +1113,7 @@ def main(cfg: DictConfig) -> dict[str, Any]:
         device=cfg.model.device,
         dtype=cfg.model.get("dtype"),
         eager_attn=cfg.model.get("eager_attn"),
+        attn_implementation=cfg.model.get("attn_implementation"),
     )
 
     try:

--- a/causalab/configs/model/gemma2_2b.yaml
+++ b/causalab/configs/model/gemma2_2b.yaml
@@ -1,0 +1,6 @@
+id: gemma2_2b
+name: google/gemma-2-2b
+device: auto
+dtype: bfloat16
+slurm:
+  gpus: 1

--- a/causalab/configs/model/gemma2_2b.yaml
+++ b/causalab/configs/model/gemma2_2b.yaml
@@ -4,3 +4,4 @@ device: auto
 dtype: bfloat16
 slurm:
   gpus: 1
+attn_implementation: eager

--- a/causalab/configs/model/gpt2.yaml
+++ b/causalab/configs/model/gpt2.yaml
@@ -4,3 +4,4 @@ device: auto
 dtype: float32
 slurm:
   gpus: 1
+attn_implementation: eager

--- a/causalab/configs/model/llama31_8b.yaml
+++ b/causalab/configs/model/llama31_8b.yaml
@@ -4,3 +4,4 @@ device: auto
 dtype: bfloat16
 slurm:
   gpus: 1
+attn_implementation: eager

--- a/causalab/configs/model/pythia70m.yaml
+++ b/causalab/configs/model/pythia70m.yaml
@@ -1,0 +1,6 @@
+id: pythia70m
+name: EleutherAI/pythia-70m-deduped
+device: auto
+dtype: float32
+slurm:
+  gpus: 1

--- a/causalab/configs/model/pythia70m.yaml
+++ b/causalab/configs/model/pythia70m.yaml
@@ -4,3 +4,4 @@ device: auto
 dtype: float32
 slurm:
   gpus: 1
+attn_implementation: eager

--- a/causalab/io/pipelines.py
+++ b/causalab/io/pipelines.py
@@ -34,6 +34,7 @@ def load_pipeline(
     device: str | None = None,
     dtype: str | None = None,
     eager_attn: bool | None = None,
+    attn_implementation: str | None = None,
 ):
     """Load an ``LMPipeline`` from explicit parameters."""
     from causalab.neural.pipeline import LMPipeline, resolve_device
@@ -60,6 +61,10 @@ def load_pipeline(
         model_kwargs["dtype"] = DTYPE_MAP.get(dtype, torch.bfloat16)
     if eager_attn is False:
         model_kwargs["eager_attn"] = False
+    if attn_implementation is not None:
+        # model YAMLs pass this through (e.g. attn_implementation: eager for
+        # K/V-side path patching); wins over eager_attn, see LMPipeline
+        model_kwargs["attn_implementation"] = attn_implementation
 
     pipeline = LMPipeline(model_name, max_new_tokens=max_new_tokens, **model_kwargs)
 

--- a/causalab/methods/path_patching/__init__.py
+++ b/causalab/methods/path_patching/__init__.py
@@ -32,7 +32,14 @@ from .descriptor import (
 from .edges import PathSpec
 from .engine import PatchEngine, Sender
 from .guards import GuardError, default_tolerances, run_construction_guards
-from .kv import AttnDetailCache, build_attn_detail_cache
+from .kv import (
+    AttnDetailCache,
+    KVEdge,
+    KVHead,
+    KVPatchEngine,
+    SlidingWindowError,
+    build_attn_detail_cache,
+)
 from .provenance import (
     CapturePoint,
     UnsupportedArchitectureError,
@@ -48,6 +55,10 @@ __all__ = [
     "AttnDetailCache",
     "CapturePoint",
     "GuardError",
+    "KVEdge",
+    "KVHead",
+    "KVPatchEngine",
+    "SlidingWindowError",
     "UnsupportedArchitectureError",
     "capture_provenance",
     "check_capability",

--- a/causalab/methods/path_patching/__init__.py
+++ b/causalab/methods/path_patching/__init__.py
@@ -34,10 +34,10 @@ from .engine import PatchEngine, Sender
 from .guards import GuardError, default_tolerances, run_construction_guards
 from .kv import AttnDetailCache, build_attn_detail_cache
 from .provenance import (
-    GAP_REGISTRY,
     CapturePoint,
-    GapEntry,
+    UnsupportedArchitectureError,
     capture_provenance,
+    check_capability,
     coverage_table,
     pyvene_pin,
 )
@@ -47,10 +47,10 @@ __all__ = [
     "ArchitectureDescriptor",
     "AttnDetailCache",
     "CapturePoint",
-    "GAP_REGISTRY",
-    "GapEntry",
     "GuardError",
+    "UnsupportedArchitectureError",
     "capture_provenance",
+    "check_capability",
     "coverage_table",
     "pyvene_pin",
     "PatchCache",

--- a/causalab/methods/path_patching/__init__.py
+++ b/causalab/methods/path_patching/__init__.py
@@ -1,0 +1,68 @@
+"""Analytic path patching (Hanna et al. 2023 semantics) with architecture guards.
+
+Quick start::
+
+    from causalab.methods.path_patching import (
+        PatchEngine, PathSpec, build_patch_cache, resolve_descriptor
+    )
+
+    desc = resolve_descriptor(pipeline.model)
+    clean = build_patch_cache(pipeline, desc, clean_texts, {"end": -1})
+    cf = build_patch_cache(pipeline, desc, cf_texts, {"end": -1})
+    engine = PatchEngine(desc, clean, cf)      # construction runs the guards
+
+    # sender a9.h1's direct edge to the logits:
+    logits = engine.patched_logits(("head", 9, 1), PathSpec.cascade())
+    # its paths through MLPs 8-11 (closed cascade, direct edge off-path):
+    logits = engine.patched_logits(
+        ("head", 9, 1),
+        PathSpec.cascade([8, 9, 10, 11], direct_to_logits=False),
+    )
+
+See ``docs`` for the freeze-recipe semantics, the edge-set specification,
+and a worked example.
+"""
+
+from .cache import PatchCache, build_patch_cache, padded_position
+from .descriptor import (
+    SUPPORTED_MODEL_TYPES,
+    ArchitectureDescriptor,
+    resolve_descriptor,
+)
+from .edges import PathSpec
+from .engine import PatchEngine, Sender
+from .guards import GuardError, default_tolerances, run_construction_guards
+from .kv import AttnDetailCache, build_attn_detail_cache
+from .provenance import (
+    GAP_REGISTRY,
+    CapturePoint,
+    GapEntry,
+    capture_provenance,
+    coverage_table,
+    pyvene_pin,
+)
+from .reference import reference_patched_logits
+
+__all__ = [
+    "ArchitectureDescriptor",
+    "AttnDetailCache",
+    "CapturePoint",
+    "GAP_REGISTRY",
+    "GapEntry",
+    "GuardError",
+    "capture_provenance",
+    "coverage_table",
+    "pyvene_pin",
+    "PatchCache",
+    "PatchEngine",
+    "PathSpec",
+    "SUPPORTED_MODEL_TYPES",
+    "Sender",
+    "build_attn_detail_cache",
+    "build_patch_cache",
+    "default_tolerances",
+    "padded_position",
+    "reference_patched_logits",
+    "resolve_descriptor",
+    "run_construction_guards",
+]

--- a/causalab/methods/path_patching/cache.py
+++ b/causalab/methods/path_patching/cache.py
@@ -1,0 +1,271 @@
+"""Activation cache for the analytic path-patching engine.
+
+One pass over a dataset collects, at each named token position, every
+quantity the engine needs:
+
+* ``z``            (N, L, H, head_dim)  per-head attention value output
+                   (the out-projection's input)
+* ``mlp_branch``   (N, L, d)   MLP module output — *before* any branch
+                   post-norm (Gemma-2), so trunk contributions are derived,
+                   never assumed
+* ``neuron_acts``  (N, L, d_ff)  the MLP output projection's input (post-GELU
+                   activations for GPT-2; the gated ``act(gate) * up`` values
+                   for Llama/Gemma) — optional
+* ``block_out``    (N, L, d)   residual stream after each block
+* ``embed``        (N, d)      block 0's input: the embedding contribution to
+                   the trunk (absorbs Gemma's embed scaling)
+* ``logits``       (N, vocab)  the model's final logits at the position
+
+Collection is pyvene-native: named components (``attention_value_output``,
+``mlp_output``, ``block_output``, ``block_input``) resolve through pyvene's
+per-family module mappings; the one capture point pyvene has no name for
+(the output projection's input) uses pyvene's dotted module-path fallback.
+No raw torch hooks.
+
+Each named position is **one token per example**, given in unpadded
+per-example coordinates (a non-negative absolute index, or a negative offset
+from the true end of each sequence — ``-1`` is the last real token) and
+converted to padded batch coordinates using the attention mask, so
+variable-length prompts under the pipeline's left padding are handled
+correctly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+import torch
+from torch import Tensor
+
+from causalab.neural.activations.intervenable_model import (
+    delete_intervenable_model,
+    prepare_intervenable_model,
+)
+from causalab.neural.units import AtomicModelUnit, ComponentIndexer
+
+from .descriptor import ArchitectureDescriptor
+
+__all__ = ["PatchCache", "build_patch_cache", "padded_position"]
+
+
+def padded_position(attention_mask: Tensor, position: int | Sequence[int]) -> list[int]:
+    """Convert an unpadded token position to padded batch coordinates.
+
+    ``position`` is one index applied to every example, or a per-example
+    sequence. A non-negative index counts from the start of the example's
+    true (unpadded) token sequence; a negative index counts from its true
+    end (``-1`` = last real token). Works for left or right padding by
+    reading the attention mask.
+    """
+    mask = attention_mask.long()
+    batch = mask.shape[0]
+    true_len = mask.sum(dim=1)
+    first_real = mask.argmax(dim=1)  # 0 under right padding
+
+    if isinstance(position, int):
+        per_example = [position] * batch
+    else:
+        per_example = list(position)
+        if len(per_example) != batch:
+            raise ValueError(f"{len(per_example)} positions for batch of {batch}")
+
+    out: list[int] = []
+    for i, p in enumerate(per_example):
+        n = int(true_len[i])
+        q = p if p >= 0 else n + p
+        if not 0 <= q < n:
+            raise IndexError(f"position {p} out of range for example {i} (length {n})")
+        idx = int(first_real[i]) + q
+        if mask[i, idx] != 1:
+            raise AssertionError(f"internal error: padded index {idx} lands on padding")
+        out.append(idx)
+    return out
+
+
+@dataclass
+class PatchCache:
+    """Cached activations at named single-token positions (float32, CPU)."""
+
+    n_layers: int
+    n_heads: int
+    head_dim: int
+    d_model: int
+    position_names: tuple[str, ...]
+    z: dict[str, Tensor]  # (N, L, H, head_dim)
+    mlp_branch: dict[str, Tensor]  # (N, L, d)
+    block_out: dict[str, Tensor]  # (N, L, d)
+    embed: dict[str, Tensor]  # (N, d)
+    logits: dict[str, Tensor]  # (N, vocab)
+    neuron_acts: dict[str, Tensor] = field(default_factory=dict)  # (N, L, d_ff)
+
+    @property
+    def n_examples(self) -> int:
+        return next(iter(self.block_out.values())).shape[0]
+
+    def final_resid(self, position: str) -> Tensor:
+        return self.block_out[position][:, self.n_layers - 1]
+
+    def save(self, path: str) -> None:
+        from safetensors.torch import save_file
+
+        tensors: dict[str, Tensor] = {}
+        for name in ("z", "mlp_branch", "block_out", "embed", "logits", "neuron_acts"):
+            for pos, t in getattr(self, name).items():
+                tensors[f"{name}@{pos}"] = t.contiguous()
+        tensors["_meta"] = torch.tensor(
+            [self.n_layers, self.n_heads, self.head_dim, self.d_model]
+        )
+        save_file(tensors, path, metadata={"positions": ",".join(self.position_names)})
+
+    @classmethod
+    def load(cls, path: str) -> "PatchCache":
+        from safetensors import safe_open
+        from safetensors.torch import load_file
+
+        with safe_open(path, framework="pt") as f:
+            positions = tuple(f.metadata()["positions"].split(","))
+        t = load_file(path)
+        meta = t.pop("_meta")
+        groups: dict[str, dict[str, Tensor]] = {
+            k: {}
+            for k in ("z", "mlp_branch", "block_out", "embed", "logits", "neuron_acts")
+        }
+        for key, val in t.items():
+            name, pos = key.split("@", 1)
+            groups[name][pos] = val
+        return cls(
+            n_layers=int(meta[0]),
+            n_heads=int(meta[1]),
+            head_dim=int(meta[2]),
+            d_model=int(meta[3]),
+            position_names=positions,
+            **groups,
+        )
+
+
+def _null_indexer() -> ComponentIndexer:
+    # Indices are supplied explicitly at collection time (computed padding-
+    # aware in this module); the unit-level indexer is never consulted.
+    return ComponentIndexer(lambda _x: [], id="path_patching_explicit")
+
+
+@torch.no_grad()
+def build_patch_cache(
+    pipeline: Any,
+    desc: ArchitectureDescriptor,
+    inputs: Sequence[Any],
+    positions: dict[str, int | Sequence[int]],
+    *,
+    batch_size: int = 32,
+    collect_neuron_acts: bool = True,
+) -> PatchCache:
+    """Collect a :class:`PatchCache` over ``inputs`` at ``positions``.
+
+    ``inputs`` are raw strings or causalab trace dicts (anything
+    ``pipeline.load`` accepts). ``positions`` maps a name (e.g. ``"end"``)
+    to one token position per example, in unpadded per-example coordinates
+    (see :func:`padded_position`).
+    """
+    if not positions:
+        raise ValueError("at least one named position is required")
+    pos_names = tuple(positions)
+    inputs = [{"raw_input": x} if isinstance(x, str) else x for x in inputs]
+
+    L = desc.n_layers
+    units: list[AtomicModelUnit] = []
+    unit_meta: list[tuple[str, int]] = []  # (quantity, layer)
+
+    def add_unit(quantity: str, layer: int, component: str) -> None:
+        units.append(
+            AtomicModelUnit(
+                layer, component, _null_indexer(), id=f"pp_{quantity}_l{layer}"
+            )
+        )
+        unit_meta.append((quantity, layer))
+
+    for layer in range(L):
+        add_unit("z", layer, desc.component_head_values())
+        add_unit("mlp_branch", layer, desc.component_mlp_branch())
+        add_unit("block_out", layer, desc.component_block_output())
+        if collect_neuron_acts:
+            add_unit("neuron_acts", layer, desc.component_neuron_values(layer))
+    add_unit("embed", 0, desc.component_block_input())
+
+    intervenable_model = prepare_intervenable_model(
+        pipeline, units, intervention_type="collect"
+    )
+
+    store: dict[tuple[str, int], list[Tensor]] = {m: [] for m in unit_meta}
+    logits_store: list[Tensor] = []
+    P = len(pos_names)
+
+    try:
+        for start in range(0, len(inputs), batch_size):
+            batch = list(inputs[start : start + batch_size])
+            loaded = pipeline.load(batch)
+            mask = loaded["attention_mask"]
+            bsz = mask.shape[0]
+            per_name = {
+                name: padded_position(
+                    mask,
+                    spec
+                    if isinstance(spec, int)
+                    else list(spec)[start : start + bsz]
+                    if len(list(spec)) == len(inputs)
+                    else spec,
+                )
+                for name, spec in positions.items()
+            }
+            flat = [[per_name[name][i] for name in pos_names] for i in range(bsz)]
+            indices = [flat for _ in units]
+
+            location_map = {"sources->base": (indices, indices)}
+            result = intervenable_model(loaded, unit_locations=location_map)
+            collected = result[0][1]
+            model_output = result[0][0]
+
+            for meta, act in zip(unit_meta, collected):
+                a = act if isinstance(act, Tensor) else torch.cat(list(act))
+                a = a.reshape(bsz, P, -1).float().cpu()
+                store[meta].append(a)
+
+            logits = model_output.logits.float()
+            idx = torch.tensor(flat, device=logits.device)
+            gathered = torch.stack([logits[i, idx[i]] for i in range(bsz)])
+            logits_store.append(gathered.cpu())  # (B, P, vocab)
+    finally:
+        delete_intervenable_model(intervenable_model)
+
+    pos_slot = {name: i for i, name in enumerate(pos_names)}
+
+    def split(chunks: list[Tensor]) -> dict[str, Tensor]:
+        full = torch.cat(chunks)  # (N, P, dim)
+        return {name: full[:, pos_slot[name]] for name in pos_names}
+
+    def stack_layers(quantity: str) -> dict[str, Tensor]:
+        per_layer = [split(store[(quantity, layer)]) for layer in range(L)]
+        return {
+            name: torch.stack([pl[name] for pl in per_layer], dim=1)
+            for name in pos_names
+        }
+
+    z_flat = stack_layers("z")
+    z = {
+        name: t.reshape(t.shape[0], L, desc.n_heads, desc.head_dim)
+        for name, t in z_flat.items()
+    }
+    logits_full = torch.cat(logits_store)
+    return PatchCache(
+        n_layers=L,
+        n_heads=desc.n_heads,
+        head_dim=desc.head_dim,
+        d_model=desc.d_model,
+        position_names=pos_names,
+        z=z,
+        mlp_branch=stack_layers("mlp_branch"),
+        block_out=stack_layers("block_out"),
+        embed=split(store[("embed", 0)]),
+        logits={name: logits_full[:, pos_slot[name]] for name in pos_names},
+        neuron_acts=stack_layers("neuron_acts") if collect_neuron_acts else {},
+    )

--- a/causalab/methods/path_patching/cache.py
+++ b/causalab/methods/path_patching/cache.py
@@ -150,6 +150,28 @@ def _null_indexer() -> ComponentIndexer:
     return ComponentIndexer(lambda _x: [], id="path_patching_explicit")
 
 
+def keep_last_dim_on_collects(intervenable_model) -> None:
+    """Opt every collect intervention out of pyvene's flatten/slice cycle.
+
+    pyvene's ``do_intervention`` flattens a multi-position gather
+    ``(batch, n_positions, d) -> (batch, n_positions*d)`` and the collect
+    then slices ``[..., :interchange_dim]`` where ``interchange_dim`` is
+    ``component_dim * max_number_of_units``. causalab's unit wrapper always
+    leaves ``max_number_of_units`` at 1 (everything else in the library
+    intervenes at exactly one position), so collecting more than one
+    position per example silently keeps only the first ``d`` of the
+    flattened row and unflattens the remainder into garbage —
+    ``(batch, n_positions, d/n_positions)``. Setting pyvene's own
+    ``keep_last_dim`` flag (the documented opt-out, used by its
+    ``SourcelessIntervention``) skips the flatten entirely, making the
+    slice a no-op at any position count, single-position collection
+    included.
+    """
+    for itv in intervenable_model.interventions.values():
+        obj = itv[0] if isinstance(itv, tuple) else itv
+        obj.keep_last_dim = True
+
+
 @torch.no_grad()
 def build_patch_cache(
     pipeline: Any,
@@ -195,6 +217,7 @@ def build_patch_cache(
     intervenable_model = prepare_intervenable_model(
         pipeline, units, intervention_type="collect"
     )
+    keep_last_dim_on_collects(intervenable_model)
 
     store: dict[tuple[str, int], list[Tensor]] = {m: [] for m in unit_meta}
     logits_store: list[Tensor] = []

--- a/causalab/methods/path_patching/cache.py
+++ b/causalab/methods/path_patching/cache.py
@@ -78,7 +78,7 @@ def padded_position(attention_mask: Tensor, position: int | Sequence[int]) -> li
             raise IndexError(f"position {p} out of range for example {i} (length {n})")
         idx = int(first_real[i]) + q
         if mask[i, idx] != 1:
-            raise AssertionError(f"internal error: padded index {idx} lands on padding")
+            raise AssertionError(f"internal error: padded index {idx} falls on padding")
         out.append(idx)
     return out
 
@@ -221,7 +221,9 @@ def build_patch_cache(
             indices = [flat for _ in units]
 
             location_map = {"sources->base": (indices, indices)}
-            result = intervenable_model(loaded, unit_locations=location_map)
+            result = intervenable_model(
+                loaded, unit_locations=location_map, output_original_output=True
+            )
             collected = result[0][1]
             model_output = result[0][0]
 

--- a/causalab/methods/path_patching/descriptor.py
+++ b/causalab/methods/path_patching/descriptor.py
@@ -280,7 +280,9 @@ def resolve_descriptor(
     config = model.config
     model_type = config.model_type
     if model_type not in _FAMILIES:
-        raise NotImplementedError(
+        from .provenance import UnsupportedArchitectureError
+
+        raise UnsupportedArchitectureError(
             f"path_patching has no architecture descriptor for model_type="
             f"{model_type!r}. Supported: {SUPPORTED_MODEL_TYPES}. Add a "
             f"_FamilySpec and validate it with guards.run_construction_guards."

--- a/causalab/methods/path_patching/descriptor.py
+++ b/causalab/methods/path_patching/descriptor.py
@@ -37,6 +37,9 @@ __all__ = [
 ]
 
 
+QKVStyle = Literal["fused-split3", "separate", "fused-interleaved"]
+
+
 @dataclass(frozen=True)
 class _FamilySpec:
     """Static per-family module naming (relative attribute paths)."""
@@ -54,6 +57,15 @@ class _FamilySpec:
     out_proj_is_conv1d: bool  # GPT-2 Conv1D (x @ W) vs nn.Linear (x @ W.T)
     attention_style_default: AttentionStyle
     norm_kind: NormKind
+    # ---- attention detail (K/V-side patching) ----
+    attn_module: str  # on a block: the attention module
+    attn_pre_norm: str  # on a block: norm applied to the attention branch input
+    qkv_style: QKVStyle  # how q/k/v projections are parameterized
+    q_proj: str  # on a block: query projection ("" for fused styles)
+    k_proj: str
+    v_proj: str
+    qkv_fused: str  # on a block: the fused projection ("" for separate)
+    rotary_emb_path: str | None  # on the CausalLM model: shared rotary module
 
 
 _FAMILIES: dict[str, _FamilySpec] = {
@@ -71,6 +83,14 @@ _FAMILIES: dict[str, _FamilySpec] = {
         out_proj_is_conv1d=True,
         attention_style_default="fused-qkv-absolute",
         norm_kind="layernorm",
+        attn_module="attn",
+        attn_pre_norm="ln_1",
+        qkv_style="fused-split3",
+        q_proj="",
+        k_proj="",
+        v_proj="",
+        qkv_fused="attn.c_attn",
+        rotary_emb_path=None,
     ),
     "gpt_neox": _FamilySpec(
         layers_path="gpt_neox.layers",
@@ -86,6 +106,14 @@ _FAMILIES: dict[str, _FamilySpec] = {
         out_proj_is_conv1d=False,
         attention_style_default="rotary",
         norm_kind="layernorm",
+        attn_module="attention",
+        attn_pre_norm="input_layernorm",
+        qkv_style="fused-interleaved",
+        q_proj="",
+        k_proj="",
+        v_proj="",
+        qkv_fused="attention.query_key_value",
+        rotary_emb_path="gpt_neox.rotary_emb",
     ),
     "llama": _FamilySpec(
         layers_path="model.layers",
@@ -101,6 +129,14 @@ _FAMILIES: dict[str, _FamilySpec] = {
         out_proj_is_conv1d=False,
         attention_style_default="rotary",
         norm_kind="rmsnorm",
+        attn_module="self_attn",
+        attn_pre_norm="input_layernorm",
+        qkv_style="separate",
+        q_proj="self_attn.q_proj",
+        k_proj="self_attn.k_proj",
+        v_proj="self_attn.v_proj",
+        qkv_fused="",
+        rotary_emb_path="model.rotary_emb",
     ),
     "gemma2": _FamilySpec(
         layers_path="model.layers",
@@ -116,6 +152,14 @@ _FAMILIES: dict[str, _FamilySpec] = {
         out_proj_is_conv1d=False,
         attention_style_default="rotary",
         norm_kind="rmsnorm",
+        attn_module="self_attn",
+        attn_pre_norm="input_layernorm",
+        qkv_style="separate",
+        q_proj="self_attn.q_proj",
+        k_proj="self_attn.k_proj",
+        v_proj="self_attn.v_proj",
+        qkv_fused="",
+        rotary_emb_path="model.rotary_emb",
     ),
 }
 
@@ -145,12 +189,23 @@ class ArchitectureDescriptor:
     norm_kind: NormKind
     n_layers: int
     n_heads: int
+    n_kv_heads: int
     head_dim: int
     d_model: int
     d_ff: int
     final_logit_softcapping: float | None
     spec: _FamilySpec
     model: nn.Module  # the CausalLM model
+
+    @property
+    def kv_group_size(self) -> int:
+        """Query heads per KV head (1 on standard multi-head attention)."""
+        return self.n_heads // self.n_kv_heads
+
+    def query_heads_of_kv(self, kv_index: int) -> list[int]:
+        """The query heads that read KV head ``kv_index``'s keys/values."""
+        g = self.kv_group_size
+        return list(range(kv_index * g, (kv_index + 1) * g))
 
     # ---------------- module handles ----------------
     def layer(self, layer_idx: int) -> nn.Module:
@@ -177,6 +232,63 @@ class ArchitectureDescriptor:
         if self.spec.mlp_post_norm is None:
             return None
         return _get_by_path(self.layer(layer_idx), self.spec.mlp_post_norm)
+
+    # ---------------- attention-detail module handles (K/V patching) ----------
+    def attn(self, layer_idx: int) -> nn.Module:
+        return _get_by_path(self.layer(layer_idx), self.spec.attn_module)
+
+    def attn_pre_norm(self, layer_idx: int) -> nn.Module:
+        """Norm applied to the attention branch's input residual."""
+        return _get_by_path(self.layer(layer_idx), self.spec.attn_pre_norm)
+
+    def rotary_emb(self) -> nn.Module | None:
+        if self.spec.rotary_emb_path is None:
+            return None
+        return _get_by_path(self.model, self.spec.rotary_emb_path)
+
+    def attn_scaling(self, layer_idx: int) -> float:
+        """The score scaling the model's own attention applies, read off the
+        attention module (not re-derived from config heuristics)."""
+        mod = self.attn(layer_idx)
+        scaling = getattr(mod, "scaling", None)
+        if scaling is not None:  # llama / gemma2 style
+            return float(scaling)
+        # GPT-2 style
+        s = 1.0
+        if getattr(mod, "scale_attn_weights", True):
+            s /= self.head_dim**0.5
+        if getattr(mod, "scale_attn_by_inverse_layer_idx", False):
+            s /= float(getattr(mod, "layer_idx", layer_idx) + 1)
+        return s
+
+    def attn_logit_softcapping(self) -> float | None:
+        return getattr(self.model.config, "attn_logit_softcapping", None)
+
+    def attn_sliding_window(self, layer_idx: int) -> int | None:
+        """This layer's sliding window (None = full attention), read off the
+        attention module the way the model's own mask construction does."""
+        return getattr(self.attn(layer_idx), "sliding_window", None)
+
+    def qkv_new(
+        self, layer_idx: int, normed: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run the layer's own q/k/v projections on an (already pre-normed)
+        input. Returns (q, k, v) with flat last dims (n_heads*head_dim for q,
+        n_kv_heads*head_dim for k/v), pre-rotation. Direct module call, same
+        provenance class as receiver MLP re-evaluation."""
+        if self.spec.qkv_style == "separate":
+            q = _get_by_path(self.layer(layer_idx), self.spec.q_proj)(normed)
+            k = _get_by_path(self.layer(layer_idx), self.spec.k_proj)(normed)
+            v = _get_by_path(self.layer(layer_idx), self.spec.v_proj)(normed)
+            return q, k, v
+        if self.spec.qkv_style == "fused-split3":
+            fused = _get_by_path(self.layer(layer_idx), self.spec.qkv_fused)(normed)
+            return tuple(fused.split(fused.shape[-1] // 3, dim=-1))  # type: ignore[return-value]
+        raise NotImplementedError(
+            f"qkv_style={self.spec.qkv_style!r} (per-head-interleaved fused QKV) "
+            f"has no analytic q/k/v accessor; this family is refused by the "
+            f"K/V capability check before reaching here."
+        )
 
     # ---------------- weight accessors (x @ W convention) ----------------
     def attn_out_weight(self, layer_idx: int) -> torch.Tensor:
@@ -256,6 +368,7 @@ class ArchitectureDescriptor:
             "norm_kind": self.norm_kind,
             "n_layers": self.n_layers,
             "n_heads": self.n_heads,
+            "n_kv_heads": self.n_kv_heads,
             "head_dim": self.head_dim,
             "d_model": self.d_model,
             "d_ff": self.d_ff,
@@ -321,6 +434,7 @@ def resolve_descriptor(
         norm_kind=spec.norm_kind,
         n_layers=n_layers,
         n_heads=n_heads,
+        n_kv_heads=n_kv_heads,
         head_dim=head_dim,
         d_model=d_model,
         d_ff=d_ff,

--- a/causalab/methods/path_patching/descriptor.py
+++ b/causalab/methods/path_patching/descriptor.py
@@ -1,0 +1,328 @@
+"""Architecture descriptors for the path-patching engine.
+
+A descriptor captures the small set of architecture facts pyvene does not
+track: how a decoder block wires its branches into the residual stream
+("trunk"), where each branch's contribution to the trunk is defined, and how
+the final logits are produced. Module *paths* for activation capture delegate
+to pyvene's per-family component mappings wherever pyvene knows them; the
+descriptor only names modules pyvene has no vocabulary for (per-branch
+post-norms, the final norm, the LM head).
+
+Nothing in a descriptor is trusted: `guards.run_construction_guards` verifies
+the declared wiring empirically (additivity of trunk contributions, per-layer
+branch reconstruction) before the engine will patch anything.
+
+Supported families: gpt2, gpt_neox (sequential or parallel residual), llama,
+gemma2. New families need a `_FamilySpec` entry plus a passing guard run.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import torch
+from torch import nn
+
+BlockOrder = Literal["sequential", "parallel"]
+AttentionStyle = Literal["fused-qkv-absolute", "rotary", "rotary-gqa"]
+NormKind = Literal["layernorm", "rmsnorm"]
+
+__all__ = [
+    "ArchitectureDescriptor",
+    "AttentionStyle",
+    "BlockOrder",
+    "SUPPORTED_MODEL_TYPES",
+    "resolve_descriptor",
+]
+
+
+@dataclass(frozen=True)
+class _FamilySpec:
+    """Static per-family module naming (relative attribute paths)."""
+
+    layers_path: str  # container of decoder blocks, on the CausalLM model
+    final_norm_path: str
+    lm_head_path: str
+    embed_dropout_path: str | None  # module whose output is the embed contribution
+    attn_out_proj: str  # on a block: the attention out-projection
+    mlp_path: str  # on a block: the MLP module
+    mlp_down_proj: str  # on a block: the MLP output projection
+    mlp_pre_norm: str  # on a block: norm applied to the MLP branch input
+    attn_post_norm: str | None  # branch post-norm (Gemma-2 style), or None
+    mlp_post_norm: str | None
+    out_proj_is_conv1d: bool  # GPT-2 Conv1D (x @ W) vs nn.Linear (x @ W.T)
+    attention_style_default: AttentionStyle
+    norm_kind: NormKind
+
+
+_FAMILIES: dict[str, _FamilySpec] = {
+    "gpt2": _FamilySpec(
+        layers_path="transformer.h",
+        final_norm_path="transformer.ln_f",
+        lm_head_path="lm_head",
+        embed_dropout_path="transformer.drop",
+        attn_out_proj="attn.c_proj",
+        mlp_path="mlp",
+        mlp_down_proj="mlp.c_proj",
+        mlp_pre_norm="ln_2",
+        attn_post_norm=None,
+        mlp_post_norm=None,
+        out_proj_is_conv1d=True,
+        attention_style_default="fused-qkv-absolute",
+        norm_kind="layernorm",
+    ),
+    "gpt_neox": _FamilySpec(
+        layers_path="gpt_neox.layers",
+        final_norm_path="gpt_neox.final_layer_norm",
+        lm_head_path="embed_out",
+        embed_dropout_path="gpt_neox.emb_dropout",
+        attn_out_proj="attention.dense",
+        mlp_path="mlp",
+        mlp_down_proj="mlp.dense_4h_to_h",
+        mlp_pre_norm="post_attention_layernorm",
+        attn_post_norm=None,
+        mlp_post_norm=None,
+        out_proj_is_conv1d=False,
+        attention_style_default="rotary",
+        norm_kind="layernorm",
+    ),
+    "llama": _FamilySpec(
+        layers_path="model.layers",
+        final_norm_path="model.norm",
+        lm_head_path="lm_head",
+        embed_dropout_path=None,
+        attn_out_proj="self_attn.o_proj",
+        mlp_path="mlp",
+        mlp_down_proj="mlp.down_proj",
+        mlp_pre_norm="post_attention_layernorm",
+        attn_post_norm=None,
+        mlp_post_norm=None,
+        out_proj_is_conv1d=False,
+        attention_style_default="rotary",
+        norm_kind="rmsnorm",
+    ),
+    "gemma2": _FamilySpec(
+        layers_path="model.layers",
+        final_norm_path="model.norm",
+        lm_head_path="lm_head",
+        embed_dropout_path=None,
+        attn_out_proj="self_attn.o_proj",
+        mlp_path="mlp",
+        mlp_down_proj="mlp.down_proj",
+        mlp_pre_norm="pre_feedforward_layernorm",
+        attn_post_norm="post_attention_layernorm",
+        mlp_post_norm="post_feedforward_layernorm",
+        out_proj_is_conv1d=False,
+        attention_style_default="rotary",
+        norm_kind="rmsnorm",
+    ),
+}
+
+SUPPORTED_MODEL_TYPES = tuple(sorted(_FAMILIES))
+
+
+def _get_by_path(root: Any, path: str) -> Any:
+    obj = root
+    for part in path.split("."):
+        obj = getattr(obj, part)
+    return obj
+
+
+@dataclass
+class ArchitectureDescriptor:
+    """Resolved architecture facts + module handles for one loaded model.
+
+    Built via :func:`resolve_descriptor`. All weight accessors return
+    matrices in the ``x @ W`` convention regardless of the underlying
+    parameterization (Conv1D vs Linear), so the engine's slicing code is
+    family-agnostic.
+    """
+
+    model_type: str
+    block_order: BlockOrder
+    attention_style: AttentionStyle
+    norm_kind: NormKind
+    n_layers: int
+    n_heads: int
+    head_dim: int
+    d_model: int
+    d_ff: int
+    final_logit_softcapping: float | None
+    spec: _FamilySpec
+    model: nn.Module  # the CausalLM model
+
+    # ---------------- module handles ----------------
+    def layer(self, layer_idx: int) -> nn.Module:
+        return _get_by_path(self.model, self.spec.layers_path)[layer_idx]
+
+    def final_norm(self) -> nn.Module:
+        return _get_by_path(self.model, self.spec.final_norm_path)
+
+    def lm_head(self) -> nn.Module:
+        return _get_by_path(self.model, self.spec.lm_head_path)
+
+    def mlp(self, layer_idx: int) -> nn.Module:
+        return _get_by_path(self.layer(layer_idx), self.spec.mlp_path)
+
+    def mlp_pre_norm(self, layer_idx: int) -> nn.Module:
+        return _get_by_path(self.layer(layer_idx), self.spec.mlp_pre_norm)
+
+    def attn_post_norm(self, layer_idx: int) -> nn.Module | None:
+        if self.spec.attn_post_norm is None:
+            return None
+        return _get_by_path(self.layer(layer_idx), self.spec.attn_post_norm)
+
+    def mlp_post_norm(self, layer_idx: int) -> nn.Module | None:
+        if self.spec.mlp_post_norm is None:
+            return None
+        return _get_by_path(self.layer(layer_idx), self.spec.mlp_post_norm)
+
+    # ---------------- weight accessors (x @ W convention) ----------------
+    def attn_out_weight(self, layer_idx: int) -> torch.Tensor:
+        """(n_heads * head_dim, d_model) so head h occupies rows
+        ``h*head_dim : (h+1)*head_dim``."""
+        proj = _get_by_path(self.layer(layer_idx), self.spec.attn_out_proj)
+        w = proj.weight.detach()
+        return w if self.spec.out_proj_is_conv1d else w.T
+
+    def attn_out_bias(self, layer_idx: int) -> torch.Tensor | None:
+        proj = _get_by_path(self.layer(layer_idx), self.spec.attn_out_proj)
+        b = getattr(proj, "bias", None)
+        return None if b is None else b.detach()
+
+    def mlp_out_weight(self, layer_idx: int) -> torch.Tensor:
+        """(d_ff, d_model): row n is neuron n's output direction."""
+        proj = _get_by_path(self.layer(layer_idx), self.spec.mlp_down_proj)
+        w = proj.weight.detach()
+        return w if self.spec.out_proj_is_conv1d else w.T
+
+    # ---------------- pyvene component names ----------------
+    # Named components delegate to pyvene's per-family mapping. The one
+    # capture point pyvene has no name for — the MLP output projection's
+    # *input* (the per-neuron values of a gated MLP) — uses pyvene's dotted
+    # module-path fallback, which is resolved by pyvene itself, not by hooks
+    # of ours.
+    def component_head_values(self) -> str:
+        """Per-head attention value output (out-projection input)."""
+        return "attention_value_output"
+
+    def component_mlp_branch(self) -> str:
+        """MLP module output (pre branch post-norm where one exists)."""
+        return "mlp_output"
+
+    def component_block_output(self) -> str:
+        return "block_output"
+
+    def component_block_input(self) -> str:
+        return "block_input"
+
+    def _layer_dotted(self, layer_idx: int) -> str:
+        return f"{self.spec.layers_path}[{layer_idx}]"
+
+    def component_neuron_values(self, layer_idx: int) -> str:
+        """Input to the MLP output projection, as a dotted pyvene path."""
+        return f"{self._layer_dotted(layer_idx)}.{self.spec.mlp_down_proj}.input"
+
+    def component_mlp_pre_norm_input(self, layer_idx: int) -> str:
+        """Input to the MLP branch's pre-norm (dotted pyvene path)."""
+        return f"{self._layer_dotted(layer_idx)}.{self.spec.mlp_pre_norm}.input"
+
+    def component_mlp_trunk_output(self, layer_idx: int) -> str:
+        """The MLP branch's contribution to the trunk: the post-norm's output
+        where one exists, else the MLP module's output (dotted path)."""
+        tail = self.spec.mlp_post_norm or self.spec.mlp_path
+        return f"{self._layer_dotted(layer_idx)}.{tail}.output"
+
+    def component_final_norm_input(self) -> str:
+        return f"{self.spec.final_norm_path}.input"
+
+    # ---------------- semantics helpers ----------------
+    def mlp_input_resid_is_block_input(self) -> bool:
+        """True for parallel-residual blocks: the MLP reads the block input,
+        so same-layer attention does NOT feed the same-layer MLP."""
+        return self.block_order == "parallel"
+
+    def head_feeds_mlp(self, head_layer: int, mlp_layer: int) -> bool:
+        if self.block_order == "sequential":
+            return head_layer <= mlp_layer
+        return head_layer < mlp_layer
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "model_type": self.model_type,
+            "block_order": self.block_order,
+            "attention_style": self.attention_style,
+            "norm_kind": self.norm_kind,
+            "n_layers": self.n_layers,
+            "n_heads": self.n_heads,
+            "head_dim": self.head_dim,
+            "d_model": self.d_model,
+            "d_ff": self.d_ff,
+            "final_logit_softcapping": self.final_logit_softcapping,
+            "branch_post_norms": bool(self.spec.attn_post_norm),
+        }
+
+
+def resolve_descriptor(
+    model: nn.Module,
+    *,
+    block_order: BlockOrder | None = None,
+    attention_style: AttentionStyle | None = None,
+) -> ArchitectureDescriptor:
+    """Resolve a descriptor from a loaded HF CausalLM.
+
+    Facts are read from the HF config where the config carries them
+    (``use_parallel_residual``, GQA head counts, softcapping); the explicit
+    keyword overrides exist for testing the guards (a deliberately
+    mis-declared order must fail construction) and for configs that lie.
+    """
+    config = model.config
+    model_type = config.model_type
+    if model_type not in _FAMILIES:
+        raise NotImplementedError(
+            f"path_patching has no architecture descriptor for model_type="
+            f"{model_type!r}. Supported: {SUPPORTED_MODEL_TYPES}. Add a "
+            f"_FamilySpec and validate it with guards.run_construction_guards."
+        )
+    spec = _FAMILIES[model_type]
+
+    if block_order is None:
+        if getattr(config, "use_parallel_residual", False):
+            block_order = "parallel"
+        else:
+            block_order = "sequential"
+
+    n_heads = config.num_attention_heads
+    n_kv_heads = getattr(config, "num_key_value_heads", n_heads)
+    if attention_style is None:
+        if spec.attention_style_default == "fused-qkv-absolute":
+            attention_style = "fused-qkv-absolute"
+        elif n_kv_heads < n_heads:
+            attention_style = "rotary-gqa"
+        else:
+            attention_style = "rotary"
+
+    d_model = config.hidden_size
+    head_dim = getattr(config, "head_dim", None) or d_model // n_heads
+    d_ff = getattr(config, "intermediate_size", None) or getattr(
+        config, "n_inner", None
+    )
+    if d_ff is None:
+        d_ff = 4 * d_model
+    n_layers = config.num_hidden_layers
+
+    return ArchitectureDescriptor(
+        model_type=model_type,
+        block_order=block_order,
+        attention_style=attention_style,
+        norm_kind=spec.norm_kind,
+        n_layers=n_layers,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        d_model=d_model,
+        d_ff=d_ff,
+        final_logit_softcapping=getattr(config, "final_logit_softcapping", None),
+        spec=spec,
+        model=model,
+    )

--- a/causalab/methods/path_patching/edges.py
+++ b/causalab/methods/path_patching/edges.py
@@ -103,9 +103,7 @@ class PathSpec:
         if not rec:
             return cls(sender_to_logits=direct_to_logits)
         sender_to = frozenset(rec) if multipath == "all" else frozenset({rec[0]})
-        r2r = frozenset(
-            (j, k) for i, j in enumerate(rec) for k in rec[i + 1 :]
-        )
+        r2r = frozenset((j, k) for i, j in enumerate(rec) for k in rec[i + 1 :])
         return cls(
             receivers=rec,
             sender_to=sender_to,

--- a/causalab/methods/path_patching/edges.py
+++ b/causalab/methods/path_patching/edges.py
@@ -1,0 +1,137 @@
+"""Path specification for the analytic patching engine.
+
+A patch is an explicit set of edges over {sender, receiver MLPs, logits}:
+
+* ``sender -> receiver_k``   the sender's trunk delta enters receiver k's input
+* ``sender -> logits``       the sender's direct edge to the final logits
+* ``receiver_j -> receiver_k``  receiver j's output delta enters receiver k
+* ``receiver_k -> logits``   receiver k's output delta reaches the logits
+
+Each receiver's input delta sums only its included incoming edges; its output
+delta propagates only along its included outgoing edges. Receivers are always
+MLP blocks (the Hanna et al. 2023 receiver vocabulary); ordering between
+receivers follows the architecture's block order, which the engine checks.
+
+Granularity ceiling (documented, deliberate): edges are atomic. One edge
+cannot carry different values per downstream branch (the "treeified" patching
+expressible in rust-circuit); expressing that requires per-path value routing
+the cache-arithmetic engine does not model.
+
+The common case is the *closed cascade*: sender feeds the receiver set, every
+receiver feeds every later receiver in the set and the logits. Build it with
+:meth:`PathSpec.cascade`, the documented default entry point; the explicit
+edge set is the power-user form.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+__all__ = ["PathSpec"]
+
+Multipath = Literal["first", "all"]
+
+
+@dataclass(frozen=True)
+class PathSpec:
+    """An explicit edge set over {sender, receiver MLPs, logits}.
+
+    Attributes
+    ----------
+    receivers:
+        MLP layers that recompute, in upstream-to-downstream order.
+    sender_to:
+        Receivers whose input includes the sender's trunk delta.
+    receiver_to_receiver:
+        Included ``(j, k)`` edges; j must be upstream of k. Any pair of
+        receivers not listed here is an *excluded* edge: k recomputes as if
+        j's output had stayed clean.
+    sender_to_logits:
+        Whether the sender's direct edge into the logits is patched.
+    receivers_to_logits:
+        Receivers whose output delta reaches the logits.
+    """
+
+    receivers: tuple[int, ...] = ()
+    sender_to: frozenset[int] = frozenset()
+    receiver_to_receiver: frozenset[tuple[int, int]] = field(default_factory=frozenset)
+    sender_to_logits: bool = True
+    receivers_to_logits: frozenset[int] = frozenset()
+
+    def __post_init__(self) -> None:
+        rec = tuple(self.receivers)
+        if len(set(rec)) != len(rec):
+            raise ValueError(f"duplicate receivers: {rec}")
+        if list(rec) != sorted(rec):
+            raise ValueError(
+                f"receivers must be in upstream-to-downstream (ascending layer) "
+                f"order, got {rec}"
+            )
+        rset = set(rec)
+        for bad in self.sender_to - rset:
+            raise ValueError(f"sender_to names non-receiver layer {bad}")
+        for bad in self.receivers_to_logits - rset:
+            raise ValueError(f"receivers_to_logits names non-receiver layer {bad}")
+        for j, k in self.receiver_to_receiver:
+            if j not in rset or k not in rset:
+                raise ValueError(f"edge ({j}, {k}) names a non-receiver layer")
+            if j >= k:
+                raise ValueError(
+                    f"edge ({j}, {k}) is not upstream->downstream (j < k required)"
+                )
+
+    # ------------------------------------------------------------------
+    @classmethod
+    def cascade(
+        cls,
+        receivers: list[int] | tuple[int, ...] = (),
+        *,
+        direct_to_logits: bool = True,
+        multipath: Multipath = "first",
+    ) -> "PathSpec":
+        """The closed cascade: the documented default entry point.
+
+        ``multipath="first"``: the sender's delta enters only the furthest-
+        upstream receiver (the via-MLP-k iterative path patch of Hanna et al.
+        Fig 3C). ``multipath="all"``: it enters every receiver directly (the
+        paper's §3.3 indirect split, patching all of the sender's paths
+        through the receiver set simultaneously). In both, every receiver
+        feeds every later receiver in the set and the logits.
+        """
+        rec = tuple(sorted(receivers))
+        if not rec:
+            return cls(sender_to_logits=direct_to_logits)
+        sender_to = frozenset(rec) if multipath == "all" else frozenset({rec[0]})
+        r2r = frozenset(
+            (j, k) for i, j in enumerate(rec) for k in rec[i + 1 :]
+        )
+        return cls(
+            receivers=rec,
+            sender_to=sender_to,
+            receiver_to_receiver=r2r,
+            sender_to_logits=direct_to_logits,
+            receivers_to_logits=frozenset(rec),
+        )
+
+    # ------------------------------------------------------------------
+    def without_edge(self, j: int, k: int) -> "PathSpec":
+        """A copy with the receiver_j -> receiver_k edge excluded."""
+        if (j, k) not in self.receiver_to_receiver:
+            raise ValueError(f"edge ({j}, {k}) is not in the spec")
+        return PathSpec(
+            receivers=self.receivers,
+            sender_to=self.sender_to,
+            receiver_to_receiver=self.receiver_to_receiver - {(j, k)},
+            sender_to_logits=self.sender_to_logits,
+            receivers_to_logits=self.receivers_to_logits,
+        )
+
+    def describe(self) -> str:
+        parts = []
+        if self.sender_to_logits:
+            parts.append("S->logits")
+        parts += [f"S->m{k}" for k in sorted(self.sender_to)]
+        parts += [f"m{j}->m{k}" for j, k in sorted(self.receiver_to_receiver)]
+        parts += [f"m{k}->logits" for k in sorted(self.receivers_to_logits)]
+        return " + ".join(parts) if parts else "(empty)"

--- a/causalab/methods/path_patching/engine.py
+++ b/causalab/methods/path_patching/engine.py
@@ -291,6 +291,46 @@ class PatchEngine:
     # ------------------------------------------------------------------
     # patched forward
     # ------------------------------------------------------------------
+    @torch.no_grad()
+    def receiver_deltas(
+        self,
+        sender_delta: Tensor,
+        spec: PathSpec,
+        *,
+        base_cache: PatchCache | None = None,
+        freeze_norms: bool = False,
+    ) -> dict[int, Tensor]:
+        """Per-receiver trunk-output deltas at this engine's position.
+
+        Runs the spec's receiver cascade on a precomputed (N, d) sender
+        trunk delta and returns each receiver MLP's output delta, without
+        assembling final logits — the building block for feeding a receiver
+        chain into something other than the logits (e.g. the K/V engine's
+        patched positions).
+        """
+        base = base_cache or self.clean
+        sd = sender_delta.to(self.device).float()
+        deltas: dict[int, Tensor] = {}
+        for k in spec.receivers:
+            inp = torch.zeros_like(sd)
+            live = False
+            if k in spec.sender_to:
+                inp = inp + sd
+                live = True
+            for j, kk in spec.receiver_to_receiver:
+                if kk == k and j in deltas:
+                    inp = inp + deltas[j]
+                    live = True
+            if not live:
+                deltas[k] = torch.zeros_like(sd)
+                continue
+            resid = self.resid_for_mlp(base, k)
+            freeze_at = resid if freeze_norms else None
+            new = self._mlp_branch_fn(k, resid + inp, freeze_at=freeze_at)
+            old = self.mlp_trunk_contribution(base, k)
+            deltas[k] = new - old
+        return deltas
+
     def _mlp_branch_fn(
         self, layer: int, resid: Tensor, *, freeze_at: Tensor | None = None
     ) -> Tensor:
@@ -356,25 +396,9 @@ class PatchEngine:
                 sender, from_cache=base, to_cache=to_cache, freeze_norms=freeze_norms
             )
 
-        deltas: dict[int, Tensor] = {}
-        for k in spec.receivers:
-            inp = torch.zeros_like(sd)
-            live = False
-            if k in spec.sender_to:
-                inp = inp + sd
-                live = True
-            for j, kk in spec.receiver_to_receiver:
-                if kk == k and j in deltas:
-                    inp = inp + deltas[j]
-                    live = True
-            if not live:
-                deltas[k] = torch.zeros_like(sd)
-                continue
-            resid = self.resid_for_mlp(base, k)
-            freeze_at = resid if freeze_norms else None
-            new = self._mlp_branch_fn(k, resid + inp, freeze_at=freeze_at)
-            old = self.mlp_trunk_contribution(base, k)
-            deltas[k] = new - old
+        deltas = self.receiver_deltas(
+            sd, spec, base_cache=base, freeze_norms=freeze_norms
+        )
 
         final = base.final_resid(self.position).to(self.device).float()
         for k in spec.receivers_to_logits:

--- a/causalab/methods/path_patching/engine.py
+++ b/causalab/methods/path_patching/engine.py
@@ -83,10 +83,10 @@ class PatchEngine:
         self.device = device or next(model.parameters()).device
         self.model_dtype = next(model.parameters()).dtype
         L = desc.n_layers
-        self._w_o = [desc.attn_out_weight(l).float() for l in range(L)]
+        self._w_o = [desc.attn_out_weight(li).float() for li in range(L)]
         self._b_o = [
-            b.float() if (b := desc.attn_out_bias(l)) is not None else None
-            for l in range(L)
+            b.float() if (b := desc.attn_out_bias(li)) is not None else None
+            for li in range(L)
         ]
         self._w_out: list[Tensor | None] = [None] * L  # lazy: (d_ff, d) float32
         self._attn_pre_clean: dict[tuple[str, int], Tensor] = {}
@@ -151,7 +151,9 @@ class PatchEngine:
             return xn * (1.0 + w)
         return xn * w
 
-    def _attn_pre_norm_clean(self, cache_key: str, cache: PatchCache, layer: int) -> Tensor:
+    def _attn_pre_norm_clean(
+        self, cache_key: str, cache: PatchCache, layer: int
+    ) -> Tensor:
         """The attention branch's output before its post-norm (reconstructed
         as z @ W_O + bias; validated by the additivity guard)."""
         key = (cache_key, layer)
@@ -199,9 +201,10 @@ class PatchEngine:
         kind = sender[0]
         if kind == "head":
             _, layer, head = sender
-            dz = self._at(to_cache, "z", layer)[:, head] - self._at(
-                from_cache, "z", layer
-            )[:, head]
+            dz = (
+                self._at(to_cache, "z", layer)[:, head]
+                - self._at(from_cache, "z", layer)[:, head]
+            )
             w = self._w_o[layer][
                 head * self.desc.head_dim : (head + 1) * self.desc.head_dim
             ]
@@ -274,9 +277,9 @@ class PatchEngine:
                     else self._at(from_cache, "mlp_branch", layer)
                 )
                 frozen = pre if freeze_norms else None
-                d = self._apply_norm(post, pre + raw, frozen_at=frozen) - self._apply_norm(
-                    post, pre, frozen_at=frozen
-                )
+                d = self._apply_norm(
+                    post, pre + raw, frozen_at=frozen
+                ) - self._apply_norm(post, pre, frozen_at=frozen)
             total = d if total is None else total + d
         for e in embed_acc:
             total = e if total is None else total + e
@@ -306,15 +309,24 @@ class PatchEngine:
         )
         return self._apply_norm(post, m, frozen_at=frozen)
 
-    def tail_logits(self, final_resid: Tensor, *, freeze_at: Tensor | None = None) -> Tensor:
+    def tail_logits(
+        self, final_resid: Tensor, *, freeze_at: Tensor | None = None
+    ) -> Tensor:
         """Final logits from a reassembled final-position residual, through
-        the model's own final norm + LM head (+ softcapping)."""
+        the model's own final norm + LM head (+ softcapping).
+
+        Softcapping runs in the LM head's output dtype, mirroring the HF
+        forward exactly — applying it in float32 instead rounds differently
+        and costs ~1 bf16 ulp at the cap scale (caught by the patch-nothing
+        closure guard on Gemma-2)."""
         x = self._apply_norm(self.desc.final_norm(), final_resid, frozen_at=freeze_at)
-        logits = self.desc.lm_head()(x.to(self.model_dtype)).float()
+        logits = self.desc.lm_head()(x.to(self.model_dtype))
         cap = self.desc.final_logit_softcapping
         if cap is not None:
-            logits = cap * torch.tanh(logits / cap)
-        return logits.cpu()
+            logits = logits / cap
+            logits = torch.tanh(logits)
+            logits = logits * cap
+        return logits.float().cpu()
 
     @torch.no_grad()
     def patched_logits(
@@ -370,7 +382,9 @@ class PatchEngine:
                 final = final + deltas[k]
         if spec.sender_to_logits:
             final = final + sd
-        freeze_at = base.final_resid(self.position).to(self.device) if freeze_norms else None
+        freeze_at = (
+            base.final_resid(self.position).to(self.device) if freeze_norms else None
+        )
         return self.tail_logits(final, freeze_at=freeze_at)
 
     # ------------------------------------------------------------------
@@ -382,7 +396,9 @@ class PatchEngine:
         circuit_heads: Sequence[tuple[int, int]],
         circuit_mlps: Sequence[int],
         direction: str = "sufficiency",
-        head_receiver_mlps: Sequence[int] | dict[tuple[int, int], Sequence[int]] | None = None,
+        head_receiver_mlps: Sequence[int]
+        | dict[tuple[int, int], Sequence[int]]
+        | None = None,
     ) -> Tensor:
         """Patched logits for a circuit evaluation.
 
@@ -397,16 +413,13 @@ class PatchEngine:
         if head_receiver_mlps is None:
             head_receiver_mlps = list(circuit_mlps)
         if not isinstance(head_receiver_mlps, dict):
-            head_receiver_mlps = {
-                hd: list(head_receiver_mlps) for hd in circuit_heads
-            }
+            head_receiver_mlps = {hd: list(head_receiver_mlps) for hd in circuit_heads}
         if direction == "sufficiency":
             base, restore = self.cf, self.clean
         elif direction == "necessity":
             base, restore = self.clean, self.cf
         else:
             raise ValueError(direction)
-        base_key = "clean" if base is self.clean else "cf"
 
         # per-(layer, head-subset) trunk deltas, grouped per branch so any
         # branch post-norm applies to the summed raw delta
@@ -414,7 +427,7 @@ class PatchEngine:
             if not heads:
                 return None
             return self.trunk_delta(
-                ("group", [("head", l, h) for l, h in heads]),
+                ("group", [("head", hl, hh) for hl, hh in heads]),
                 from_cache=base,
                 to_cache=restore,
             )
@@ -424,10 +437,10 @@ class PatchEngine:
         subset_cache: dict[frozenset, Tensor | None] = {}
         for k in sorted(circuit_mlps):
             feeding = [
-                (l, h)
-                for (l, h) in all_heads
-                if self.desc.head_feeds_mlp(l, k)
-                and k in head_receiver_mlps.get((l, h), ())
+                (hl, hh)
+                for (hl, hh) in all_heads
+                if self.desc.head_feeds_mlp(hl, k)
+                and k in head_receiver_mlps.get((hl, hh), ())
             ]
             key = frozenset(feeding)
             if key not in subset_cache:

--- a/causalab/methods/path_patching/engine.py
+++ b/causalab/methods/path_patching/engine.py
@@ -91,10 +91,17 @@ class PatchEngine:
         self._w_out: list[Tensor | None] = [None] * L  # lazy: (d_ff, d) float32
         self._attn_pre_clean: dict[tuple[str, int], Tensor] = {}
         self._mlp_trunk_clean: dict[int, Tensor] = {}
-        from .provenance import log_provenance
+        from .provenance import check_capability, log_provenance
 
-        #: capture-point provenance (pyvene-named / pyvene-path / raw-hook /
-        #: direct-module-call, with reason codes); also logged at INFO once.
+        # capability contract: every pyvene unit the engine and its twin
+        # need must exist in the family's mapping, else this raises
+        # UnsupportedArchitectureError before anything is patched.
+        self.capability = check_capability(
+            model,
+            ["path-patching cache collection", "reference-twin interventions"],
+        )
+        #: which pyvene units / module calls this engine uses (pyvene-named /
+        #: pyvene-path / direct-module-call); also logged at INFO once.
         self.provenance: list[dict[str, Any]] = log_provenance(desc)
         self.guard_report: dict[str, Any] | None = None
         if run_guards:

--- a/causalab/methods/path_patching/engine.py
+++ b/causalab/methods/path_patching/engine.py
@@ -1,0 +1,442 @@
+"""Analytic path patching over cached activations.
+
+Semantics follow Hanna et al. (2023) §3.1 / Fig 3: all receivers act at one
+token position, where the residual stream is a sum of component
+contributions (verified at construction by the additivity guard, never
+assumed). Replacing a sender's contribution along a named edge set, with
+every off-path component frozen at its clean value, reduces to delta
+arithmetic on cached activations plus direct re-evaluation of the receiver
+MLP branches (through the model's real norm modules) and of the model's own
+final norm + LM head (+ logit softcapping where the model has one).
+
+Freeze-recipe equivalence: run on clean input; only the sender's output at
+the position changes; frozen components pass their clean values through;
+receivers recompute on (clean input + accumulated on-path deltas). Verified
+against an independent pyvene replace-intervention implementation
+(``reference.py``) in the validation suite.
+
+Sender vocabulary:
+  ("head", layer, head)        attention head (contribution = z @ W_O slice)
+  ("mlp", layer)               MLP block
+  ("neuron", layer, index)     single MLP output-projection input channel
+  ("neuron_group", layer, [i]) several channels of one MLP
+  ("embed",)                   the embedding contribution
+  ("group", [senders...])      union of senders (e.g. a circuit complement)
+
+Branch post-norms (Gemma-2): a branch's contribution to the trunk passes
+through its post-norm, which is nonlinear, so sender deltas are computed as
+``post_norm(branch_clean + raw_delta) - post_norm(branch_clean)`` — exactly
+what a live patched forward produces. Raw deltas from senders inside the
+same branch are summed *before* the post-norm.
+
+Block order: on parallel-residual models (Pythia), the MLP reads the block
+*input*, so a same-layer head never feeds the same-layer MLP and receiver
+inputs are derived from ``block_input`` rather than ``block_output - mlp``.
+Declared order is verified empirically at construction (guards).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import torch
+from torch import Tensor, nn
+
+from .cache import PatchCache
+from .descriptor import ArchitectureDescriptor
+from .edges import PathSpec
+
+__all__ = ["PatchEngine", "Sender"]
+
+Sender = tuple  # see module docstring for the shapes
+
+
+def _is_gemma_norm(module: nn.Module) -> bool:
+    return "gemma" in module.__class__.__name__.lower()
+
+
+class PatchEngine:
+    """Analytic patched logits from a clean and a counterfactual cache.
+
+    Construction runs the empirical guards by default (additivity of trunk
+    contributions, per-layer branch reconstruction, patch-nothing /
+    patch-everything closure); see ``guards.py``. An engine that fails its
+    guards refuses to patch.
+    """
+
+    def __init__(
+        self,
+        desc: ArchitectureDescriptor,
+        cache_clean: PatchCache,
+        cache_cf: PatchCache,
+        *,
+        position: str = "end",
+        run_guards: bool = True,
+        guard_tolerances: dict[str, float] | None = None,
+        device: torch.device | str | None = None,
+    ) -> None:
+        self.desc = desc
+        self.clean = cache_clean
+        self.cf = cache_cf
+        self.position = position
+        model = desc.model
+        self.device = device or next(model.parameters()).device
+        self.model_dtype = next(model.parameters()).dtype
+        L = desc.n_layers
+        self._w_o = [desc.attn_out_weight(l).float() for l in range(L)]
+        self._b_o = [
+            b.float() if (b := desc.attn_out_bias(l)) is not None else None
+            for l in range(L)
+        ]
+        self._w_out: list[Tensor | None] = [None] * L  # lazy: (d_ff, d) float32
+        self._attn_pre_clean: dict[tuple[str, int], Tensor] = {}
+        self._mlp_trunk_clean: dict[int, Tensor] = {}
+        from .provenance import log_provenance
+
+        #: capture-point provenance (pyvene-named / pyvene-path / raw-hook /
+        #: direct-module-call, with reason codes); also logged at INFO once.
+        self.provenance: list[dict[str, Any]] = log_provenance(desc)
+        self.guard_report: dict[str, Any] | None = None
+        if run_guards:
+            from .guards import run_construction_guards
+
+            self.guard_report = run_construction_guards(
+                self, tolerances=guard_tolerances
+            )
+
+    # ------------------------------------------------------------------
+    # cached-quantity helpers (float32, on device)
+    # ------------------------------------------------------------------
+    def _at(self, cache: PatchCache, quantity: str, layer: int | None = None) -> Tensor:
+        t = getattr(cache, quantity)[self.position]
+        if layer is not None:
+            t = t[:, layer]
+        return t.to(self.device)
+
+    def _mlp_out_weight(self, layer: int) -> Tensor:
+        if self._w_out[layer] is None:
+            self._w_out[layer] = self.desc.mlp_out_weight(layer).float()
+        return self._w_out[layer]
+
+    def _apply_norm(
+        self, module: nn.Module | None, x: Tensor, frozen_at: Tensor | None = None
+    ) -> Tensor:
+        """Apply a norm module (or identity). ``frozen_at`` freezes the
+        normalization denominator at another tensor's value (linearized-norm
+        diagnostic, rust-circuit style)."""
+        if module is None:
+            return x
+        if frozen_at is None:
+            return module(x.to(self.model_dtype)).float()
+        xf = x.float()
+        ref = frozen_at.float()
+        eps = getattr(module, "eps", None) or getattr(module, "variance_epsilon", 1e-6)
+        if isinstance(module, nn.LayerNorm):
+            mu = xf.mean(-1, keepdim=True)
+            var = ref.var(-1, keepdim=True, unbiased=False)
+            xn = (xf - mu) / torch.sqrt(var + eps)
+            return xn * module.weight.float() + module.bias.float()
+        # RMSNorm family (no mean subtraction)
+        rms = torch.sqrt(ref.pow(2).mean(-1, keepdim=True) + eps)
+        xn = xf / rms
+        w = module.weight.float()
+        if _is_gemma_norm(module):
+            return xn * (1.0 + w)
+        return xn * w
+
+    def _attn_pre_norm_clean(self, cache_key: str, cache: PatchCache, layer: int) -> Tensor:
+        """The attention branch's output before its post-norm (reconstructed
+        as z @ W_O + bias; validated by the additivity guard)."""
+        key = (cache_key, layer)
+        if key not in self._attn_pre_clean:
+            z = self._at(cache, "z", layer)  # (N, H, dh)
+            flat = z.reshape(z.shape[0], -1)
+            out = flat @ self._w_o[layer]
+            if self._b_o[layer] is not None:
+                out = out + self._b_o[layer]
+            self._attn_pre_clean[key] = out
+        return self._attn_pre_clean[key]
+
+    def mlp_trunk_contribution(self, cache: PatchCache, layer: int) -> Tensor:
+        """The MLP branch's contribution to the trunk (through its post-norm
+        where one exists)."""
+        pre = self._at(cache, "mlp_branch", layer)
+        return self._apply_norm(self.desc.mlp_post_norm(layer), pre)
+
+    def attn_trunk_contribution(self, cache: PatchCache, layer: int) -> Tensor:
+        key = "clean" if cache is self.clean else "cf"
+        pre = self._attn_pre_norm_clean(key, cache, layer)
+        return self._apply_norm(self.desc.attn_post_norm(layer), pre)
+
+    def resid_for_mlp(self, cache: PatchCache, layer: int) -> Tensor:
+        """Residual stream entering layer ``layer``'s MLP branch."""
+        if self.desc.mlp_input_resid_is_block_input():
+            if layer == 0:
+                return self._at(cache, "embed")
+            return self._at(cache, "block_out", layer - 1)
+        return self._at(cache, "block_out", layer) - self.mlp_trunk_contribution(
+            cache, layer
+        )
+
+    # ------------------------------------------------------------------
+    # sender deltas
+    # ------------------------------------------------------------------
+    def _raw_branch_deltas(
+        self,
+        sender: Sender,
+        from_cache: PatchCache,
+        to_cache: PatchCache,
+        acc: dict[tuple[str, int], Tensor],
+        embed_acc: list[Tensor],
+    ) -> None:
+        kind = sender[0]
+        if kind == "head":
+            _, layer, head = sender
+            dz = self._at(to_cache, "z", layer)[:, head] - self._at(
+                from_cache, "z", layer
+            )[:, head]
+            w = self._w_o[layer][
+                head * self.desc.head_dim : (head + 1) * self.desc.head_dim
+            ]
+            self._acc(acc, ("attn", layer), dz @ w)
+        elif kind == "mlp":
+            _, layer = sender
+            d = self._at(to_cache, "mlp_branch", layer) - self._at(
+                from_cache, "mlp_branch", layer
+            )
+            self._acc(acc, ("mlp", layer), d)
+        elif kind in ("neuron", "neuron_group"):
+            _, layer, idx = sender
+            if not from_cache.neuron_acts:
+                raise ValueError(
+                    "neuron senders need caches built with collect_neuron_acts=True"
+                )
+            sel = [idx] if kind == "neuron" else list(idx)
+            da = (
+                self._at(to_cache, "neuron_acts", layer)[:, sel]
+                - self._at(from_cache, "neuron_acts", layer)[:, sel]
+            )
+            self._acc(acc, ("mlp", layer), da @ self._mlp_out_weight(layer)[sel])
+        elif kind == "embed":
+            embed_acc.append(
+                self._at(to_cache, "embed") - self._at(from_cache, "embed")
+            )
+        elif kind == "group":
+            for s in sender[1]:
+                self._raw_branch_deltas(s, from_cache, to_cache, acc, embed_acc)
+        else:
+            raise ValueError(f"unknown sender {sender!r}")
+
+    @staticmethod
+    def _acc(acc: dict, key: tuple[str, int], val: Tensor) -> None:
+        acc[key] = acc[key] + val if key in acc else val
+
+    @torch.no_grad()
+    def trunk_delta(
+        self,
+        sender: Sender,
+        *,
+        from_cache: PatchCache | None = None,
+        to_cache: PatchCache | None = None,
+        freeze_norms: bool = False,
+    ) -> Tensor:
+        """(N, d) change in the sender's contribution to the trunk when its
+        activation moves from ``from_cache`` (default clean) to ``to_cache``
+        (default counterfactual). Raw deltas within one branch are summed
+        before that branch's post-norm."""
+        from_cache = from_cache or self.clean
+        to_cache = to_cache or self.cf
+        acc: dict[tuple[str, int], Tensor] = {}
+        embed_acc: list[Tensor] = []
+        self._raw_branch_deltas(sender, from_cache, to_cache, acc, embed_acc)
+        cache_key = "clean" if from_cache is self.clean else "cf"
+
+        total: Tensor | None = None
+        for (branch, layer), raw in acc.items():
+            post = (
+                self.desc.attn_post_norm(layer)
+                if branch == "attn"
+                else self.desc.mlp_post_norm(layer)
+            )
+            if post is None:
+                d = raw
+            else:
+                pre = (
+                    self._attn_pre_norm_clean(cache_key, from_cache, layer)
+                    if branch == "attn"
+                    else self._at(from_cache, "mlp_branch", layer)
+                )
+                frozen = pre if freeze_norms else None
+                d = self._apply_norm(post, pre + raw, frozen_at=frozen) - self._apply_norm(
+                    post, pre, frozen_at=frozen
+                )
+            total = d if total is None else total + d
+        for e in embed_acc:
+            total = e if total is None else total + e
+        if total is None:
+            n = from_cache.n_examples
+            total = torch.zeros(n, self.desc.d_model, device=self.device)
+        return total
+
+    # ------------------------------------------------------------------
+    # patched forward
+    # ------------------------------------------------------------------
+    def _mlp_branch_fn(
+        self, layer: int, resid: Tensor, *, freeze_at: Tensor | None = None
+    ) -> Tensor:
+        """Re-evaluate layer ``layer``'s full MLP branch (pre-norm, MLP,
+        post-norm where present) on ``resid``. ``freeze_at`` freezes norm
+        denominators at that residual's value (diagnostic)."""
+        pre_norm = self.desc.mlp_pre_norm(layer)
+        x = self._apply_norm(pre_norm, resid, frozen_at=freeze_at)
+        m = self.desc.mlp(layer)(x.to(self.model_dtype)).float()
+        post = self.desc.mlp_post_norm(layer)
+        if post is None:
+            return m
+        # freezing the post-norm at the clean branch output value
+        frozen = (
+            self._at(self.clean, "mlp_branch", layer) if freeze_at is not None else None
+        )
+        return self._apply_norm(post, m, frozen_at=frozen)
+
+    def tail_logits(self, final_resid: Tensor, *, freeze_at: Tensor | None = None) -> Tensor:
+        """Final logits from a reassembled final-position residual, through
+        the model's own final norm + LM head (+ softcapping)."""
+        x = self._apply_norm(self.desc.final_norm(), final_resid, frozen_at=freeze_at)
+        logits = self.desc.lm_head()(x.to(self.model_dtype)).float()
+        cap = self.desc.final_logit_softcapping
+        if cap is not None:
+            logits = cap * torch.tanh(logits / cap)
+        return logits.cpu()
+
+    @torch.no_grad()
+    def patched_logits(
+        self,
+        sender: Sender | Tensor,
+        spec: PathSpec | None = None,
+        *,
+        base_cache: PatchCache | None = None,
+        freeze_norms: bool = False,
+    ) -> Tensor:
+        """Patched final logits (N, vocab) for ``sender`` along ``spec``.
+
+        ``sender`` is a sender tuple (its trunk delta is computed from the
+        engine's caches) or a precomputed (N, d) trunk-delta tensor.
+        ``base_cache`` is the cache the patched run otherwise follows
+        (default clean). ``freeze_norms`` freezes every recomputed norm's
+        denominator at its base value (linearized-norm diagnostic; default
+        recomputes norms exactly).
+        """
+        spec = spec or PathSpec.cascade()
+        base = base_cache or self.clean
+        if isinstance(sender, Tensor):
+            sd = sender.to(self.device).float()
+        else:
+            to_cache = self.cf if base is self.clean else self.clean
+            sd = self.trunk_delta(
+                sender, from_cache=base, to_cache=to_cache, freeze_norms=freeze_norms
+            )
+
+        deltas: dict[int, Tensor] = {}
+        for k in spec.receivers:
+            inp = torch.zeros_like(sd)
+            live = False
+            if k in spec.sender_to:
+                inp = inp + sd
+                live = True
+            for j, kk in spec.receiver_to_receiver:
+                if kk == k and j in deltas:
+                    inp = inp + deltas[j]
+                    live = True
+            if not live:
+                deltas[k] = torch.zeros_like(sd)
+                continue
+            resid = self.resid_for_mlp(base, k)
+            freeze_at = resid if freeze_norms else None
+            new = self._mlp_branch_fn(k, resid + inp, freeze_at=freeze_at)
+            old = self.mlp_trunk_contribution(base, k)
+            deltas[k] = new - old
+
+        final = base.final_resid(self.position).to(self.device).float()
+        for k in spec.receivers_to_logits:
+            if k in deltas:
+                final = final + deltas[k]
+        if spec.sender_to_logits:
+            final = final + sd
+        freeze_at = base.final_resid(self.position).to(self.device) if freeze_norms else None
+        return self.tail_logits(final, freeze_at=freeze_at)
+
+    # ------------------------------------------------------------------
+    # circuit evaluation (Hanna et al. §3.2 / Fig 5)
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def circuit_eval(
+        self,
+        circuit_heads: Sequence[tuple[int, int]],
+        circuit_mlps: Sequence[int],
+        direction: str = "sufficiency",
+        head_receiver_mlps: Sequence[int] | dict[tuple[int, int], Sequence[int]] | None = None,
+    ) -> Tensor:
+        """Patched logits for a circuit evaluation.
+
+        sufficiency: model runs on the counterfactual side; circuit paths
+        (heads->MLPs, heads->logits, MLPs->MLPs->logits) restored to clean.
+        necessity: model runs on the clean side; circuit paths receive the
+        counterfactual. Heads always keep their direct edge to the logits;
+        circuit MLPs feed all downstream circuit MLPs and the logits.
+        ``head_receiver_mlps`` limits which circuit MLPs receive the heads'
+        deltas: one list applying to every head, or a per-head dict.
+        """
+        if head_receiver_mlps is None:
+            head_receiver_mlps = list(circuit_mlps)
+        if not isinstance(head_receiver_mlps, dict):
+            head_receiver_mlps = {
+                hd: list(head_receiver_mlps) for hd in circuit_heads
+            }
+        if direction == "sufficiency":
+            base, restore = self.cf, self.clean
+        elif direction == "necessity":
+            base, restore = self.clean, self.cf
+        else:
+            raise ValueError(direction)
+        base_key = "clean" if base is self.clean else "cf"
+
+        # per-(layer, head-subset) trunk deltas, grouped per branch so any
+        # branch post-norm applies to the summed raw delta
+        def heads_trunk_delta(heads: Sequence[tuple[int, int]]) -> Tensor | None:
+            if not heads:
+                return None
+            return self.trunk_delta(
+                ("group", [("head", l, h) for l, h in heads]),
+                from_cache=base,
+                to_cache=restore,
+            )
+
+        all_heads = list(circuit_heads)
+        mlp_deltas: list[tuple[int, Tensor]] = []
+        subset_cache: dict[frozenset, Tensor | None] = {}
+        for k in sorted(circuit_mlps):
+            feeding = [
+                (l, h)
+                for (l, h) in all_heads
+                if self.desc.head_feeds_mlp(l, k)
+                and k in head_receiver_mlps.get((l, h), ())
+            ]
+            key = frozenset(feeding)
+            if key not in subset_cache:
+                subset_cache[key] = heads_trunk_delta(feeding)
+            inp_parts = [] if subset_cache[key] is None else [subset_cache[key]]
+            inp_parts += [d for j, d in mlp_deltas if j < k]
+            resid = self.resid_for_mlp(base, k)
+            inp = sum(inp_parts, torch.zeros_like(resid))
+            new = self._mlp_branch_fn(k, resid + inp)
+            old = self.mlp_trunk_contribution(base, k)
+            mlp_deltas.append((k, new - old))
+
+        final = base.final_resid(self.position).to(self.device).float()
+        full_heads_delta = heads_trunk_delta(all_heads)
+        if full_heads_delta is not None:
+            final = final + full_heads_delta
+        for _, d in mlp_deltas:
+            final = final + d
+        return self.tail_logits(final)

--- a/causalab/methods/path_patching/guards.py
+++ b/causalab/methods/path_patching/guards.py
@@ -42,19 +42,35 @@ class GuardError(RuntimeError):
 
 def default_tolerances(model_dtype: torch.dtype) -> dict[str, float]:
     """Relative tolerances for G1/G2 (vs the residual's max magnitude) and
-    absolute max-logit tolerances for G3/G4."""
+    absolute max-logit tolerances for G3/G4.
+
+    The two closure guards have different numerical floors, so they get
+    separate tolerances. G3 (patch-nothing) re-runs the model's own tail on
+    the cached final residual — identical values through identical modules —
+    so it is near-exact in any dtype. G4 (patch-everything) reconstructs the
+    counterfactual residual as a float32 sum of per-component contributions,
+    whereas the model's own trunk accumulated those adds in the model dtype;
+    for bf16 models the model's own per-add rounding puts a floor of roughly
+    (additivity error x logit scale) ≈ a few percent of the logit range on
+    this comparison. That floor is a property of validating a float32
+    decomposition against a bf16 forward, not of the wiring — the same model
+    run in float32 closes tightly (the matrix includes such a run). The bf16
+    G4 default is therefore a sanity bound; measured values are always
+    recorded in ``engine.guard_report``. The teeth against wrong *wiring*
+    are G2 (relative, dtype-robust) in every dtype.
+    """
     if model_dtype in (torch.float32, torch.float64):
         return {
             "additivity_rel": 1e-4,
             "branch_rel": 1e-4,
-            "closure_logits": 2e-3,
+            "closure_patch_nothing": 2e-3,
+            "closure_patch_everything": 2e-3,
         }
-    # bf16 / fp16: the model's own trunk accumulates in half precision, so
-    # a float32 re-sum legitimately differs at ~1e-2 relative scale.
     return {
         "additivity_rel": 3e-2,
         "branch_rel": 3e-2,
-        "closure_logits": 1e-1,
+        "closure_patch_nothing": 5e-2,
+        "closure_patch_everything": 1.0,
     }
 
 
@@ -121,16 +137,14 @@ def run_construction_guards(
             )
 
     # ---- G3: patch-nothing closure ----
-    zero = torch.zeros(
-        engine.clean.n_examples, desc.d_model, device=engine.device
-    )
+    zero = torch.zeros(engine.clean.n_examples, desc.d_model, device=engine.device)
     logits = engine.patched_logits(zero, PathSpec.cascade())
     err3 = (logits - engine.clean.logits[engine.position]).abs().max().item()
     report["G3_patch_nothing_max_logit_err"] = err3
-    if err3 > tol["closure_logits"]:
+    if err3 > tol["closure_patch_nothing"]:
         failures.append(
             f"G3 patch-nothing closure: max logit error {err3:.2e} > "
-            f"{tol['closure_logits']:.0e}. The reassembled final norm + LM "
+            f"{tol['closure_patch_nothing']:.0e}. The reassembled final norm + LM "
             f"head does not reproduce the model's own logits. Likely causes: "
             f"wrong final-norm/LM-head modules or a missing logit transform "
             f"(softcapping)."
@@ -140,16 +154,19 @@ def run_construction_guards(
     everything = (
         "group",
         [("embed",)]
-        + [("head", l, h) for l in range(desc.n_layers) for h in range(desc.n_heads)]
-        + [("mlp", l) for l in range(desc.n_layers)],
+        + [("head", li, h) for li in range(desc.n_layers) for h in range(desc.n_heads)]
+        + [("mlp", li) for li in range(desc.n_layers)],
     )
     logits = engine.patched_logits(everything, PathSpec.cascade())
     err4 = (logits - engine.cf.logits[engine.position]).abs().max().item()
     report["G4_patch_everything_max_logit_err"] = err4
-    if err4 > tol["closure_logits"]:
+    scale = engine.cf.logits[engine.position].abs().max().item()
+    report["logit_scale"] = scale
+    report["G4_rel_to_logit_scale"] = err4 / max(scale, 1e-12)
+    if err4 > tol["closure_patch_everything"]:
         failures.append(
             f"G4 patch-everything closure: max logit error {err4:.2e} > "
-            f"{tol['closure_logits']:.0e}. Patching every component's direct "
+            f"{tol['closure_patch_everything']:.0e}. Patching every component's direct "
             f"edge does not reconstruct the counterfactual logits: the "
             f"residual decomposition does not close across inputs. Likely "
             f"causes: wrong block order, wrong capture points, or caches "

--- a/causalab/methods/path_patching/guards.py
+++ b/causalab/methods/path_patching/guards.py
@@ -1,0 +1,163 @@
+"""Empirical construction guards for the path-patching engine.
+
+The analytic recipe is exact only for pre-LN additive-trunk decoders whose
+capture points and block wiring the descriptor got right. None of that is
+trusted: every engine runs these checks on its own caches at construction
+and refuses to patch if any fails.
+
+G1  additivity      final-position residual == embedding contribution +
+                    sum of every branch's trunk contribution. Fails on
+                    post-LN trunks and wrong capture points.
+G2  branch wiring   re-evaluating each MLP branch on its derived input
+                    residual reproduces the cached branch output. Fails on
+                    a mis-declared block order (sequential vs parallel) and
+                    on wrong pre-norm modules.
+G3  patch-nothing   the reassembled tail on the untouched final residual
+                    reproduces the model's own logits.
+G4  patch-everything  patching every component's direct edge (embedding +
+                    all heads + all MLPs) reconstructs the counterfactual
+                    side's logits: the decomposition closes across inputs.
+
+Default tolerances are per-dtype; measured errors are kept in
+``engine.guard_report`` for reporting either way.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from .edges import PathSpec
+
+if TYPE_CHECKING:
+    from .engine import PatchEngine
+
+__all__ = ["GuardError", "run_construction_guards", "default_tolerances"]
+
+
+class GuardError(RuntimeError):
+    """A construction guard failed; the engine refuses to patch."""
+
+
+def default_tolerances(model_dtype: torch.dtype) -> dict[str, float]:
+    """Relative tolerances for G1/G2 (vs the residual's max magnitude) and
+    absolute max-logit tolerances for G3/G4."""
+    if model_dtype in (torch.float32, torch.float64):
+        return {
+            "additivity_rel": 1e-4,
+            "branch_rel": 1e-4,
+            "closure_logits": 2e-3,
+        }
+    # bf16 / fp16: the model's own trunk accumulates in half precision, so
+    # a float32 re-sum legitimately differs at ~1e-2 relative scale.
+    return {
+        "additivity_rel": 3e-2,
+        "branch_rel": 3e-2,
+        "closure_logits": 1e-1,
+    }
+
+
+def _rel_err(err: torch.Tensor, ref: torch.Tensor) -> float:
+    return (err.abs().max() / ref.abs().max().clamp_min(1e-12)).item()
+
+
+@torch.no_grad()
+def run_construction_guards(
+    engine: "PatchEngine", tolerances: dict[str, float] | None = None
+) -> dict[str, Any]:
+    """Run G1-G4 on the engine's caches; raise :class:`GuardError` on any
+    failure; return the measured errors."""
+    tol = default_tolerances(engine.model_dtype)
+    if tolerances:
+        tol.update(tolerances)
+    desc = engine.desc
+    report: dict[str, Any] = {"tolerances": dict(tol)}
+    failures: list[str] = []
+
+    caches = {"clean": engine.clean, "cf": engine.cf}
+
+    # ---- G1: additivity of trunk contributions ----
+    for name, cache in caches.items():
+        resid = cache.final_resid(engine.position).to(engine.device).float()
+        total = engine._at(cache, "embed").clone()
+        for layer in range(desc.n_layers):
+            total = total + engine.attn_trunk_contribution(cache, layer)
+            total = total + engine.mlp_trunk_contribution(cache, layer)
+        err = _rel_err(total - resid, resid)
+        report[f"G1_additivity_{name}"] = err
+        if err > tol["additivity_rel"]:
+            failures.append(
+                f"G1 additivity ({name} cache): relative error {err:.2e} > "
+                f"{tol['additivity_rel']:.0e}. The final-position residual is "
+                f"not the sum of the captured contributions. Likely causes: a "
+                f"post-LN trunk (this recipe is only exact for pre-LN "
+                f"additive-trunk decoders) or wrong capture points in the "
+                f"architecture descriptor."
+            )
+
+    # ---- G2: branch wiring (block order + pre-norm) ----
+    worst = {"clean": 0.0, "cf": 0.0}
+    for name, cache in caches.items():
+        for layer in range(desc.n_layers):
+            resid = engine.resid_for_mlp(cache, layer)
+            recomputed = engine._mlp_branch_fn(layer, resid)
+            cached = engine.mlp_trunk_contribution(cache, layer)
+            err = _rel_err(
+                recomputed - cached,
+                cache.final_resid(engine.position).to(engine.device).float(),
+            )
+            worst[name] = max(worst[name], err)
+        report[f"G2_branch_wiring_{name}"] = worst[name]
+        if worst[name] > tol["branch_rel"]:
+            failures.append(
+                f"G2 branch wiring ({name} cache): worst per-layer relative "
+                f"error {worst[name]:.2e} > {tol['branch_rel']:.0e}. "
+                f"Re-evaluating an MLP branch on its derived input residual "
+                f"does not reproduce the cached branch output. Likely causes: "
+                f"the declared block order ({desc.block_order!r}) is wrong for "
+                f"this model, or the descriptor's MLP pre-norm module is not "
+                f"the one the block actually applies."
+            )
+
+    # ---- G3: patch-nothing closure ----
+    zero = torch.zeros(
+        engine.clean.n_examples, desc.d_model, device=engine.device
+    )
+    logits = engine.patched_logits(zero, PathSpec.cascade())
+    err3 = (logits - engine.clean.logits[engine.position]).abs().max().item()
+    report["G3_patch_nothing_max_logit_err"] = err3
+    if err3 > tol["closure_logits"]:
+        failures.append(
+            f"G3 patch-nothing closure: max logit error {err3:.2e} > "
+            f"{tol['closure_logits']:.0e}. The reassembled final norm + LM "
+            f"head does not reproduce the model's own logits. Likely causes: "
+            f"wrong final-norm/LM-head modules or a missing logit transform "
+            f"(softcapping)."
+        )
+
+    # ---- G4: patch-everything closure ----
+    everything = (
+        "group",
+        [("embed",)]
+        + [("head", l, h) for l in range(desc.n_layers) for h in range(desc.n_heads)]
+        + [("mlp", l) for l in range(desc.n_layers)],
+    )
+    logits = engine.patched_logits(everything, PathSpec.cascade())
+    err4 = (logits - engine.cf.logits[engine.position]).abs().max().item()
+    report["G4_patch_everything_max_logit_err"] = err4
+    if err4 > tol["closure_logits"]:
+        failures.append(
+            f"G4 patch-everything closure: max logit error {err4:.2e} > "
+            f"{tol['closure_logits']:.0e}. Patching every component's direct "
+            f"edge does not reconstruct the counterfactual logits: the "
+            f"residual decomposition does not close across inputs. Likely "
+            f"causes: wrong block order, wrong capture points, or caches "
+            f"built at inconsistent positions."
+        )
+
+    if failures:
+        raise GuardError(
+            "path-patching construction guards failed:\n- " + "\n- ".join(failures)
+        )
+    return report

--- a/causalab/methods/path_patching/kv.py
+++ b/causalab/methods/path_patching/kv.py
@@ -166,11 +166,11 @@ def build_attn_detail_cache(
         a = act if isinstance(act, Tensor) else torch.cat(list(act))
         store[m] = per_head(a.reshape(bsz, T, -1).float().cpu())
 
-    k_all = torch.stack([store[("k", l)] for l in range(L)], dim=1)
-    v_all = torch.stack([store[("v", l)] for l in range(L)], dim=1)
+    k_all = torch.stack([store[("k", li)] for li in range(L)], dim=1)
+    v_all = torch.stack([store[("v", li)] for li in range(L)], dim=1)
     bidx = torch.arange(bsz)
     pidx = torch.tensor(pos)
-    q_pos = torch.stack([store[("q", l)][bidx, :, pidx] for l in range(L)], dim=1)
+    q_pos = torch.stack([store[("q", li)][bidx, :, pidx] for li in range(L)], dim=1)
 
     # derived arithmetic — gap registry: kv:scores (no-module-boundary);
     # the score tensor is never hooked or intervened on.

--- a/causalab/methods/path_patching/kv.py
+++ b/causalab/methods/path_patching/kv.py
@@ -475,14 +475,17 @@ class KVPatchEngine:
     # patched k/v construction
     # ------------------------------------------------------------------
     def _kv_delta_from_resid(
-        self, layer: int, delta_resid: Tensor, base: str
+        self, layer: int, delta_resid: Tensor, base: str, freeze_prenorm: bool = False
     ) -> tuple[Tensor, Tensor]:
         """(Δk, Δv) at the patched position for every KV head of ``layer``,
         pre-rotation, from a residual delta at that position.
 
         Formed as ``proj(norm(x+Δ)) − proj(norm(x))`` through the model's own
         pre-norm and projections (direct module calls, model dtype), so a
-        zero residual delta gives exactly zero.
+        zero residual delta gives exactly zero. ``freeze_prenorm`` freezes
+        the pre-norm's normalization denominator at the base residual's
+        value (rust-circuit-style linearized norm), the same diagnostic the
+        engine offers via ``freeze_norms``.
         """
         cache = self._cache(base)
         eng = self.engine_patch
@@ -492,8 +495,12 @@ class KVPatchEngine:
             x = eng._at(cache, "block_out", layer - 1)
         norm = self.desc.attn_pre_norm(layer)
         d = delta_resid.to(self.device).float()
-        normed_new = norm((x + d).to(self.model_dtype))
-        normed_old = norm(x.to(self.model_dtype))
+        if freeze_prenorm:
+            normed_new = eng._apply_norm(norm, x + d, frozen_at=x).to(self.model_dtype)
+            normed_old = eng._apply_norm(norm, x, frozen_at=x).to(self.model_dtype)
+        else:
+            normed_new = norm((x + d).to(self.model_dtype))
+            normed_old = norm(x.to(self.model_dtype))
         _, k_new, v_new = self.desc.qkv_new(layer, normed_new)
         _, k_old, v_old = self.desc.qkv_new(layer, normed_old)
         KV, DH = self.desc.n_kv_heads, self.desc.head_dim
@@ -534,6 +541,7 @@ class KVPatchEngine:
         base_cache: str = "clean",
         patch_q: bool = False,
         rotate_key_delta: bool = True,
+        freeze_prenorm: bool = False,
     ) -> Tensor:
         """(N, d) change in the edges' layers' attention-branch trunk
         contributions at the end position when the named KV heads' keys
@@ -591,7 +599,9 @@ class KVPatchEngine:
                     if isinstance(input_deltas, Mapping)
                     else input_deltas
                 )
-                dk_all, dv_all = self._kv_delta_from_resid(layer, dr, base_cache)
+                dk_all, dv_all = self._kv_delta_from_resid(
+                    layer, dr, base_cache, freeze_prenorm
+                )
                 for e in layer_edges:
                     j = e.kv.kv_index
                     deltas_ready[j] = (

--- a/causalab/methods/path_patching/kv.py
+++ b/causalab/methods/path_patching/kv.py
@@ -5,13 +5,19 @@ GATED: everything here requires ``attention_style == "fused-qkv-absolute"``
 raises :class:`NotImplementedError` otherwise. The main path-patching engine
 is unaffected by this gate — it never recomputes attention.
 
-Capture is pyvene-native: per-head q/k/v come from pyvene's
-``head_query_output`` / ``head_key_output`` / ``head_value_output``
-components (pyvene splits GPT-2's fused ``c_attn`` itself). Pre-softmax
-scores are **derived arithmetic** on the captured q/k — the score tensor is
-not a module boundary anywhere (gap registry: ``kv:scores``,
-``no-module-boundary``), and no intervention on it is ever needed: analytic
+Capture is pyvene, like everything in this package: per-head q/k/v come from
+pyvene's ``query_output`` / ``key_output`` / ``value_output`` components
+(pyvene splits GPT-2's fused ``c_attn`` itself), and construction runs the
+same capability check as the engine — a family whose mapping lacks these
+units raises :class:`UnsupportedArchitectureError`. Pre-softmax scores are
+**derived arithmetic** on the captured q/k; the score tensor is not a module
+boundary anywhere, and no intervention on it is ever needed: analytic
 K/V-side patching recomputes scores from cached q/k.
+
+K/V capture requires ``attn_implementation="eager"`` at pipeline load
+(causalab's ``LMPipeline`` default): fused sdpa/flash kernels do not
+materialize what pyvene's attention units need, and eager is cheap at
+analysis scale. Construction verifies this.
 
 Design notes for generalization beyond GPT-2 (agreed direction; deliberately
 NOT implemented here):
@@ -20,7 +26,10 @@ NOT implemented here):
   already rotated it by its source position's angle. Patching a key along a
   path therefore requires rotating the key *delta* by the patched position's
   angle before re-scoring; raw cache-to-cache key substitution is only valid
-  when clean and counterfactual token positions coincide.
+  when clean and counterfactual token positions coincide. Pre-rotation keys
+  collected via pyvene (``key_output`` is the projection output, before RoPE)
+  with the rotation applied in engine arithmetic is pyvene-native — no hooks
+  needed.
 * **GQA models**: the honest unit for key/value path edges is the *KV head*,
   with effects fanning out to every query head in its group — that is what
   is causally separable in the weights. Per-query-head value semantics would
@@ -28,11 +37,11 @@ NOT implemented here):
   analytic engine could later offer as pure cache arithmetic (duplicate the
   cached k/v per group member, re-average one query head's z); KV-head edges
   should remain the default.
-* **Reference twin**: the K/V twin should stay pyvene-native — replace
-  per-head k/v at the patched position via replace interventions
-  (``head_key_output`` / ``head_value_output``) and let the model's own
-  attention recompute. Analytic scores are reconstructable from cached q/k,
-  so no score-tensor intervention is ever needed.
+* **Reference twin**: the K/V twin should stay pyvene — replace per-head k/v
+  at the patched position via replace interventions (``head_key_output`` /
+  ``head_value_output``) and let the model's own attention recompute.
+  Analytic scores are reconstructable from cached q/k, so no score-tensor
+  intervention is ever needed.
 """
 
 from __future__ import annotations
@@ -104,6 +113,17 @@ def build_attn_detail_cache(
     is validation-scale machinery.
     """
     _require_fused_absolute(desc, "attention-detail capture")
+    from .provenance import check_capability
+
+    check_capability(desc.model, ["K/V attention-detail collection"])
+    attn_impl = getattr(desc.model.config, "_attn_implementation", "eager")
+    if attn_impl != "eager":
+        raise RuntimeError(
+            f"K/V attention-detail capture requires attn_implementation="
+            f"'eager' (got {attn_impl!r}): fused sdpa/flash kernels do not "
+            f"materialize what pyvene's attention units need. causalab's "
+            f"LMPipeline loads models eager by default."
+        )
     inputs = [{"raw_input": x} if isinstance(x, str) else x for x in inputs]
     L, H, DH = desc.n_layers, desc.n_heads, desc.head_dim
 

--- a/causalab/methods/path_patching/kv.py
+++ b/causalab/methods/path_patching/kv.py
@@ -1,0 +1,169 @@
+"""Key/value-side attention detail: capture and score reconstruction.
+
+GATED: everything here requires ``attention_style == "fused-qkv-absolute"``
+(GPT-2-style fused-QKV attention with absolute position embeddings) and
+raises :class:`NotImplementedError` otherwise. The main path-patching engine
+is unaffected by this gate — it never recomputes attention.
+
+Capture is pyvene-native: per-head q/k/v come from pyvene's
+``head_query_output`` / ``head_key_output`` / ``head_value_output``
+components (pyvene splits GPT-2's fused ``c_attn`` itself). Pre-softmax
+scores are **derived arithmetic** on the captured q/k — the score tensor is
+not a module boundary anywhere (gap registry: ``kv:scores``,
+``no-module-boundary``), and no intervention on it is ever needed: analytic
+K/V-side patching recomputes scores from cached q/k.
+
+Design notes for generalization beyond GPT-2 (agreed direction; deliberately
+NOT implemented here):
+
+* **Rotary models**: a cached key vector is position-entangled — RoPE has
+  already rotated it by its source position's angle. Patching a key along a
+  path therefore requires rotating the key *delta* by the patched position's
+  angle before re-scoring; raw cache-to-cache key substitution is only valid
+  when clean and counterfactual token positions coincide.
+* **GQA models**: the honest unit for key/value path edges is the *KV head*,
+  with effects fanning out to every query head in its group — that is what
+  is causally separable in the weights. Per-query-head value semantics would
+  require a TransformerLens-style expansion of shared KV heads, which this
+  analytic engine could later offer as pure cache arithmetic (duplicate the
+  cached k/v per group member, re-average one query head's z); KV-head edges
+  should remain the default.
+* **Reference twin**: the K/V twin should stay pyvene-native — replace
+  per-head k/v at the patched position via replace interventions
+  (``head_key_output`` / ``head_value_output``) and let the model's own
+  attention recompute. Analytic scores are reconstructable from cached q/k,
+  so no score-tensor intervention is ever needed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import torch
+from torch import Tensor
+
+from causalab.neural.activations.intervenable_model import (
+    delete_intervenable_model,
+    prepare_intervenable_model,
+)
+from causalab.neural.units import AtomicModelUnit, ComponentIndexer
+
+from .cache import padded_position
+from .descriptor import ArchitectureDescriptor
+
+__all__ = ["AttnDetailCache", "build_attn_detail_cache"]
+
+
+def _require_fused_absolute(desc: ArchitectureDescriptor, what: str) -> None:
+    if desc.attention_style != "fused-qkv-absolute":
+        raise NotImplementedError(
+            f"{what} is only implemented for GPT-2-style attention "
+            f"(fused QKV, absolute positions); this model declares "
+            f"attention_style={desc.attention_style!r}. Rotary models need "
+            f"the key delta rotated by the patched position's angle before "
+            f"re-scoring, and GQA models need KV-head (not query-head) edge "
+            f"units — see this module's docstring for the agreed design."
+        )
+
+
+@dataclass
+class AttnDetailCache:
+    """Per-head q/k/v and derived attention scores at one patched position.
+
+    q_pos      (N, L, H, dh)    query vectors at the position
+    k_all      (N, L, H, T, dh) key vectors, all (padded) positions
+    v_all      (N, L, H, T, dh) value vectors
+    scores_pos (N, L, H, T)     pre-softmax masked scores at the position
+                                (derived from q_pos/k_all; not captured)
+    attention_mask (N, T)
+    """
+
+    q_pos: Tensor
+    k_all: Tensor
+    v_all: Tensor
+    scores_pos: Tensor
+    attention_mask: Tensor
+
+
+def _null_indexer() -> ComponentIndexer:
+    return ComponentIndexer(lambda _x: [], id="path_patching_explicit")
+
+
+@torch.no_grad()
+def build_attn_detail_cache(
+    pipeline: Any,
+    desc: ArchitectureDescriptor,
+    inputs: Sequence[Any],
+    *,
+    position_index: int | Sequence[int] = -1,
+) -> AttnDetailCache:
+    """Capture per-head q/k/v via pyvene and derive masked scores.
+
+    GPT-2-style attention only (see the gate). Runs as a single batch: this
+    is validation-scale machinery.
+    """
+    _require_fused_absolute(desc, "attention-detail capture")
+    inputs = [{"raw_input": x} if isinstance(x, str) else x for x in inputs]
+    L, H, DH = desc.n_layers, desc.n_heads, desc.head_dim
+
+    units: list[AtomicModelUnit] = []
+    meta: list[tuple[str, int]] = []
+    for layer in range(L):
+        for quantity, comp in (
+            ("q", "query_output"),
+            ("k", "key_output"),
+            ("v", "value_output"),
+        ):
+            units.append(
+                AtomicModelUnit(
+                    layer, comp, _null_indexer(), id=f"pp_kv_{quantity}_l{layer}"
+                )
+            )
+            meta.append((quantity, layer))
+
+    intervenable_model = prepare_intervenable_model(
+        pipeline, units, intervention_type="collect"
+    )
+    try:
+        loaded = pipeline.load(list(inputs))
+        mask = loaded["attention_mask"]
+        bsz, T = mask.shape
+        pos = padded_position(mask, position_index)
+        all_positions = [list(range(T)) for _ in range(bsz)]
+        indices = [all_positions for _ in units]
+        location_map = {"sources->base": (indices, indices)}
+        result = intervenable_model(loaded, unit_locations=location_map)
+        collected = result[0][1]
+    finally:
+        delete_intervenable_model(intervenable_model)
+
+    def per_head(x: Tensor) -> Tensor:  # (B, T, H*dh) -> (B, H, T, dh)
+        return x.reshape(bsz, T, H, DH).permute(0, 2, 1, 3)
+
+    store: dict[tuple[str, int], Tensor] = {}
+    for m, act in zip(meta, collected):
+        a = act if isinstance(act, Tensor) else torch.cat(list(act))
+        store[m] = per_head(a.reshape(bsz, T, -1).float().cpu())
+
+    k_all = torch.stack([store[("k", l)] for l in range(L)], dim=1)
+    v_all = torch.stack([store[("v", l)] for l in range(L)], dim=1)
+    bidx = torch.arange(bsz)
+    pidx = torch.tensor(pos)
+    q_pos = torch.stack([store[("q", l)][bidx, :, pidx] for l in range(L)], dim=1)
+
+    # derived arithmetic — gap registry: kv:scores (no-module-boundary);
+    # the score tensor is never hooked or intervened on.
+    scores = (q_pos.unsqueeze(3) @ k_all.transpose(-1, -2)).squeeze(3) / (DH**0.5)
+    mask_c = mask.cpu()
+    scores = scores.masked_fill(mask_c[:, None, None, :] == 0, float("-inf"))
+    causal = torch.arange(T)[None, :] > pidx[:, None]
+    scores = scores.masked_fill(causal[:, None, None, :], float("-inf"))
+
+    return AttnDetailCache(
+        q_pos=q_pos,
+        k_all=k_all,
+        v_all=v_all,
+        scores_pos=scores,
+        attention_mask=mask_c,
+    )

--- a/causalab/methods/path_patching/kv.py
+++ b/causalab/methods/path_patching/kv.py
@@ -723,10 +723,16 @@ class KVPatchEngine:
         pre-rotation q/k/v through the analytic score path, must match the
         cached attention_value_output. This exercises rotation, GQA fan-in,
         scaling, softcapping, masks, and softmax in one check."""
+        # bf16 K1 is a sanity bound, not a precision target (same stance as
+        # the engine's G4): reconstructing in float32 what the model
+        # accumulated in bf16 has a model-size-dependent rounding floor —
+        # measured 1.6e-2 on Gemma-2-2B and 4.3e-2 on Llama-3.1-8B, while
+        # the same models in float32 close at ~1e-6 (proving the
+        # conventions) and genuine wiring errors show up at O(1).
         tol = {
             "z_reconstruction_rel": 1e-4
             if self.model_dtype in (torch.float32, torch.float64)
-            else 3e-2,
+            else 1e-1,
         }
         if tolerances:
             tol.update(tolerances)

--- a/causalab/methods/path_patching/kv.py
+++ b/causalab/methods/path_patching/kv.py
@@ -1,53 +1,68 @@
-"""Key/value-side attention detail: capture and score reconstruction.
+"""Key/value-side path patching: capture, score reconstruction, KV-head edges.
 
-GATED: everything here requires ``attention_style == "fused-qkv-absolute"``
-(GPT-2-style fused-QKV attention with absolute position embeddings) and
-raises :class:`NotImplementedError` otherwise. The main path-patching engine
-is unaffected by this gate — it never recomputes attention.
+Extends the analytic engine to edges that end at an attention head's **keys
+or values at one patched token position** (Hanna et al. 2023 App. 8: what
+feeds the circuit heads' k/v at the YY position), general across the same
+four families as the main engine, with three architecture facts handled
+explicitly:
 
-Capture is pyvene, like everything in this package: per-head q/k/v come from
-pyvene's ``query_output`` / ``key_output`` / ``value_output`` components
-(pyvene splits GPT-2's fused ``c_attn`` itself), and construction runs the
-same capability check as the engine — a family whose mapping lacks these
-units raises :class:`UnsupportedArchitectureError`. Pre-softmax scores are
-**derived arithmetic** on the captured q/k; the score tensor is not a module
-boundary anywhere, and no intervention on it is ever needed: analytic
-K/V-side patching recomputes scores from cached q/k.
+* **Rotary embeddings** (Llama, Gemma-2): pyvene's ``key_output`` unit is the
+  k-projection's *output*, before rotation, so cached keys are
+  position-disentangled. Score reconstruction applies the model's **own
+  rotary module** (``desc.rotary_emb()``) to both q and k at their actual
+  position ids; a key patched at position ``p`` is rotated by ``p``'s angle.
+  Rotation is linear, so rotating the patched key equals rotating the key
+  delta — the docstring recipe "rotate the delta" and "rotate the new key"
+  are the same operation.
+* **Grouped-query attention** (Llama-3.1): the causally separable unit in
+  the weights is the **KV head**; edges attach to :class:`KVHead` and the
+  engine fans the resulting z-deltas across every query head in the group
+  (:meth:`ArchitectureDescriptor.query_heads_of_kv`). Standard multi-head
+  models are the special case of group size 1. Per-*query*-head value paths
+  do not exist in the weights; a TransformerLens-style expansion (duplicate
+  cached k/v per group member, re-average one query head's z) would be pure
+  cache arithmetic and is deliberately not offered as a default.
+* **Sliding-window attention** (Gemma-2): before patching position ``p`` as
+  seen from the end position at layer ``L``, the engine verifies the end
+  position can attend to ``p`` within that layer's window (read off the
+  attention module, the way the model's own mask construction does) and
+  raises :class:`SlidingWindowError` naming the layer and window otherwise.
 
-K/V capture requires ``attn_implementation="eager"`` at pipeline load
-(causalab's ``LMPipeline`` default): fused sdpa/flash kernels do not
-materialize what pyvene's attention units need, and eager is cheap at
-analysis scale. Construction verifies this.
+Support policy (same as the engine): an operation is available iff pyvene's
+mapping has the units it needs — ``query_output``/``key_output``/
+``value_output`` for collection, ``head_key_output``/``head_value_output``
+for the reference twin. A family whose mapping lacks them (gpt_neox: the
+fused per-head-interleaved QKV projection has no pyvene q/k/v units) raises
+:class:`UnsupportedArchitectureError` at construction. No raw torch hooks.
 
-Design notes for generalization beyond GPT-2 (agreed direction; deliberately
-NOT implemented here):
+K/V capture and patching require ``attn_implementation="eager"`` at pipeline
+load: fused sdpa/flash kernels do not materialize what pyvene's attention
+units hook, and the analytic score reconstruction mirrors the eager
+reference path. Construction verifies this and names the loader option
+(``LMPipeline(..., attn_implementation="eager")`` /
+``attn_implementation: eager`` in the model YAML).
 
-* **Rotary models**: a cached key vector is position-entangled — RoPE has
-  already rotated it by its source position's angle. Patching a key along a
-  path therefore requires rotating the key *delta* by the patched position's
-  angle before re-scoring; raw cache-to-cache key substitution is only valid
-  when clean and counterfactual token positions coincide. Pre-rotation keys
-  collected via pyvene (``key_output`` is the projection output, before RoPE)
-  with the rotation applied in engine arithmetic is pyvene-native — no hooks
-  needed.
-* **GQA models**: the honest unit for key/value path edges is the *KV head*,
-  with effects fanning out to every query head in its group — that is what
-  is causally separable in the weights. Per-query-head value semantics would
-  require a TransformerLens-style expansion of shared KV heads, which this
-  analytic engine could later offer as pure cache arithmetic (duplicate the
-  cached k/v per group member, re-average one query head's z); KV-head edges
-  should remain the default.
-* **Reference twin**: the K/V twin should stay pyvene — replace per-head k/v
-  at the patched position via replace interventions (``head_key_output`` /
-  ``head_value_output``) and let the model's own attention recompute.
-  Analytic scores are reconstructable from cached q/k, so no score-tensor
-  intervention is ever needed.
+Numerical contract: everything is float32 cache arithmetic through the
+model's own modules (pre-norms, q/k/v projections, rotary, post-norms, LM
+head run in model dtype at module boundaries, matching the engine). Score
+reconstruction mirrors the HF eager path exactly: scores * module scaling,
+Gemma-2 attention softcapping **before** masking, softmax in float32.
+Construction guard K1 verifies the whole chain empirically: reconstructed
+per-head z at the end position must match the cached
+``attention_value_output`` on both caches (tight in float32; the bf16 floor
+is recorded, as with G4). Patch deltas are formed as
+``proj(norm(x+Δ)) − proj(norm(x))`` through the same code path, so a
+zero-delta patch is exactly zero in any dtype.
+
+The score tensor itself is never a module boundary and is never intervened
+on: analytic K/V patching recomputes scores from cached q/k (gap registry:
+kv:scores, no-module-boundary).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Sequence
 
 import torch
 from torch import Tensor
@@ -58,41 +73,89 @@ from causalab.neural.activations.intervenable_model import (
 )
 from causalab.neural.units import AtomicModelUnit, ComponentIndexer
 
-from .cache import padded_position
+from .cache import PatchCache, keep_last_dim_on_collects, padded_position
 from .descriptor import ArchitectureDescriptor
+from .engine import PatchEngine
 
-__all__ = ["AttnDetailCache", "build_attn_detail_cache"]
+__all__ = [
+    "AttnDetailCache",
+    "KVEdge",
+    "KVHead",
+    "KVPatchEngine",
+    "SlidingWindowError",
+    "build_attn_detail_cache",
+]
 
 
-def _require_fused_absolute(desc: ArchitectureDescriptor, what: str) -> None:
-    if desc.attention_style != "fused-qkv-absolute":
-        raise NotImplementedError(
-            f"{what} is only implemented for GPT-2-style attention "
-            f"(fused QKV, absolute positions); this model declares "
-            f"attention_style={desc.attention_style!r}. Rotary models need "
-            f"the key delta rotated by the patched position's angle before "
-            f"re-scoring, and GQA models need KV-head (not query-head) edge "
-            f"units — see this module's docstring for the agreed design."
-        )
+class SlidingWindowError(ValueError):
+    """The patched position is outside the layer's attention window."""
+
+
+@dataclass(frozen=True)
+class KVHead:
+    """A key/value head: the causally separable K/V unit in the weights.
+
+    On grouped-query models this is one of ``n_kv_heads`` heads whose keys
+    and values are read by ``kv_group_size`` query heads; on standard
+    multi-head attention it coincides with the query head of the same index.
+    """
+
+    layer: int
+    kv_index: int
+
+    @classmethod
+    def for_query_head(
+        cls, desc: ArchitectureDescriptor, layer: int, head: int
+    ) -> "KVHead":
+        """The KV head whose keys/values query head ``head`` reads."""
+        return cls(layer, head // desc.kv_group_size)
+
+
+@dataclass(frozen=True)
+class KVEdge:
+    """One K/V-side edge: a KV head with which of its inputs are patched."""
+
+    kv: KVHead
+    patch_k: bool = False
+    patch_v: bool = True
+
+    def __post_init__(self) -> None:
+        if not (self.patch_k or self.patch_v):
+            raise ValueError("KVEdge patches neither keys nor values")
 
 
 @dataclass
 class AttnDetailCache:
-    """Per-head q/k/v and derived attention scores at one patched position.
+    """Pre-rotation per-head q/k/v for one loaded batch (float32, CPU).
 
-    q_pos      (N, L, H, dh)    query vectors at the position
-    k_all      (N, L, H, T, dh) key vectors, all (padded) positions
-    v_all      (N, L, H, T, dh) value vectors
-    scores_pos (N, L, H, T)     pre-softmax masked scores at the position
-                                (derived from q_pos/k_all; not captured)
+    q          (N, L, H, dh)      query vectors at each named position
+                                  (dict: position name -> tensor)
+    k_all      (N, L, KV, T, dh)  key vectors, all padded positions,
+                                  pre-rotation
+    v_all      (N, L, KV, T, dh)  value vectors, all padded positions
     attention_mask (N, T)
+    position_ids   (N, T)         the position ids the forward actually used
+    positions      name -> list of padded batch indices (one per example)
     """
 
-    q_pos: Tensor
+    n_layers: int
+    n_heads: int
+    n_kv_heads: int
+    head_dim: int
+    q: dict[str, Tensor]
     k_all: Tensor
     v_all: Tensor
-    scores_pos: Tensor
     attention_mask: Tensor
+    position_ids: Tensor
+    positions: dict[str, list[int]] = field(default_factory=dict)
+
+    @property
+    def n_examples(self) -> int:
+        return self.k_all.shape[0]
+
+    @property
+    def seq_len(self) -> int:
+        return self.k_all.shape[3]
 
 
 def _null_indexer() -> ComponentIndexer:
@@ -104,28 +167,27 @@ def build_attn_detail_cache(
     pipeline: Any,
     desc: ArchitectureDescriptor,
     inputs: Sequence[Any],
+    positions: dict[str, int | Sequence[int]],
     *,
-    position_index: int | Sequence[int] = -1,
+    require_eager: bool = True,
 ) -> AttnDetailCache:
-    """Capture per-head q/k/v via pyvene and derive masked scores.
+    """Capture pre-rotation per-head q/k/v via pyvene.
 
-    GPT-2-style attention only (see the gate). Runs as a single batch: this
-    is validation-scale machinery.
+    ``positions`` maps names (e.g. ``"end"``, ``"yy"``) to unpadded
+    per-example coordinates, as in :func:`build_patch_cache`. Query vectors
+    are stored at each named position; keys and values at every position.
+    Runs as a single batch: this is validation-scale machinery, and a single
+    load fixes one padding for the whole set.
     """
-    _require_fused_absolute(desc, "attention-detail capture")
     from .provenance import check_capability
 
     check_capability(desc.model, ["K/V attention-detail collection"])
-    attn_impl = getattr(desc.model.config, "_attn_implementation", "eager")
-    if attn_impl != "eager":
-        raise RuntimeError(
-            f"K/V attention-detail capture requires attn_implementation="
-            f"'eager' (got {attn_impl!r}): fused sdpa/flash kernels do not "
-            f"materialize what pyvene's attention units need. causalab's "
-            f"LMPipeline loads models eager by default."
-        )
+    if require_eager:
+        _require_eager(desc)
+    if not positions:
+        raise ValueError("at least one named position is required")
     inputs = [{"raw_input": x} if isinstance(x, str) else x for x in inputs]
-    L, H, DH = desc.n_layers, desc.n_heads, desc.head_dim
+    L, H, KV, DH = desc.n_layers, desc.n_heads, desc.n_kv_heads, desc.head_dim
 
     units: list[AtomicModelUnit] = []
     meta: list[tuple[str, int]] = []
@@ -145,11 +207,20 @@ def build_attn_detail_cache(
     intervenable_model = prepare_intervenable_model(
         pipeline, units, intervention_type="collect"
     )
+    keep_last_dim_on_collects(intervenable_model)
     try:
         loaded = pipeline.load(list(inputs))
         mask = loaded["attention_mask"]
         bsz, T = mask.shape
-        pos = padded_position(mask, position_index)
+        pos_named = {
+            name: padded_position(mask, spec) for name, spec in positions.items()
+        }
+        if "position_ids" in loaded:
+            position_ids = loaded["position_ids"]
+        else:  # the model's default when none are passed: arange over padded T
+            position_ids = (
+                torch.arange(T, device=mask.device).unsqueeze(0).expand(bsz, T)
+            )
         all_positions = [list(range(T)) for _ in range(bsz)]
         indices = [all_positions for _ in units]
         location_map = {"sources->base": (indices, indices)}
@@ -158,32 +229,542 @@ def build_attn_detail_cache(
     finally:
         delete_intervenable_model(intervenable_model)
 
-    def per_head(x: Tensor) -> Tensor:  # (B, T, H*dh) -> (B, H, T, dh)
-        return x.reshape(bsz, T, H, DH).permute(0, 2, 1, 3)
-
     store: dict[tuple[str, int], Tensor] = {}
     for m, act in zip(meta, collected):
         a = act if isinstance(act, Tensor) else torch.cat(list(act))
-        store[m] = per_head(a.reshape(bsz, T, -1).float().cpu())
+        n_heads_here = H if m[0] == "q" else KV
+        store[m] = a.reshape(bsz, T, n_heads_here, DH).permute(0, 2, 1, 3).float().cpu()
 
     k_all = torch.stack([store[("k", li)] for li in range(L)], dim=1)
     v_all = torch.stack([store[("v", li)] for li in range(L)], dim=1)
     bidx = torch.arange(bsz)
-    pidx = torch.tensor(pos)
-    q_pos = torch.stack([store[("q", li)][bidx, :, pidx] for li in range(L)], dim=1)
-
-    # derived arithmetic — gap registry: kv:scores (no-module-boundary);
-    # the score tensor is never hooked or intervened on.
-    scores = (q_pos.unsqueeze(3) @ k_all.transpose(-1, -2)).squeeze(3) / (DH**0.5)
-    mask_c = mask.cpu()
-    scores = scores.masked_fill(mask_c[:, None, None, :] == 0, float("-inf"))
-    causal = torch.arange(T)[None, :] > pidx[:, None]
-    scores = scores.masked_fill(causal[:, None, None, :], float("-inf"))
-
+    q = {
+        name: torch.stack(
+            [store[("q", li)][bidx, :, torch.tensor(p)] for li in range(L)], dim=1
+        )
+        for name, p in pos_named.items()
+    }
     return AttnDetailCache(
-        q_pos=q_pos,
+        n_layers=L,
+        n_heads=H,
+        n_kv_heads=KV,
+        head_dim=DH,
+        q=q,
         k_all=k_all,
         v_all=v_all,
-        scores_pos=scores,
-        attention_mask=mask_c,
+        attention_mask=mask.cpu(),
+        position_ids=position_ids.cpu(),
+        positions=pos_named,
     )
+
+
+def _require_eager(desc: ArchitectureDescriptor) -> None:
+    attn_impl = getattr(desc.model.config, "_attn_implementation", "eager")
+    if attn_impl != "eager":
+        raise RuntimeError(
+            f"K/V-side path patching requires attn_implementation='eager' "
+            f"(got {attn_impl!r}): fused sdpa/flash kernels do not "
+            f"materialize what pyvene's attention units hook, and the "
+            f"analytic score reconstruction mirrors the eager path. Load "
+            f"with LMPipeline(..., attn_implementation='eager') or set "
+            f"attn_implementation: eager in the model YAML; no re-loading "
+            f"or monkey-patching is done on your behalf."
+        )
+
+
+def _rotate_half(x: Tensor) -> Tensor:
+    x1, x2 = x.chunk(2, dim=-1)
+    return torch.cat((-x2, x1), dim=-1)
+
+
+class KVPatchEngine:
+    """Analytic K/V-side patching over detail caches, twin-checked.
+
+    Built from two position views of the same cache pair (``engine_end``
+    reads the receiver position, ``engine_patch`` the patched K/V position)
+    plus the pre-rotation q/k/v detail caches for both sides.
+
+    Construction refuses non-eager models, refuses families whose pyvene
+    mapping lacks the q/k/v units, and runs guard K1 (z reconstruction) on
+    both caches.
+    """
+
+    def __init__(
+        self,
+        engine_end: PatchEngine,
+        engine_patch: PatchEngine,
+        detail_clean: AttnDetailCache,
+        detail_cf: AttnDetailCache,
+        *,
+        position_end: str = "end",
+        position_patch: str = "yy",
+        run_guards: bool = True,
+        guard_tolerances: dict[str, float] | None = None,
+    ) -> None:
+        if engine_end.desc is not engine_patch.desc:
+            raise ValueError("engines must share one resolved descriptor")
+        self.desc = engine_end.desc
+        self.engine_end = engine_end
+        self.engine_patch = engine_patch
+        self.detail = {"clean": detail_clean, "cf": detail_cf}
+        self.position_end = position_end
+        self.position_patch = position_patch
+        self.device = engine_end.device
+        self.model_dtype = engine_end.model_dtype
+        from .provenance import check_capability
+
+        self.capability = check_capability(
+            self.desc.model,
+            ["K/V attention-detail collection", "K/V reference-twin interventions"],
+        )
+        _require_eager(self.desc)
+        for name, det in self.detail.items():
+            for pos in (position_end, position_patch):
+                if pos not in det.positions:
+                    raise ValueError(
+                        f"detail cache ({name}) has no position {pos!r}; build "
+                        f"it with positions={{{position_end!r}: ..., "
+                        f"{position_patch!r}: ...}}"
+                    )
+        self._rope: dict[str, tuple[Tensor, Tensor] | None] = {}
+        self.guard_report: dict[str, Any] | None = None
+        if run_guards:
+            self.guard_report = self._run_guards(guard_tolerances)
+
+    # ------------------------------------------------------------------
+    # caches and coordinates
+    # ------------------------------------------------------------------
+    def _cache(self, name: str) -> PatchCache:
+        return self.engine_end.clean if name == "clean" else self.engine_end.cf
+
+    def _pos_idx(self, detail: AttnDetailCache, name: str) -> Tensor:
+        return torch.tensor(detail.positions[name], dtype=torch.long)
+
+    def _cos_sin(self, name: str) -> tuple[Tensor, Tensor] | None:
+        """(cos, sin) over all padded positions, via the model's own rotary
+        module on the position ids the forward actually used."""
+        if name in self._rope:
+            return self._rope[name]
+        rotary = self.desc.rotary_emb()
+        if rotary is None or self.desc.attention_style == "fused-qkv-absolute":
+            self._rope[name] = None
+            return None
+        det = self.detail[name]
+        pos_ids = det.position_ids.to(self.device)
+        dummy = torch.zeros(1, dtype=torch.float32, device=self.device)
+        cos, sin = rotary(dummy, pos_ids)
+        self._rope[name] = (cos.float().cpu(), sin.float().cpu())
+        return self._rope[name]
+
+    def _rot(self, x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+        """Apply rotary rotation. x: (..., T, dh) or (..., dh) with matching
+        cos/sin broadcastable to it."""
+        return x * cos + _rotate_half(x) * sin
+
+    # ------------------------------------------------------------------
+    # score/z reconstruction (the HF eager path, in float32)
+    # ------------------------------------------------------------------
+    def _z_from_qkv(
+        self,
+        layer: int,
+        q_pos: Tensor,  # (N, H, dh) pre-rotation, at the end position
+        k_all: Tensor,  # (N, KV, T, dh) pre-rotation
+        v_all: Tensor,  # (N, KV, T, dh)
+        detail_name: str,
+        *,
+        heads: Sequence[int] | None = None,
+        return_weights: bool = False,
+    ) -> Tensor | tuple[Tensor, Tensor]:
+        """Per-query-head z at the end position, reconstructed the way the
+        eager kernel computes it. ``heads`` restricts to a subset of query
+        heads (default: all)."""
+        desc = self.desc
+        det = self.detail[detail_name]
+        N, T = det.n_examples, det.seq_len
+        heads = list(range(desc.n_heads)) if heads is None else list(heads)
+        end_idx = self._pos_idx(det, self.position_end)
+        bidx = torch.arange(N)
+
+        rope = self._cos_sin(detail_name)
+        if rope is not None:
+            cos, sin = rope  # (N, T, dh)
+            q_r = self._rot(
+                q_pos, cos[bidx, end_idx][:, None, :], sin[bidx, end_idx][:, None, :]
+            )
+            k_r = self._rot(k_all, cos[:, None, :, :], sin[:, None, :, :])
+        else:
+            q_r, k_r = q_pos, k_all
+
+        g = desc.kv_group_size
+        kv_of = [h // g for h in heads]
+        qh = q_r[:, heads]  # (N, |heads|, dh)
+        kh = k_r[:, kv_of]  # (N, |heads|, T, dh)
+        vh = v_all[:, kv_of]  # (N, |heads|, T, dh)
+
+        scores = torch.einsum("nhd,nhtd->nht", qh, kh) * desc.attn_scaling(layer)
+        cap = desc.attn_logit_softcapping()
+        if cap is not None:  # Gemma-2: softcap BEFORE masking, as in HF eager
+            scores = torch.tanh(scores / cap) * cap
+
+        mask = det.attention_mask  # (N, T)
+        neg = torch.finfo(torch.float32).min
+        scores = scores.masked_fill(mask[:, None, :] == 0, neg)
+        causal = torch.arange(T)[None, :] > end_idx[:, None]  # (N, T)
+        scores = scores.masked_fill(causal[:, None, :], neg)
+        window = desc.attn_sliding_window(layer)
+        if window is not None:
+            too_far = (end_idx[:, None] - torch.arange(T)[None, :]) >= window
+            scores = scores.masked_fill(too_far[:, None, :], neg)
+
+        weights = torch.softmax(scores.float(), dim=-1)
+        z = torch.einsum("nht,nhtd->nhd", weights, vh)
+        if return_weights:
+            return z, weights
+        return z
+
+    def attention_weights(
+        self, layer: int, cache: str = "clean", heads: Sequence[int] | None = None
+    ) -> Tensor:
+        """(N, |heads|, T) reconstructed attention from the end position."""
+        det = self.detail[cache]
+        _, w = self._z_from_qkv(
+            layer,
+            det.q[self.position_end][:, layer],
+            det.k_all[:, layer],
+            det.v_all[:, layer],
+            cache,
+            heads=heads,
+            return_weights=True,
+        )
+        return w
+
+    def attention_to_patch_position(
+        self, layer: int, head: int, cache: str = "clean"
+    ) -> Tensor:
+        """(N,) attention weight from the end position to the patched
+        position (e.g. Hanna et al. Fig 11: a7.h10 end -> YY)."""
+        det = self.detail[cache]
+        w = self.attention_weights(layer, cache, heads=[head])[:, 0]
+        p_idx = self._pos_idx(det, self.position_patch)
+        return w[torch.arange(det.n_examples), p_idx]
+
+    # ------------------------------------------------------------------
+    # reachability
+    # ------------------------------------------------------------------
+    def check_reachable(self, layer: int, detail_name: str = "clean") -> None:
+        """Refuse a K/V edge whose patched position the end position cannot
+        attend to within this layer's sliding window."""
+        window = self.desc.attn_sliding_window(layer)
+        if window is None:
+            return
+        det = self.detail[detail_name]
+        end_idx = self._pos_idx(det, self.position_end)
+        p_idx = self._pos_idx(det, self.position_patch)
+        dist = (end_idx - p_idx).max().item()
+        if dist >= window:
+            raise SlidingWindowError(
+                f"K/V edge at layer {layer}: the end position cannot attend "
+                f"to patched position {self.position_patch!r} there — layer "
+                f"{layer} uses sliding-window attention with window "
+                f"{window}, and the largest end-to-patch distance in this "
+                f"batch is {dist} (must be < window). Pick a full-attention "
+                f"layer or a closer position."
+            )
+
+    # ------------------------------------------------------------------
+    # patched k/v construction
+    # ------------------------------------------------------------------
+    def _kv_delta_from_resid(
+        self, layer: int, delta_resid: Tensor, base: str
+    ) -> tuple[Tensor, Tensor]:
+        """(Δk, Δv) at the patched position for every KV head of ``layer``,
+        pre-rotation, from a residual delta at that position.
+
+        Formed as ``proj(norm(x+Δ)) − proj(norm(x))`` through the model's own
+        pre-norm and projections (direct module calls, model dtype), so a
+        zero residual delta gives exactly zero.
+        """
+        cache = self._cache(base)
+        eng = self.engine_patch
+        if layer == 0:
+            x = eng._at(cache, "embed")
+        else:
+            x = eng._at(cache, "block_out", layer - 1)
+        norm = self.desc.attn_pre_norm(layer)
+        d = delta_resid.to(self.device).float()
+        normed_new = norm((x + d).to(self.model_dtype))
+        normed_old = norm(x.to(self.model_dtype))
+        _, k_new, v_new = self.desc.qkv_new(layer, normed_new)
+        _, k_old, v_old = self.desc.qkv_new(layer, normed_old)
+        KV, DH = self.desc.n_kv_heads, self.desc.head_dim
+        dk = (k_new - k_old).float().reshape(-1, KV, DH).cpu()
+        dv = (v_new - v_old).float().reshape(-1, KV, DH).cpu()
+        return dk, dv
+
+    def _substitution_delta(
+        self, edge: KVEdge, base: str
+    ) -> tuple[Tensor | None, Tensor | None]:
+        """(Δk, Δv) at the patched position from cache-to-cache substitution:
+        the other side's captured pre-rotation k/v minus the base side's.
+        Valid when clean and counterfactual token positions coincide (token-
+        aligned pairs), which is exactly the regime raw substitution is
+        correct in."""
+        other = "cf" if base == "clean" else "clean"
+        det_b, det_o = self.detail[base], self.detail[other]
+        L, j = edge.kv.layer, edge.kv.kv_index
+        pb = self._pos_idx(det_b, self.position_patch)
+        po = self._pos_idx(det_o, self.position_patch)
+        bidx = torch.arange(det_b.n_examples)
+        dk = dv = None
+        if edge.patch_k:
+            dk = det_o.k_all[bidx, L, j, po] - det_b.k_all[bidx, L, j, pb]
+        if edge.patch_v:
+            dv = det_o.v_all[bidx, L, j, po] - det_b.v_all[bidx, L, j, pb]
+        return dk, dv
+
+    # ------------------------------------------------------------------
+    # the K/V trunk delta
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def kv_trunk_delta(
+        self,
+        edges: Sequence[KVEdge],
+        input_deltas: Mapping[int, Tensor] | Tensor | None = None,
+        *,
+        base_cache: str = "clean",
+        patch_q: bool = False,
+        rotate_key_delta: bool = True,
+    ) -> Tensor:
+        """(N, d) change in the edges' layers' attention-branch trunk
+        contributions at the end position when the named KV heads' keys
+        and/or values at the patched position are patched.
+
+        ``input_deltas``: residual delta(s) at the patched position entering
+        each edge's layer — one tensor for all layers or a per-layer map
+        (path-patch mode). ``None`` selects cache-to-cache substitution: the
+        other side's captured k/v at the position replace the base side's.
+
+        ``patch_q=True`` additionally restores the affected query heads'
+        query vectors from the other cache (the same side a substitution
+        patch draws k/v from) — the "queries receive all good inputs" case
+        of a full-circuit evaluation. The query swap is then part of the
+        patch: the base-side z is scored with the base-side q, the patched
+        z with the other side's q. Substitution semantics (token-aligned
+        pairs), like ``input_deltas=None``.
+
+        ``rotate_key_delta=False`` is the **negative control**: it adds the
+        key delta to the already-rotated base keys without rotating it by
+        the patched position's angle. On a rotary family this is wrong by
+        construction and must disagree with the reference twin; it exists so
+        validation can prove the rotation term has teeth.
+
+        Per-layer raw deltas are summed before any branch post-norm
+        (Gemma-2), matching the main engine's trunk_delta.
+        """
+        desc = self.desc
+        det_b = self.detail[base_cache]
+        other = "cf" if base_cache == "clean" else "clean"
+        N = det_b.n_examples
+        bidx = torch.arange(N)
+        p_idx = self._pos_idx(det_b, self.position_patch)
+
+        # accumulate per-layer z-deltas (N, H, dh) over affected query heads
+        per_layer_dz: dict[int, Tensor] = {}
+        # group edges per layer so one reconstruction handles several KV heads
+        by_layer: dict[int, list[KVEdge]] = {}
+        for e in edges:
+            by_layer.setdefault(e.kv.layer, []).append(e)
+
+        for layer, layer_edges in sorted(by_layer.items()):
+            self.check_reachable(layer, base_cache)
+            k_base = det_b.k_all[:, layer].clone()  # (N, KV, T, dh) pre-rot
+            v_base = det_b.v_all[:, layer].clone()
+            deltas_ready: dict[int, tuple[Tensor | None, Tensor | None]] = {}
+            if input_deltas is None:
+                for e in layer_edges:
+                    deltas_ready[e.kv.kv_index] = self._substitution_delta(
+                        e, base_cache
+                    )
+            else:
+                dr = (
+                    input_deltas[layer]
+                    if isinstance(input_deltas, Mapping)
+                    else input_deltas
+                )
+                dk_all, dv_all = self._kv_delta_from_resid(layer, dr, base_cache)
+                for e in layer_edges:
+                    j = e.kv.kv_index
+                    deltas_ready[j] = (
+                        dk_all[:, j] if e.patch_k else None,
+                        dv_all[:, j] if e.patch_v else None,
+                    )
+
+            k_patched = k_base.clone()
+            v_patched = v_base.clone()
+            unrotated_extra: dict[int, Tensor] = {}
+            affected_q_heads: set[int] = set()
+            for e in layer_edges:
+                j = e.kv.kv_index
+                dk, dv = deltas_ready[j]
+                if dk is not None:
+                    if rotate_key_delta:
+                        k_patched[bidx, j, p_idx] = k_patched[bidx, j, p_idx] + dk
+                    else:
+                        # negative control: remember the raw delta; it will be
+                        # added AFTER rotation below (wrong on rotary models)
+                        unrotated_extra[j] = dk
+                if dv is not None:
+                    v_patched[bidx, j, p_idx] = v_patched[bidx, j, p_idx] + dv
+                affected_q_heads.update(desc.query_heads_of_kv(j))
+
+            heads = sorted(affected_q_heads)
+            q_base = det_b.q[self.position_end][:, layer]
+            q_new = (
+                self.detail[other].q[self.position_end][:, layer] if patch_q else q_base
+            )
+            if unrotated_extra:
+                z_new = self._z_with_unrotated_extra(
+                    layer,
+                    q_new,
+                    k_patched,
+                    v_patched,
+                    base_cache,
+                    unrotated_extra,
+                    heads,
+                )
+            else:
+                z_new = self._z_from_qkv(
+                    layer, q_new, k_patched, v_patched, base_cache, heads=heads
+                )
+            # base-side z for the same heads, reconstructed the same way so
+            # the delta isolates the patch (reconstruction bias cancels)
+            z_old = self._z_from_qkv(
+                layer, q_base, k_base, v_base, base_cache, heads=heads
+            )
+            per_layer_dz[layer] = (z_new - z_old, heads)
+
+        # z-deltas -> trunk deltas through W_O (+ branch post-norm)
+        eng = self.engine_end
+        cache_b = self._cache(base_cache)
+        total: Tensor | None = None
+        for layer, (dz, heads) in per_layer_dz.items():
+            w_o = eng._w_o[layer]
+            raw = torch.zeros(N, desc.d_model, device=self.device)
+            for i, h in enumerate(heads):
+                rows = w_o[h * desc.head_dim : (h + 1) * desc.head_dim]
+                raw = raw + dz[:, i].to(self.device) @ rows
+            post = desc.attn_post_norm(layer)
+            if post is None:
+                d = raw
+            else:
+                cache_key = "clean" if cache_b is eng.clean else "cf"
+                pre = eng._attn_pre_norm_clean(cache_key, cache_b, layer)
+                d = eng._apply_norm(post, pre + raw) - eng._apply_norm(post, pre)
+            total = d if total is None else total + d
+        if total is None:
+            total = torch.zeros(N, desc.d_model, device=self.device)
+        return total
+
+    def _z_with_unrotated_extra(
+        self,
+        layer: int,
+        q_pos: Tensor,
+        k_patched: Tensor,
+        v_patched: Tensor,
+        detail_name: str,
+        unrotated_extra: dict[int, Tensor],
+        heads: Sequence[int],
+    ) -> Tensor:
+        """Negative-control scoring: key deltas added after rotation.
+
+        Only exists to prove the rotation term matters; identical to the
+        correct path on non-rotary families (where rotation is identity).
+        """
+        desc = self.desc
+        det = self.detail[detail_name]
+        N, T = det.n_examples, det.seq_len
+        end_idx = self._pos_idx(det, self.position_end)
+        p_idx = self._pos_idx(det, self.position_patch)
+        bidx = torch.arange(N)
+        rope = self._cos_sin(detail_name)
+        if rope is not None:
+            cos, sin = rope
+            q_r = self._rot(
+                q_pos, cos[bidx, end_idx][:, None, :], sin[bidx, end_idx][:, None, :]
+            )
+            k_r = self._rot(k_patched, cos[:, None, :, :], sin[:, None, :, :])
+        else:
+            q_r, k_r = q_pos, k_patched
+        for j, dk in unrotated_extra.items():
+            k_r[bidx, j, p_idx] = k_r[bidx, j, p_idx] + dk  # the deliberate bug
+        g = desc.kv_group_size
+        kv_of = [h // g for h in heads]
+        qh, kh, vh = q_r[:, list(heads)], k_r[:, kv_of], v_patched[:, kv_of]
+        scores = torch.einsum("nhd,nhtd->nht", qh, kh) * desc.attn_scaling(layer)
+        cap = desc.attn_logit_softcapping()
+        if cap is not None:
+            scores = torch.tanh(scores / cap) * cap
+        neg = torch.finfo(torch.float32).min
+        scores = scores.masked_fill(det.attention_mask[:, None, :] == 0, neg)
+        causal = torch.arange(T)[None, :] > end_idx[:, None]
+        scores = scores.masked_fill(causal[:, None, :], neg)
+        window = desc.attn_sliding_window(layer)
+        if window is not None:
+            too_far = (end_idx[:, None] - torch.arange(T)[None, :]) >= window
+            scores = scores.masked_fill(too_far[:, None, :], neg)
+        weights = torch.softmax(scores.float(), dim=-1)
+        return torch.einsum("nht,nhtd->nhd", weights, vh)
+
+    # ------------------------------------------------------------------
+    # guards
+    # ------------------------------------------------------------------
+    def _run_guards(self, tolerances: dict[str, float] | None) -> dict[str, Any]:
+        """K1: per-head z at the end position, reconstructed from captured
+        pre-rotation q/k/v through the analytic score path, must match the
+        cached attention_value_output. This exercises rotation, GQA fan-in,
+        scaling, softcapping, masks, and softmax in one check."""
+        tol = {
+            "z_reconstruction_rel": 1e-4
+            if self.model_dtype in (torch.float32, torch.float64)
+            else 3e-2,
+        }
+        if tolerances:
+            tol.update(tolerances)
+        report: dict[str, Any] = {"tolerances": dict(tol)}
+        failures: list[str] = []
+        for name in ("clean", "cf"):
+            det = self.detail[name]
+            cache = self._cache(name)
+            worst = 0.0
+            for layer in range(self.desc.n_layers):
+                z_rec = self._z_from_qkv(
+                    layer,
+                    det.q[self.position_end][:, layer],
+                    det.k_all[:, layer],
+                    det.v_all[:, layer],
+                    name,
+                )
+                z_cached = cache.z[self.position_end][:, layer]
+                err = (
+                    (z_rec.cpu() - z_cached).abs().max()
+                    / z_cached.abs().max().clamp_min(1e-12)
+                ).item()
+                worst = max(worst, err)
+            report[f"K1_z_reconstruction_{name}"] = worst
+            if worst > tol["z_reconstruction_rel"]:
+                failures.append(
+                    f"K1 z reconstruction ({name} cache): worst per-layer "
+                    f"relative error {worst:.2e} > "
+                    f"{tol['z_reconstruction_rel']:.0e}. Reconstructing z at "
+                    f"the end position from captured q/k/v does not "
+                    f"reproduce the model's own attention output. Likely "
+                    f"causes: wrong rotation (position ids), wrong scaling/"
+                    f"softcapping, or a mask mismatch."
+                )
+        if failures:
+            from .guards import GuardError
+
+            raise GuardError(
+                "K/V construction guards failed:\n- " + "\n- ".join(failures)
+            )
+        return report

--- a/causalab/methods/path_patching/provenance.py
+++ b/causalab/methods/path_patching/provenance.py
@@ -1,0 +1,317 @@
+"""Capture-point provenance: gap registry, runtime report, coverage table.
+
+Every activation capture or intervention point this package uses is labeled
+with its *mechanism*:
+
+* ``pyvene-named``    a component in pyvene's per-family mapping
+* ``pyvene-path``     pyvene's dotted module-path fallback (still pyvene —
+                      no hooks of ours — but not covered by the named
+                      vocabulary, so it carries a reason code)
+* ``raw-hook``        a torch hook of our own (K/V module only); requires a
+                      gap-registry entry, enforced by the hygiene test
+* ``direct-module-call``  the engine invoking a module on cached tensors
+                      (receiver re-evaluation, tail); no hook involved
+* ``unsupported``     not available for this family
+
+Reason codes for anything not pyvene-named:
+
+* ``mapping-lacks-entry``    pyvene's mapping has no unit for this point
+* ``unit-is-wrong-quantity`` pyvene has a similarly-named unit but it
+                             captures the wrong tensor (e.g. ``mlp_activation``
+                             is the gate activation, not the gated product a
+                             neuron sender needs)
+* ``family-unmapped``        pyvene does not map this model family at all
+* ``no-module-boundary``     the quantity is not any module's input/output
+                             (e.g. pre-softmax attention scores)
+
+The registry exists for drift detection as much as for review: the coverage
+table is regenerated in tests against the installed pyvene, so a pin bump
+that adds or moves units surfaces as a table diff instead of a silent
+behavior change.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+Mechanism = Literal[
+    "pyvene-named", "pyvene-path", "raw-hook", "direct-module-call", "unsupported"
+]
+ReasonCode = Literal[
+    "mapping-lacks-entry",
+    "unit-is-wrong-quantity",
+    "family-unmapped",
+    "no-module-boundary",
+]
+
+__all__ = [
+    "GAP_REGISTRY",
+    "GapEntry",
+    "CapturePoint",
+    "capture_provenance",
+    "coverage_table",
+    "pyvene_pin",
+    "register_gap",
+]
+
+
+@dataclass(frozen=True)
+class GapEntry:
+    site: str  # "<module>:<symbol>" of the code site
+    component: str
+    model_families: tuple[str, ...]
+    reason: ReasonCode
+    note: str = ""
+
+
+GAP_REGISTRY: dict[str, GapEntry] = {}
+
+
+def register_gap(entry: GapEntry) -> None:
+    GAP_REGISTRY[entry.site] = entry
+
+
+# ---------------------------------------------------------------------------
+# Registrations. Import-time, so the hygiene test can cross-check code sites
+# against the registry without executing any model code.
+# ---------------------------------------------------------------------------
+
+# The package currently has ZERO raw hooks (pyvene's gpt2 mapping splits the
+# fused c_attn itself, so even K/V capture is pyvene-named). The registry
+# still records the one no-module-boundary quantity, which is *derived*
+# arithmetic rather than a capture:
+register_gap(
+    GapEntry(
+        site="kv:scores",
+        component="pre-softmax masked attention scores",
+        model_families=("gpt2",),
+        reason="no-module-boundary",
+        note=(
+            "scores are computed inline in HF attention (no module I/O); "
+            "derived analytically from captured q/k, never hooked or "
+            "intervened on"
+        ),
+    )
+)
+
+# pyvene-path (dotted fallback) captures — pyvene-native, registered for
+# visibility and for the coverage table:
+register_gap(
+    GapEntry(
+        site="cache:component_neuron_values",
+        component="mlp down-projection input (neuron values)",
+        model_families=("gpt2", "gpt_neox", "llama", "gemma2"),
+        reason="unit-is-wrong-quantity",
+        note=(
+            "pyvene's mlp_activation captures act_fn output, which for gated "
+            "MLPs (Llama/Gemma) is the gate activation alone, not the "
+            "act(gate)*up product a neuron sender needs; the down-projection "
+            "input is the right quantity on every family."
+        ),
+    )
+)
+register_gap(
+    GapEntry(
+        site="reference:component_mlp_pre_norm_input",
+        component="MLP branch pre-norm input",
+        model_families=("gpt2", "gpt_neox", "llama", "gemma2"),
+        reason="mapping-lacks-entry",
+        note="no named unit for norm inputs; used for excluded-edge cancellation",
+    )
+)
+register_gap(
+    GapEntry(
+        site="reference:component_mlp_trunk_output",
+        component="MLP branch trunk contribution (post-norm output where present)",
+        model_families=("gemma2",),
+        reason="mapping-lacks-entry",
+        note=(
+            "pyvene's mlp_output is the MLP module output, which on Gemma-2 "
+            "is pre-post-norm; the trunk contribution is the post-norm output"
+        ),
+    )
+)
+register_gap(
+    GapEntry(
+        site="reference:component_final_norm_input",
+        component="final norm input",
+        model_families=("gpt2", "gpt_neox", "llama", "gemma2"),
+        reason="mapping-lacks-entry",
+        note="no named unit; used for direct-edge cancellation at the logits",
+    )
+)
+
+
+def pyvene_pin() -> str:
+    """The installed pyvene's VCS commit (from installation metadata)."""
+    try:
+        from importlib.metadata import distribution
+
+        dist = distribution("pyvene")
+        direct = dist.read_text("direct_url.json")
+        if direct:
+            info = json.loads(direct)
+            commit = info.get("vcs_info", {}).get("commit_id", "")
+            if commit:
+                return commit[:12]
+        return f"pypi:{dist.version}"
+    except Exception:  # noqa: BLE001 - purely diagnostic
+        return "unknown"
+
+
+@dataclass(frozen=True)
+class CapturePoint:
+    name: str
+    component: str
+    mechanism: Mechanism
+    reason: ReasonCode | None = None
+    gap_site: str | None = None
+
+
+def capture_provenance(desc) -> list[CapturePoint]:
+    """Provenance of every capture/intervention point the engine, cache, and
+    reference twin use for this descriptor's family."""
+    points = [
+        CapturePoint("head values (z)", desc.component_head_values(), "pyvene-named"),
+        CapturePoint("mlp branch output", desc.component_mlp_branch(), "pyvene-named"),
+        CapturePoint("block output", desc.component_block_output(), "pyvene-named"),
+        CapturePoint(
+            "embed contribution", desc.component_block_input(), "pyvene-named"
+        ),
+        CapturePoint(
+            "neuron values",
+            desc.component_neuron_values(0).replace("[0]", "[i]"),
+            "pyvene-path",
+            "unit-is-wrong-quantity",
+            "cache:component_neuron_values",
+        ),
+        CapturePoint(
+            "receiver MLP re-evaluation",
+            "mlp branch modules on cached tensors",
+            "direct-module-call",
+        ),
+        CapturePoint(
+            "tail (final norm + LM head + softcapping)",
+            "final norm / LM head modules on cached tensors",
+            "direct-module-call",
+        ),
+        # reference twin intervention points
+        CapturePoint(
+            "twin: sender/freeze substitution",
+            "head_attention_value_output / attention_value_output / mlp_output",
+            "pyvene-named",
+        ),
+        CapturePoint(
+            "twin: pre-norm input cancellation",
+            desc.component_mlp_pre_norm_input(0).replace("[0]", "[i]"),
+            "pyvene-path",
+            "mapping-lacks-entry",
+            "reference:component_mlp_pre_norm_input",
+        ),
+        CapturePoint(
+            "twin: receiver trunk-output recording",
+            desc.component_mlp_trunk_output(0).replace("[0]", "[i]"),
+            "pyvene-path",
+            "mapping-lacks-entry" if desc.spec.mlp_post_norm else None,
+            "reference:component_mlp_trunk_output" if desc.spec.mlp_post_norm else None,
+        ),
+        CapturePoint(
+            "twin: final-norm input cancellation",
+            desc.component_final_norm_input(),
+            "pyvene-path",
+            "mapping-lacks-entry",
+            "reference:component_final_norm_input",
+        ),
+    ]
+    if desc.attention_style == "fused-qkv-absolute":
+        points.append(
+            CapturePoint(
+                "K/V detail (gated module)",
+                "(head_)query/key/value_output; scores derived from cached q/k",
+                "pyvene-named",
+            )
+        )
+        points.append(
+            CapturePoint(
+                "K/V detail: pre-softmax scores",
+                "derived arithmetic on captured q/k (never hooked)",
+                "direct-module-call",
+                "no-module-boundary",
+                "kv:scores",
+            )
+        )
+    else:
+        points.append(
+            CapturePoint(
+                "K/V detail (gated module)",
+                "n/a for this attention style",
+                "unsupported",
+            )
+        )
+    return points
+
+
+def log_provenance(desc) -> list[dict]:
+    points = [asdict(p) for p in capture_provenance(desc)]
+    logger.info(
+        "path_patching capture provenance (%s, pyvene %s): %s",
+        desc.model_type,
+        pyvene_pin(),
+        json.dumps(points, indent=None),
+    )
+    return points
+
+
+# ---------------------------------------------------------------------------
+# Coverage table
+# ---------------------------------------------------------------------------
+
+_COVERAGE_FAMILIES = ("gpt2", "gpt_neox", "llama", "gemma2")
+_NAMED_COMPONENTS = (
+    "attention_value_output",
+    "head_attention_value_output",
+    "mlp_output",
+    "mlp_activation",
+    "block_input",
+    "block_output",
+    "head_key_output",
+    "head_query_output",
+    "head_value_output",
+)
+_LOGICAL_POINTS = (
+    ("neuron values (down-proj input)", "pyvene-path", "unit-is-wrong-quantity"),
+    ("MLP pre-norm input", "pyvene-path", "mapping-lacks-entry"),
+    ("final norm input", "pyvene-path", "mapping-lacks-entry"),
+    ("pre-softmax attention scores", "derived-from-cache", "no-module-boundary"),
+)
+
+
+def coverage_table() -> dict:
+    """family × component → mechanism, generated from the installed pyvene.
+
+    Regenerated in tests and diffed against the committed artifact so a
+    pyvene pin bump surfaces as a table diff.
+    """
+    import importlib
+
+    table: dict[str, dict[str, str]] = {}
+    for family in _COVERAGE_FAMILIES:
+        mod = importlib.import_module(f"pyvene.models.{family}.modelings_intervenable_{family}")
+        mapping = getattr(mod, f"{family}_lm_type_to_module_mapping", None) or getattr(
+            mod, f"{family}_type_to_module_mapping"
+        )
+        row: dict[str, str] = {}
+        for comp in _NAMED_COMPONENTS:
+            row[comp] = "pyvene-named" if comp in mapping else "unsupported"
+        for name, mech, reason in _LOGICAL_POINTS:
+            if name == "pre-softmax attention scores" and family != "gpt2":
+                row[name] = "unsupported (gated)"
+            else:
+                row[name] = f"{mech} ({reason})"
+        table[family] = row
+    return {"pyvene_pin": pyvene_pin(), "families": table}

--- a/causalab/methods/path_patching/provenance.py
+++ b/causalab/methods/path_patching/provenance.py
@@ -1,33 +1,26 @@
-"""Capture-point provenance: gap registry, runtime report, coverage table.
+"""Capability checking, capture provenance, and pyvene coverage.
 
-Every activation capture or intervention point this package uses is labeled
-with its *mechanism*:
+causalab's contract is that a model works iff its family is in pyvene's
+mapping — every intervention routes through ``IntervenableModel``. This
+method keeps that contract exactly: there are **no raw torch hooks anywhere**
+(grep-checkable), and every capture point is either a pyvene *named*
+component or a pyvene *dotted module path* (pyvene's own fallback resolution;
+still an ``IntervenableModel`` intervention, not a hook of ours).
 
-* ``pyvene-named``    a component in pyvene's per-family mapping
-* ``pyvene-path``     pyvene's dotted module-path fallback (still pyvene —
-                      no hooks of ours — but not covered by the named
-                      vocabulary, so it carries a reason code)
-* ``raw-hook``        a torch hook of our own (K/V module only); requires a
-                      gap-registry entry, enforced by the hygiene test
-* ``direct-module-call``  the engine invoking a module on cached tensors
-                      (receiver re-evaluation, tail); no hook involved
-* ``unsupported``     not available for this family
+Three surfaces:
 
-Reason codes for anything not pyvene-named:
-
-* ``mapping-lacks-entry``    pyvene's mapping has no unit for this point
-* ``unit-is-wrong-quantity`` pyvene has a similarly-named unit but it
-                             captures the wrong tensor (e.g. ``mlp_activation``
-                             is the gate activation, not the gated product a
-                             neuron sender needs)
-* ``family-unmapped``        pyvene does not map this model family at all
-* ``no-module-boundary``     the quantity is not any module's input/output
-                             (e.g. pre-softmax attention scores)
-
-The registry exists for drift detection as much as for review: the coverage
-table is regenerated in tests against the installed pyvene, so a pin bump
-that adds or moves units surfaces as a table diff instead of a silent
-behavior change.
+* :func:`check_capability` — at engine construction, verify that every
+  pyvene unit the requested operation needs exists in the family's mapping;
+  otherwise raise :class:`UnsupportedArchitectureError` naming the missing
+  units and the operation that needs them. Unsupported means unsupported,
+  same as the rest of the library.
+* :func:`capture_provenance` — document which pyvene units an engine uses
+  (named vs dotted-path); exposed as ``engine.provenance`` and written into
+  validation results JSONs.
+* :func:`coverage_table` — supported/unsupported per family × component,
+  generated from the installed pyvene. Regenerated in tests and diffed
+  against the committed artifact, so a pyvene pin bump surfaces as a table
+  diff instead of a silent behavior change.
 """
 
 from __future__ import annotations
@@ -39,112 +32,81 @@ from typing import Literal
 
 logger = logging.getLogger(__name__)
 
-Mechanism = Literal[
-    "pyvene-named", "pyvene-path", "raw-hook", "direct-module-call", "unsupported"
-]
-ReasonCode = Literal[
-    "mapping-lacks-entry",
-    "unit-is-wrong-quantity",
-    "family-unmapped",
-    "no-module-boundary",
-]
+Mechanism = Literal["pyvene-named", "pyvene-path", "direct-module-call"]
 
 __all__ = [
-    "GAP_REGISTRY",
-    "GapEntry",
     "CapturePoint",
+    "UnsupportedArchitectureError",
     "capture_provenance",
+    "check_capability",
     "coverage_table",
     "pyvene_pin",
-    "register_gap",
 ]
 
 
-@dataclass(frozen=True)
-class GapEntry:
-    site: str  # "<module>:<symbol>" of the code site
-    component: str
-    model_families: tuple[str, ...]
-    reason: ReasonCode
-    note: str = ""
+class UnsupportedArchitectureError(NotImplementedError):
+    """The model family lacks pyvene units this operation needs."""
 
 
-GAP_REGISTRY: dict[str, GapEntry] = {}
+# pyvene named units each operation requires, beyond family membership.
+REQUIRED_UNITS: dict[str, tuple[str, ...]] = {
+    "path-patching cache collection": (
+        "attention_value_output",
+        "mlp_output",
+        "block_input",
+        "block_output",
+    ),
+    "reference-twin interventions": (
+        "attention_value_output",
+        "head_attention_value_output",
+        "mlp_output",
+        "block_input",
+    ),
+    "K/V attention-detail collection": (
+        "query_output",
+        "key_output",
+        "value_output",
+    ),
+}
 
 
-def register_gap(entry: GapEntry) -> None:
-    GAP_REGISTRY[entry.site] = entry
+def _family_mapping(model) -> dict | None:
+    """The installed pyvene's component mapping for this model's class."""
+    from pyvene.models.intervenable_modelcard import type_to_module_mapping
+
+    return type_to_module_mapping.get(type(model))
 
 
-# ---------------------------------------------------------------------------
-# Registrations. Import-time, so the hygiene test can cross-check code sites
-# against the registry without executing any model code.
-# ---------------------------------------------------------------------------
+def check_capability(model, operations: list[str]) -> dict[str, list[str]]:
+    """Verify pyvene covers ``operations`` for this model; raise otherwise.
 
-# The package currently has ZERO raw hooks (pyvene's gpt2 mapping splits the
-# fused c_attn itself, so even K/V capture is pyvene-named). The registry
-# still records the one no-module-boundary quantity, which is *derived*
-# arithmetic rather than a capture:
-register_gap(
-    GapEntry(
-        site="kv:scores",
-        component="pre-softmax masked attention scores",
-        model_families=("gpt2",),
-        reason="no-module-boundary",
-        note=(
-            "scores are computed inline in HF attention (no module I/O); "
-            "derived analytically from captured q/k, never hooked or "
-            "intervened on"
-        ),
-    )
-)
-
-# pyvene-path (dotted fallback) captures — pyvene-native, registered for
-# visibility and for the coverage table:
-register_gap(
-    GapEntry(
-        site="cache:component_neuron_values",
-        component="mlp down-projection input (neuron values)",
-        model_families=("gpt2", "gpt_neox", "llama", "gemma2"),
-        reason="unit-is-wrong-quantity",
-        note=(
-            "pyvene's mlp_activation captures act_fn output, which for gated "
-            "MLPs (Llama/Gemma) is the gate activation alone, not the "
-            "act(gate)*up product a neuron sender needs; the down-projection "
-            "input is the right quantity on every family."
-        ),
-    )
-)
-register_gap(
-    GapEntry(
-        site="reference:component_mlp_pre_norm_input",
-        component="MLP branch pre-norm input",
-        model_families=("gpt2", "gpt_neox", "llama", "gemma2"),
-        reason="mapping-lacks-entry",
-        note="no named unit for norm inputs; used for excluded-edge cancellation",
-    )
-)
-register_gap(
-    GapEntry(
-        site="reference:component_mlp_trunk_output",
-        component="MLP branch trunk contribution (post-norm output where present)",
-        model_families=("gemma2",),
-        reason="mapping-lacks-entry",
-        note=(
-            "pyvene's mlp_output is the MLP module output, which on Gemma-2 "
-            "is pre-post-norm; the trunk contribution is the post-norm output"
-        ),
-    )
-)
-register_gap(
-    GapEntry(
-        site="reference:component_final_norm_input",
-        component="final norm input",
-        model_families=("gpt2", "gpt_neox", "llama", "gemma2"),
-        reason="mapping-lacks-entry",
-        note="no named unit; used for direct-edge cancellation at the logits",
-    )
-)
+    Returns {operation: [units used]} for provenance on success.
+    """
+    mapping = _family_mapping(model)
+    if mapping is None:
+        raise UnsupportedArchitectureError(
+            f"pyvene has no component mapping for model class "
+            f"{type(model).__name__} (pyvene pin {pyvene_pin()}); causalab "
+            f"methods require the model family to be in pyvene's mapping. "
+            f"Operations requested: {operations}."
+        )
+    used: dict[str, list[str]] = {}
+    problems: list[str] = []
+    for op in operations:
+        required = REQUIRED_UNITS[op]
+        missing = [u for u in required if u not in mapping]
+        if missing:
+            problems.append(
+                f"{op!r} needs pyvene unit(s) {missing} that "
+                f"{type(model).__name__}'s mapping does not define"
+            )
+        used[op] = list(required)
+    if problems:
+        raise UnsupportedArchitectureError(
+            "unsupported architecture for path patching (pyvene pin "
+            f"{pyvene_pin()}):\n- " + "\n- ".join(problems)
+        )
+    return used
 
 
 def pyvene_pin() -> str:
@@ -169,13 +131,11 @@ class CapturePoint:
     name: str
     component: str
     mechanism: Mechanism
-    reason: ReasonCode | None = None
-    gap_site: str | None = None
+    note: str = ""
 
 
 def capture_provenance(desc) -> list[CapturePoint]:
-    """Provenance of every capture/intervention point the engine, cache, and
-    reference twin use for this descriptor's family."""
+    """The pyvene units and module calls an engine for this family uses."""
     points = [
         CapturePoint("head values (z)", desc.component_head_values(), "pyvene-named"),
         CapturePoint("mlp branch output", desc.component_mlp_branch(), "pyvene-named"),
@@ -187,20 +147,20 @@ def capture_provenance(desc) -> list[CapturePoint]:
             "neuron values",
             desc.component_neuron_values(0).replace("[0]", "[i]"),
             "pyvene-path",
-            "unit-is-wrong-quantity",
-            "cache:component_neuron_values",
+            "pyvene's mlp_activation is the gate activation; a neuron sender "
+            "needs the down-projection input (the gated product on "
+            "Llama/Gemma), addressed by module path",
         ),
         CapturePoint(
             "receiver MLP re-evaluation",
-            "mlp branch modules on cached tensors",
+            "mlp branch modules invoked on cached tensors",
             "direct-module-call",
         ),
         CapturePoint(
             "tail (final norm + LM head + softcapping)",
-            "final norm / LM head modules on cached tensors",
+            "final norm / LM head modules invoked on cached tensors",
             "direct-module-call",
         ),
-        # reference twin intervention points
         CapturePoint(
             "twin: sender/freeze substitution",
             "head_attention_value_output / attention_value_output / mlp_output",
@@ -210,47 +170,30 @@ def capture_provenance(desc) -> list[CapturePoint]:
             "twin: pre-norm input cancellation",
             desc.component_mlp_pre_norm_input(0).replace("[0]", "[i]"),
             "pyvene-path",
-            "mapping-lacks-entry",
-            "reference:component_mlp_pre_norm_input",
+            "norm inputs have no named unit",
         ),
         CapturePoint(
             "twin: receiver trunk-output recording",
             desc.component_mlp_trunk_output(0).replace("[0]", "[i]"),
             "pyvene-path",
-            "mapping-lacks-entry" if desc.spec.mlp_post_norm else None,
-            "reference:component_mlp_trunk_output" if desc.spec.mlp_post_norm else None,
+            "the trunk contribution is the branch post-norm's output on "
+            "Gemma-2; the MLP module's output elsewhere",
         ),
         CapturePoint(
             "twin: final-norm input cancellation",
             desc.component_final_norm_input(),
             "pyvene-path",
-            "mapping-lacks-entry",
-            "reference:component_final_norm_input",
+            "norm inputs have no named unit",
         ),
     ]
     if desc.attention_style == "fused-qkv-absolute":
         points.append(
             CapturePoint(
                 "K/V detail (gated module)",
-                "(head_)query/key/value_output; scores derived from cached q/k",
+                "(head_)query/key/value_output",
                 "pyvene-named",
-            )
-        )
-        points.append(
-            CapturePoint(
-                "K/V detail: pre-softmax scores",
-                "derived arithmetic on captured q/k (never hooked)",
-                "direct-module-call",
-                "no-module-boundary",
-                "kv:scores",
-            )
-        )
-    else:
-        points.append(
-            CapturePoint(
-                "K/V detail (gated module)",
-                "n/a for this attention style",
-                "unsupported",
+                "pre-softmax scores are derived arithmetic on the captured "
+                "q/k (no module boundary exists for scores; none is needed)",
             )
         )
     return points
@@ -279,39 +222,30 @@ _NAMED_COMPONENTS = (
     "mlp_activation",
     "block_input",
     "block_output",
-    "head_key_output",
+    "query_output",
+    "key_output",
+    "value_output",
     "head_query_output",
+    "head_key_output",
     "head_value_output",
-)
-_LOGICAL_POINTS = (
-    ("neuron values (down-proj input)", "pyvene-path", "unit-is-wrong-quantity"),
-    ("MLP pre-norm input", "pyvene-path", "mapping-lacks-entry"),
-    ("final norm input", "pyvene-path", "mapping-lacks-entry"),
-    ("pre-softmax attention scores", "derived-from-cache", "no-module-boundary"),
 )
 
 
 def coverage_table() -> dict:
-    """family × component → mechanism, generated from the installed pyvene.
-
-    Regenerated in tests and diffed against the committed artifact so a
-    pyvene pin bump surfaces as a table diff.
-    """
+    """family × pyvene component → supported/unsupported, from the installed
+    pyvene. The drift-detection artifact for pin bumps."""
     import importlib
 
     table: dict[str, dict[str, str]] = {}
     for family in _COVERAGE_FAMILIES:
-        mod = importlib.import_module(f"pyvene.models.{family}.modelings_intervenable_{family}")
+        mod = importlib.import_module(
+            f"pyvene.models.{family}.modelings_intervenable_{family}"
+        )
         mapping = getattr(mod, f"{family}_lm_type_to_module_mapping", None) or getattr(
             mod, f"{family}_type_to_module_mapping"
         )
-        row: dict[str, str] = {}
-        for comp in _NAMED_COMPONENTS:
-            row[comp] = "pyvene-named" if comp in mapping else "unsupported"
-        for name, mech, reason in _LOGICAL_POINTS:
-            if name == "pre-softmax attention scores" and family != "gpt2":
-                row[name] = "unsupported (gated)"
-            else:
-                row[name] = f"{mech} ({reason})"
-        table[family] = row
+        table[family] = {
+            comp: "supported" if comp in mapping else "unsupported"
+            for comp in _NAMED_COMPONENTS
+        }
     return {"pyvene_pin": pyvene_pin(), "families": table}

--- a/causalab/methods/path_patching/provenance.py
+++ b/causalab/methods/path_patching/provenance.py
@@ -67,6 +67,12 @@ REQUIRED_UNITS: dict[str, tuple[str, ...]] = {
         "key_output",
         "value_output",
     ),
+    "K/V reference-twin interventions": (
+        "head_key_output",
+        "head_value_output",
+        "attention_value_output",
+        "mlp_output",
+    ),
 }
 
 
@@ -186,14 +192,25 @@ def capture_provenance(desc) -> list[CapturePoint]:
             "norm inputs have no named unit",
         ),
     ]
-    if desc.attention_style == "fused-qkv-absolute":
+    mapping = _family_mapping(desc.model) or {}
+    if all(u in mapping for u in REQUIRED_UNITS["K/V attention-detail collection"]):
         points.append(
             CapturePoint(
-                "K/V detail (gated module)",
+                "K/V detail",
                 "(head_)query/key/value_output",
                 "pyvene-named",
-                "pre-softmax scores are derived arithmetic on the captured "
-                "q/k (no module boundary exists for scores; none is needed)",
+                "captured at the projection output (pre-rotation on rotary "
+                "families); pre-softmax scores are derived arithmetic on the "
+                "captured q/k (no module boundary exists for scores; none is "
+                "needed), with rotation, scaling, softcapping and windowing "
+                "applied via the model's own modules/attributes",
+            )
+        )
+        points.append(
+            CapturePoint(
+                "K/V recompute (patched k/v from a residual delta)",
+                "attention pre-norm + q/k/v projections invoked on cached tensors",
+                "direct-module-call",
             )
         )
     return points

--- a/causalab/methods/path_patching/reference.py
+++ b/causalab/methods/path_patching/reference.py
@@ -334,8 +334,10 @@ def reference_patched_logits(
             else:
                 indices.append([[p] for p in pos_padded])
         location_map = {"sources->base": (indices, indices)}
+        # pyvene returns (base_outputs, intervened_outputs) here; the
+        # patched run is the second element.
         result = iv_model(loaded, unit_locations=location_map)
-        output = result[0][0]
+        output = result[1]
         logits = output.logits.float()
         idx = torch.tensor(pos_padded, device=logits.device)
         out = logits[torch.arange(batch, device=logits.device), idx]

--- a/causalab/methods/path_patching/reference.py
+++ b/causalab/methods/path_patching/reference.py
@@ -112,10 +112,9 @@ class _TrunkOutputAdjust(pv.ConstantSourceIntervention):
         assert self.store is not None
         if self.record_key is not None:
             assert self.reference is not None
-            self.store[self.record_key] = (
-                base.float()
-                - self.reference.to(base.device).float().reshape(base.shape)
-            )
+            self.store[self.record_key] = base.float() - self.reference.to(
+                base.device
+            ).float().reshape(base.shape)
         out = base
         for t in self.compensation_static:
             out = out + t.to(base.dtype).to(base.device).reshape(base.shape)
@@ -138,11 +137,9 @@ def _downstream_components(
     if kind == "embed":
         return list(range(desc.n_layers)), list(range(desc.n_layers))
     layer = sender[1]
-    attn_layers = [l for l in range(desc.n_layers) if l > layer]
+    attn_layers = [li for li in range(desc.n_layers) if li > layer]
     if kind == "head":
-        mlp_layers = [
-            m for m in range(desc.n_layers) if desc.head_feeds_mlp(layer, m)
-        ]
+        mlp_layers = [m for m in range(desc.n_layers) if desc.head_feeds_mlp(layer, m)]
     else:  # mlp / neuron / neuron_group
         mlp_layers = [m for m in range(desc.n_layers) if m > layer]
     return attn_layers, mlp_layers
@@ -173,9 +170,7 @@ def reference_patched_logits(
         engine = PatchEngine(
             desc, cache_clean, cache_cf, position=position, run_guards=False
         )
-    inputs_clean = [
-        {"raw_input": x} if isinstance(x, str) else x for x in inputs_clean
-    ]
+    inputs_clean = [{"raw_input": x} if isinstance(x, str) else x for x in inputs_clean]
     loaded = pipeline.load(list(inputs_clean))
     mask = loaded["attention_mask"]
     pos_padded = padded_position(mask, position_index)
@@ -244,13 +239,13 @@ def reference_patched_logits(
 
     # ---- 2. freeze downstream components at clean values ----
     attn_layers, mlp_layers = _downstream_components(desc, sender)
-    for l in attn_layers:
-        z_clean = cache_clean.z[position][:, l].reshape(batch, -1)
+    for li in attn_layers:
+        z_clean = cache_clean.z[position][:, li].reshape(batch, -1)
 
         def setup_freeze_attn(iv, val=z_clean):
             iv.payload = val
 
-        add("attention_value_output", l, "pos", _ValueSetter, setup_freeze_attn)
+        add("attention_value_output", li, "pos", _ValueSetter, setup_freeze_attn)
     for m in mlp_layers:
         if m in receivers:
             continue
@@ -282,8 +277,7 @@ def reference_patched_logits(
                 live_keys.append(f"recv{j}")
         # does anything downstream need this receiver's live output delta?
         needs_record = k not in spec.receivers_to_logits or any(
-            kk > k and (k, kk) not in spec.receiver_to_receiver
-            for kk in spec.receivers
+            kk > k and (k, kk) not in spec.receiver_to_receiver for kk in spec.receivers
         )
 
         if static_terms or live_keys:

--- a/causalab/methods/path_patching/reference.py
+++ b/causalab/methods/path_patching/reference.py
@@ -13,6 +13,14 @@ the receiving module's input:
   upstream receiver's *live* output delta, recorded earlier in the same
   forward pass (upstream modules run first, so the value is available).
 
+One pyvene mechanic matters here: setter interventions scatter IN PLACE, and
+a pre-norm's input tensor is the residual-stream tensor itself, so a
+subtraction at a receiver's pre-norm input would otherwise leak into the
+trunk permanently. Every such subtraction is therefore paired with a
+trunk-output adjustment on the same receiver that adds the subtracted terms
+back after the MLP has consumed the cancelled input (see
+:class:`_TrunkOutputAdjust`).
+
 Everything runs through pyvene: static substitutions, freezes, delta
 subtraction, and live recording are all constant-source interventions
 attached via pyvene's component mappings (dotted-path fallback for norm
@@ -78,21 +86,43 @@ class _DeltaSubtract(pv.ConstantSourceIntervention):
         return out
 
 
-class _LiveDeltaRecorder(pv.ConstantSourceIntervention):
-    """Record (live - reference) for the gathered slice; pass through."""
+class _TrunkOutputAdjust(pv.ConstantSourceIntervention):
+    """Per-receiver trunk-output intervention: record and/or compensate.
+
+    pyvene setter hooks scatter IN PLACE into the hooked tensor, and the
+    pre-MLP norm's input tensor *is* the residual-stream tensor in every
+    supported block — so a delta subtracted at a receiver's pre-norm input
+    also vanishes from the trunk from that point on. This intervention,
+    placed on the same receiver's trunk-output component (which the block
+    adds to the residual AFTER the MLP ran on the cancelled input), adds the
+    subtracted terms back, restoring the trunk exactly. It also records the
+    receiver's live output delta (live - clean reference) for downstream
+    excluded-edge cancellation.
+    """
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.reference: Tensor | None = None
-        self.key: str = ""
+        self.reference: Tensor | None = None  # clean trunk contribution
+        self.record_key: str | None = None
+        self.compensation_static: list[Tensor] = []
+        self.compensation_live: list[str] = []
         self.store: dict[str, Tensor] | None = None
 
     def forward(self, base, source=None, subspaces=None, **kwargs):
-        assert self.reference is not None and self.store is not None
-        self.store[self.key] = (
-            base.float() - self.reference.to(base.device).float().reshape(base.shape)
-        )
-        return base
+        assert self.store is not None
+        if self.record_key is not None:
+            assert self.reference is not None
+            self.store[self.record_key] = (
+                base.float()
+                - self.reference.to(base.device).float().reshape(base.shape)
+            )
+        out = base
+        for t in self.compensation_static:
+            out = out + t.to(base.dtype).to(base.device).reshape(base.shape)
+        for k in self.compensation_live:
+            assert k in self.store, f"live delta {k!r} not recorded before use"
+            out = out + self.store[k].to(base.dtype).to(base.device).reshape(base.shape)
+        return out
 
 
 def _downstream_components(
@@ -231,36 +261,9 @@ def reference_patched_logits(
 
         add("mlp_output", m, "pos", _ValueSetter, setup_freeze_mlp)
 
-    # ---- 3. live recorders on receivers whose outgoing edges are cut ----
-    for j in spec.receivers:
-        cut_r2r = any(
-            (j, k) not in spec.receiver_to_receiver
-            for k in spec.receivers
-            if k > j
-        )
-        cut_logits = j not in spec.receivers_to_logits
-        if not (cut_r2r or cut_logits):
-            continue
-        ref = engine.mlp_trunk_contribution(cache_clean, j).cpu()
-
-        def setup_rec(iv, ref=ref, key=f"recv{j}"):
-            iv.reference = ref
-            iv.key = key
-            iv.store = store
-
-        add(
-            desc.component_mlp_trunk_output(j),
-            j,
-            "pos",
-            _LiveDeltaRecorder,
-            setup_rec,
-        )
-
-    # ---- 4. cancellation subtractors ----
+    # ---- 3+4. per-receiver cancellation + trunk restoration + recording ----
     sender_trunk_delta = engine.trunk_delta(sender).cpu()  # (N, d)
 
-    # at each receiver k: subtract the sender's delta if S->k is excluded but
-    # the sender is upstream of k; subtract live deltas of excluded (j, k)
     def sender_upstream_of_mlp(k: int) -> bool:
         if kind == "embed":
             return True
@@ -269,6 +272,7 @@ def reference_patched_logits(
         return sender[1] < k
 
     for k in spec.receivers:
+        # terms this receiver's pre-norm input must NOT see
         static_terms: list[Tensor] = []
         live_keys: list[str] = []
         if k not in spec.sender_to and sender_upstream_of_mlp(k):
@@ -276,21 +280,57 @@ def reference_patched_logits(
         for j in spec.receivers:
             if j < k and (j, k) not in spec.receiver_to_receiver:
                 live_keys.append(f"recv{j}")
-        if not static_terms and not live_keys:
-            continue
-
-        def setup_sub(iv, st=static_terms, lk=live_keys):
-            iv.static_terms = st
-            iv.live_keys = lk
-            iv.store = store
-
-        add(
-            desc.component_mlp_pre_norm_input(k),
-            k,
-            "pos",
-            _DeltaSubtract,
-            setup_sub,
+        # does anything downstream need this receiver's live output delta?
+        needs_record = k not in spec.receivers_to_logits or any(
+            kk > k and (k, kk) not in spec.receiver_to_receiver
+            for kk in spec.receivers
         )
+
+        if static_terms or live_keys:
+            # pyvene scatters IN PLACE and the pre-norm's input tensor IS the
+            # residual stream, so this subtraction also leaks into the trunk;
+            # the matching _TrunkOutputAdjust below adds it back after the
+            # MLP has consumed the cancelled input.
+            def setup_sub(iv, st=static_terms, lk=live_keys):
+                iv.static_terms = st
+                iv.live_keys = lk
+                iv.store = store
+
+            add(
+                desc.component_mlp_pre_norm_input(k),
+                k,
+                "pos",
+                _DeltaSubtract,
+                setup_sub,
+            )
+
+        if static_terms or live_keys or needs_record:
+            ref = (
+                engine.mlp_trunk_contribution(cache_clean, k).cpu()
+                if needs_record
+                else None
+            )
+
+            def setup_adj(
+                iv,
+                ref=ref,
+                key=f"recv{k}" if needs_record else None,
+                st=list(static_terms),
+                lk=list(live_keys),
+            ):
+                iv.reference = ref
+                iv.record_key = key
+                iv.compensation_static = st
+                iv.compensation_live = lk
+                iv.store = store
+
+            add(
+                desc.component_mlp_trunk_output(k),
+                k,
+                "pos",
+                _TrunkOutputAdjust,
+                setup_adj,
+            )
 
     # at the final norm input: cancel the sender's direct edge and any
     # receiver->logits edge the spec excludes

--- a/causalab/methods/path_patching/reference.py
+++ b/causalab/methods/path_patching/reference.py
@@ -1,0 +1,345 @@
+"""pyvene replace-intervention reference patcher (validation twin).
+
+Implements the freeze recipe with *live intervened forward passes*:
+run on the clean inputs; replace the sender's raw activation at the patched
+position with its counterfactual cached value; freeze every component
+strictly downstream of the sender at its clean cached value, except the
+receiver MLPs (and the final norm + LM head), which recompute. Edges the
+path spec excludes are cancelled by subtracting the corresponding delta at
+the receiving module's input:
+
+* an excluded sender edge subtracts the sender's (cached) trunk delta;
+* an excluded receiver->receiver or receiver->logits edge subtracts the
+  upstream receiver's *live* output delta, recorded earlier in the same
+  forward pass (upstream modules run first, so the value is available).
+
+Everything runs through pyvene: static substitutions, freezes, delta
+subtraction, and live recording are all constant-source interventions
+attached via pyvene's component mappings (dotted-path fallback for norm
+inputs/outputs). No raw torch hooks.
+
+Deliberately independent of the analytic engine — real forwards with module
+substitution vs delta arithmetic on caches — so their agreement is
+informative. Slow; validation only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import pyvene as pv
+import torch
+from torch import Tensor
+
+from .cache import PatchCache, padded_position
+from .descriptor import ArchitectureDescriptor
+from .edges import PathSpec
+from .engine import PatchEngine, Sender
+
+__all__ = ["reference_patched_logits"]
+
+
+class _ValueSetter(pv.ConstantSourceIntervention):
+    """Set the gathered slice (optionally a channel subset) to a stored value."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.payload: Tensor | None = None
+        self.channels: list[int] | None = None
+
+    def forward(self, base, source=None, subspaces=None, **kwargs):
+        assert self.payload is not None, "payload unset"
+        val = self.payload.to(base.dtype).to(base.device)
+        if self.channels is None:
+            return val.reshape(base.shape)
+        out = base.clone()
+        out[..., self.channels] = val.reshape(out[..., self.channels].shape)
+        return out
+
+
+class _DeltaSubtract(pv.ConstantSourceIntervention):
+    """Subtract a sum of delta terms (static tensors or live-recorded keys)."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.static_terms: list[Tensor] = []
+        self.live_keys: list[str] = []
+        self.store: dict[str, Tensor] | None = None
+
+    def forward(self, base, source=None, subspaces=None, **kwargs):
+        out = base
+        for t in self.static_terms:
+            out = out - t.to(base.dtype).to(base.device).reshape(base.shape)
+        for k in self.live_keys:
+            assert self.store is not None and k in self.store, (
+                f"live delta {k!r} not recorded before use (module order bug)"
+            )
+            out = out - self.store[k].to(base.dtype).to(base.device).reshape(base.shape)
+        return out
+
+
+class _LiveDeltaRecorder(pv.ConstantSourceIntervention):
+    """Record (live - reference) for the gathered slice; pass through."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.reference: Tensor | None = None
+        self.key: str = ""
+        self.store: dict[str, Tensor] | None = None
+
+    def forward(self, base, source=None, subspaces=None, **kwargs):
+        assert self.reference is not None and self.store is not None
+        self.store[self.key] = (
+            base.float() - self.reference.to(base.device).float().reshape(base.shape)
+        )
+        return base
+
+
+def _downstream_components(
+    desc: ArchitectureDescriptor, sender: Sender
+) -> tuple[list[tuple[int]], list[int]]:
+    """(attention layers, MLP layers) strictly downstream of the sender."""
+    kind = sender[0]
+    if kind == "group":
+        raise NotImplementedError(
+            "the reference twin validates atomic senders; validate group "
+            "members individually"
+        )
+    if kind == "embed":
+        return list(range(desc.n_layers)), list(range(desc.n_layers))
+    layer = sender[1]
+    attn_layers = [l for l in range(desc.n_layers) if l > layer]
+    if kind == "head":
+        mlp_layers = [
+            m for m in range(desc.n_layers) if desc.head_feeds_mlp(layer, m)
+        ]
+    else:  # mlp / neuron / neuron_group
+        mlp_layers = [m for m in range(desc.n_layers) if m > layer]
+    return attn_layers, mlp_layers
+
+
+@torch.no_grad()
+def reference_patched_logits(
+    pipeline: Any,
+    desc: ArchitectureDescriptor,
+    inputs_clean: Sequence[Any],
+    cache_clean: PatchCache,
+    cache_cf: PatchCache,
+    sender: Sender,
+    spec: PathSpec,
+    *,
+    position: str = "end",
+    position_index: int | Sequence[int] = -1,
+    engine: PatchEngine | None = None,
+) -> Tensor:
+    """Patched final logits (N, vocab) via a live intervened forward.
+
+    ``position_index`` is the patched position in unpadded per-example
+    coordinates (matching what the caches were built at for ``position``).
+    ``engine`` (optional) supplies the sender's cached trunk delta for
+    excluded-sender-edge cancellation; one is built without guards if absent.
+    """
+    if engine is None:
+        engine = PatchEngine(
+            desc, cache_clean, cache_cf, position=position, run_guards=False
+        )
+    inputs_clean = [
+        {"raw_input": x} if isinstance(x, str) else x for x in inputs_clean
+    ]
+    loaded = pipeline.load(list(inputs_clean))
+    mask = loaded["attention_mask"]
+    pos_padded = padded_position(mask, position_index)
+    batch = mask.shape[0]
+
+    store: dict[str, Tensor] = {}
+    configs: list[dict[str, Any]] = []
+    setups: list[Any] = []  # callables run on the instantiated interventions
+
+    def add(component: str, layer: int, unit: str, cls: type, setup) -> None:
+        configs.append(
+            {
+                "component": component,
+                "unit": unit,
+                "layer": layer,
+                "intervention_type": cls,
+            }
+        )
+        setups.append(setup)
+
+    receivers = set(spec.receivers)
+    kind = sender[0]
+
+    # ---- 1. sender substitution (cf value at the position) ----
+    if kind == "head":
+        _, s_layer, s_head = sender
+        z_cf = cache_cf.z[position][:, s_layer, s_head]  # (N, dh)
+
+        def setup_sender(iv, val=z_cf):
+            iv.payload = val
+
+        add("head_attention_value_output", s_layer, "h.pos", _ValueSetter, setup_sender)
+    elif kind == "mlp":
+        _, s_layer = sender
+        val = cache_cf.mlp_branch[position][:, s_layer]
+
+        def setup_sender(iv, val=val):
+            iv.payload = val
+
+        add("mlp_output", s_layer, "pos", _ValueSetter, setup_sender)
+    elif kind in ("neuron", "neuron_group"):
+        _, s_layer, idx = sender
+        channels = [idx] if kind == "neuron" else list(idx)
+        val = cache_cf.neuron_acts[position][:, s_layer][:, channels]
+
+        def setup_sender(iv, val=val, ch=channels):
+            iv.payload = val
+            iv.channels = ch
+
+        add(
+            desc.component_neuron_values(s_layer),
+            s_layer,
+            "pos",
+            _ValueSetter,
+            setup_sender,
+        )
+    elif kind == "embed":
+        val = cache_cf.embed[position]
+
+        def setup_sender(iv, val=val):
+            iv.payload = val
+
+        add("block_input", 0, "pos", _ValueSetter, setup_sender)
+    else:
+        raise NotImplementedError(f"reference twin: unsupported sender {sender!r}")
+
+    # ---- 2. freeze downstream components at clean values ----
+    attn_layers, mlp_layers = _downstream_components(desc, sender)
+    for l in attn_layers:
+        z_clean = cache_clean.z[position][:, l].reshape(batch, -1)
+
+        def setup_freeze_attn(iv, val=z_clean):
+            iv.payload = val
+
+        add("attention_value_output", l, "pos", _ValueSetter, setup_freeze_attn)
+    for m in mlp_layers:
+        if m in receivers:
+            continue
+        val = cache_clean.mlp_branch[position][:, m]
+
+        def setup_freeze_mlp(iv, val=val):
+            iv.payload = val
+
+        add("mlp_output", m, "pos", _ValueSetter, setup_freeze_mlp)
+
+    # ---- 3. live recorders on receivers whose outgoing edges are cut ----
+    for j in spec.receivers:
+        cut_r2r = any(
+            (j, k) not in spec.receiver_to_receiver
+            for k in spec.receivers
+            if k > j
+        )
+        cut_logits = j not in spec.receivers_to_logits
+        if not (cut_r2r or cut_logits):
+            continue
+        ref = engine.mlp_trunk_contribution(cache_clean, j).cpu()
+
+        def setup_rec(iv, ref=ref, key=f"recv{j}"):
+            iv.reference = ref
+            iv.key = key
+            iv.store = store
+
+        add(
+            desc.component_mlp_trunk_output(j),
+            j,
+            "pos",
+            _LiveDeltaRecorder,
+            setup_rec,
+        )
+
+    # ---- 4. cancellation subtractors ----
+    sender_trunk_delta = engine.trunk_delta(sender).cpu()  # (N, d)
+
+    # at each receiver k: subtract the sender's delta if S->k is excluded but
+    # the sender is upstream of k; subtract live deltas of excluded (j, k)
+    def sender_upstream_of_mlp(k: int) -> bool:
+        if kind == "embed":
+            return True
+        if kind == "head":
+            return desc.head_feeds_mlp(sender[1], k)
+        return sender[1] < k
+
+    for k in spec.receivers:
+        static_terms: list[Tensor] = []
+        live_keys: list[str] = []
+        if k not in spec.sender_to and sender_upstream_of_mlp(k):
+            static_terms.append(sender_trunk_delta)
+        for j in spec.receivers:
+            if j < k and (j, k) not in spec.receiver_to_receiver:
+                live_keys.append(f"recv{j}")
+        if not static_terms and not live_keys:
+            continue
+
+        def setup_sub(iv, st=static_terms, lk=live_keys):
+            iv.static_terms = st
+            iv.live_keys = lk
+            iv.store = store
+
+        add(
+            desc.component_mlp_pre_norm_input(k),
+            k,
+            "pos",
+            _DeltaSubtract,
+            setup_sub,
+        )
+
+    # at the final norm input: cancel the sender's direct edge and any
+    # receiver->logits edge the spec excludes
+    static_terms = [] if spec.sender_to_logits else [sender_trunk_delta]
+    live_keys = [
+        f"recv{j}" for j in spec.receivers if j not in spec.receivers_to_logits
+    ]
+    if static_terms or live_keys:
+
+        def setup_final(iv, st=static_terms, lk=live_keys):
+            iv.static_terms = st
+            iv.live_keys = lk
+            iv.store = store
+
+        add(
+            desc.component_final_norm_input(),
+            desc.n_layers - 1,
+            "pos",
+            _DeltaSubtract,
+            setup_final,
+        )
+
+    # ---- build the intervenable model, wire payloads, run ----
+    iv_config = pv.IntervenableConfig(configs)
+    iv_model = pv.IntervenableModel(iv_config, model=pipeline.model)
+    iv_model.disable_model_gradients()
+    try:
+        keys_in_order = list(iv_model.interventions.keys())
+        assert len(keys_in_order) == len(setups)
+        for key, setup in zip(keys_in_order, setups):
+            iv = iv_model.interventions[key]
+            iv = iv[0] if isinstance(iv, tuple) else iv
+            setup(iv)
+
+        # unit locations: heads use [head, pos] pairs, others positions only
+        indices: list[Any] = []
+        for cfg in configs:
+            if cfg["unit"] == "h.pos":
+                head = sender[2]
+                indices.append([[[head]] * batch, [[p] for p in pos_padded]])
+            else:
+                indices.append([[p] for p in pos_padded])
+        location_map = {"sources->base": (indices, indices)}
+        result = iv_model(loaded, unit_locations=location_map)
+        output = result[0][0]
+        logits = output.logits.float()
+        idx = torch.tensor(pos_padded, device=logits.device)
+        out = logits[torch.arange(batch, device=logits.device), idx]
+        return out.cpu()
+    finally:
+        store.clear()
+        del iv_model

--- a/causalab/methods/path_patching/reference.py
+++ b/causalab/methods/path_patching/reference.py
@@ -138,7 +138,10 @@ def _downstream_components(
         return list(range(desc.n_layers)), list(range(desc.n_layers))
     layer = sender[1]
     attn_layers = [li for li in range(desc.n_layers) if li > layer]
-    if kind == "head":
+    if kind in ("head", "kv"):
+        # a K/V patch surfaces as the owning layer's (group) z, so its
+        # downstream footprint is a head's: same-layer MLP included on
+        # sequential trunks
         mlp_layers = [m for m in range(desc.n_layers) if desc.head_feeds_mlp(layer, m)]
     else:  # mlp / neuron / neuron_group
         mlp_layers = [m for m in range(desc.n_layers) if m > layer]
@@ -158,6 +161,7 @@ def reference_patched_logits(
     position: str = "end",
     position_index: int | Sequence[int] = -1,
     engine: PatchEngine | None = None,
+    sender_trunk_delta: Tensor | None = None,
 ) -> Tensor:
     """Patched final logits (N, vocab) via a live intervened forward.
 
@@ -165,6 +169,26 @@ def reference_patched_logits(
     coordinates (matching what the caches were built at for ``position``).
     ``engine`` (optional) supplies the sender's cached trunk delta for
     excluded-sender-edge cancellation; one is built without guards if absent.
+
+    K/V sender (the twin side of :class:`~.kv.KVPatchEngine`)::
+
+        ("kv", layer, kv_index, {
+            "k": (N, dh) pre-rotation replacement keys at the patched
+                 position, or None to leave keys alone,
+            "v": (N, dh) replacement values, or None,
+            "position_index": the patched K/V position, unpadded
+                 per-example coordinates (int or per-example sequence),
+        })
+
+    pyvene replaces the named KV head's k/v at that position via its
+    ``head_key_output`` / ``head_value_output`` units (pre-rotation hooks:
+    the model applies its own rotation to the replaced key downstream), the
+    model's own attention recomputes the layer's z everywhere — scoring,
+    softmax, softcapping, sliding windows, and GQA fan-out all come from the
+    model — and the freeze recipe isolates the (kv -> layer-z -> spec) path.
+    For a "kv" sender with excluded edges, pass ``sender_trunk_delta`` (the
+    analytic K/V trunk delta) since the engine cannot derive it from a
+    sender tuple.
     """
     if engine is None:
         engine = PatchEngine(
@@ -179,8 +203,18 @@ def reference_patched_logits(
     store: dict[str, Tensor] = {}
     configs: list[dict[str, Any]] = []
     setups: list[Any] = []  # callables run on the instantiated interventions
+    locs: list[dict[str, Any] | None] = []  # per-config unit-location override
 
-    def add(component: str, layer: int, unit: str, cls: type, setup) -> None:
+    def add(
+        component: str,
+        layer: int,
+        unit: str,
+        cls: type,
+        setup,
+        *,
+        head: int | None = None,
+        positions: list[int] | None = None,
+    ) -> None:
         configs.append(
             {
                 "component": component,
@@ -190,12 +224,37 @@ def reference_patched_logits(
             }
         )
         setups.append(setup)
+        locs.append(
+            None
+            if head is None and positions is None
+            else {"head": head, "positions": positions}
+        )
 
     receivers = set(spec.receivers)
     kind = sender[0]
 
     # ---- 1. sender substitution (cf value at the position) ----
-    if kind == "head":
+    if kind == "kv":
+        _, s_layer, s_kv, kv_payload = sender
+        kv_pos_padded = padded_position(mask, kv_payload["position_index"])
+        for quantity, comp in (("k", "head_key_output"), ("v", "head_value_output")):
+            val = kv_payload.get(quantity)
+            if val is None:
+                continue
+
+            def setup_kv(iv, val=val):
+                iv.payload = val
+
+            add(
+                comp,
+                s_layer,
+                "h.pos",
+                _ValueSetter,
+                setup_kv,
+                head=s_kv,
+                positions=kv_pos_padded,
+            )
+    elif kind == "head":
         _, s_layer, s_head = sender
         z_cf = cache_cf.z[position][:, s_layer, s_head]  # (N, dh)
 
@@ -257,12 +316,28 @@ def reference_patched_logits(
         add("mlp_output", m, "pos", _ValueSetter, setup_freeze_mlp)
 
     # ---- 3+4. per-receiver cancellation + trunk restoration + recording ----
-    sender_trunk_delta = engine.trunk_delta(sender).cpu()  # (N, d)
+    if sender_trunk_delta is not None:
+        sender_trunk_delta = sender_trunk_delta.cpu()
+    elif kind == "kv":
+        # only needed when the spec excludes edges; the analytic K/V trunk
+        # delta must then be supplied by the caller
+        needs_delta = (not spec.sender_to_logits) or any(
+            k not in spec.sender_to and desc.head_feeds_mlp(sender[1], k)
+            for k in spec.receivers
+        )
+        if needs_delta:
+            raise ValueError(
+                "a 'kv' sender with excluded edges needs sender_trunk_delta "
+                "(use KVPatchEngine.kv_trunk_delta)"
+            )
+        sender_trunk_delta = torch.zeros(batch, desc.d_model)
+    else:
+        sender_trunk_delta = engine.trunk_delta(sender).cpu()  # (N, d)
 
     def sender_upstream_of_mlp(k: int) -> bool:
         if kind == "embed":
             return True
-        if kind == "head":
+        if kind in ("head", "kv"):
             return desc.head_feeds_mlp(sender[1], k)
         return sender[1] < k
 
@@ -359,14 +434,22 @@ def reference_patched_logits(
             iv = iv[0] if isinstance(iv, tuple) else iv
             setup(iv)
 
-        # unit locations: heads use [head, pos] pairs, others positions only
+        # unit locations: heads use [head, pos] pairs, others positions only;
+        # a per-config override (K/V senders) names its own head index and
+        # patched position, everything else acts at the receiver position
         indices: list[Any] = []
-        for cfg in configs:
+        for cfg, loc in zip(configs, locs):
             if cfg["unit"] == "h.pos":
-                head = sender[2]
-                indices.append([[[head]] * batch, [[p] for p in pos_padded]])
+                head = sender[2] if loc is None else loc["head"]
+                positions = (
+                    pos_padded if loc is None else (loc["positions"] or pos_padded)
+                )
+                indices.append([[[head]] * batch, [[p] for p in positions]])
             else:
-                indices.append([[p] for p in pos_padded])
+                positions = (
+                    pos_padded if loc is None else (loc["positions"] or pos_padded)
+                )
+                indices.append([[p] for p in positions])
         location_map = {"sources->base": (indices, indices)}
         # pyvene returns (base_outputs, intervened_outputs) here; the
         # patched run is the second element.

--- a/causalab/neural/activations/collect.py
+++ b/causalab/neural/activations/collect.py
@@ -22,6 +22,7 @@ from causalab.causal.counterfactual_dataset import (
 )
 from pyvene import IntervenableModel  # type: ignore[reportMissingTypeStubs]
 
+from causalab.neural.padding import shift_unit_indices_for_padding
 from causalab.neural.activations.intervenable_model import (
     prepare_intervenable_model,
     delete_intervenable_model,
@@ -138,6 +139,15 @@ def collect_features(
 
         # Load inputs through pipeline
         loaded_inputs = pipeline.load(batched_inputs)
+
+        # Indexers work in unpadded per-example coordinates; convert to the
+        # padded batch coordinates this batch was actually loaded with.
+        indices = [
+            shift_unit_indices_for_padding(
+                model_unit, unit_indices, loaded_inputs["attention_mask"]
+            )
+            for model_unit, unit_indices in zip(model_units, indices)
+        ]
 
         # Use shared helper to collect activations
         result = _collect_activations_single_batch(

--- a/causalab/neural/activations/interchange_mode.py
+++ b/causalab/neural/activations/interchange_mode.py
@@ -23,6 +23,7 @@ from causalab.causal.counterfactual_dataset import (
     CounterfactualExample,
     LabeledCounterfactualExample,
 )
+from causalab.neural.padding import shift_unit_indices_for_padding
 from causalab.neural.pipeline import Pipeline
 from causalab.neural.units import InterchangeTarget
 from causalab.neural.activations.intervenable_model import (
@@ -103,6 +104,28 @@ def prepare_intervenable_inputs(
     batched_counterfactuals = [
         pipeline.load(batched_counterfactual)
         for batched_counterfactual in batched_counterfactuals
+    ]
+
+    # Indexers work in unpadded per-example coordinates; convert to the
+    # padded batch coordinates each batch was actually loaded with. Base and
+    # counterfactual batches pad independently, so each gets its own shift.
+    flat_units = [model_unit for group in interchange_target for model_unit in group]
+    base_indices = [
+        shift_unit_indices_for_padding(
+            model_unit, unit_indices, batched_base["attention_mask"]
+        )
+        for model_unit, unit_indices in zip(flat_units, base_indices)
+    ]
+    cf_masks = [
+        loaded_cf["attention_mask"]
+        for group, loaded_cf in zip(interchange_target, batched_counterfactuals)
+        for _model_unit in group
+    ]
+    counterfactual_indices = [
+        shift_unit_indices_for_padding(model_unit, unit_indices, cf_mask)
+        for model_unit, unit_indices, cf_mask in zip(
+            flat_units, counterfactual_indices, cf_masks
+        )
     ]
 
     inv_locations = {"sources->base": (counterfactual_indices, base_indices)}

--- a/causalab/neural/padding.py
+++ b/causalab/neural/padding.py
@@ -30,7 +30,7 @@ def _per_example_shifts(attention_mask: Tensor) -> list[int]:
     total = mask.shape[1]
     true_len = mask.sum(dim=1)
     first_real = mask.argmax(dim=1)  # (total - true_len) under left padding, 0 under right
-    # first_real is where unpadded index 0 landed; that IS the shift.
+    # first_real is where unpadded index 0 was placed; that IS the shift.
     del total, true_len
     return [int(s) for s in first_real]
 

--- a/causalab/neural/padding.py
+++ b/causalab/neural/padding.py
@@ -29,7 +29,9 @@ def _per_example_shifts(attention_mask: Tensor) -> list[int]:
     mask = attention_mask.long()
     total = mask.shape[1]
     true_len = mask.sum(dim=1)
-    first_real = mask.argmax(dim=1)  # (total - true_len) under left padding, 0 under right
+    first_real = mask.argmax(
+        dim=1
+    )  # (total - true_len) under left padding, 0 under right
     # first_real is where unpadded index 0 was placed; that IS the shift.
     del total, true_len
     return [int(s) for s in first_real]

--- a/causalab/neural/padding.py
+++ b/causalab/neural/padding.py
@@ -87,12 +87,13 @@ def shift_unit_indices_for_padding(
     second element is one position list per example). Head indices are
     positionless and pass through untouched.
     """
-    unit_kind = getattr(unit, "unit", "pos")
+    unit_kind = getattr(unit, "unit", None)
     if unit_kind == "pos":
         return shift_indices_for_padding(indices, attention_mask)
     if unit_kind == "h.pos":
         heads, positions = indices
         return [heads, shift_indices_for_padding(positions, attention_mask)]
-    # Unknown unit layout (or a mock in tests): leave indices untouched —
-    # the pre-fix behavior — rather than guess at the structure.
+    # Unknown or missing unit layout (e.g. a mock in tests, or a custom unit
+    # class): leave indices untouched — the pre-fix behavior — rather than
+    # guess at the structure.
     return indices

--- a/causalab/neural/padding.py
+++ b/causalab/neural/padding.py
@@ -50,14 +50,27 @@ def shift_indices_for_padding(
         )
     out: list[list[int]] = []
     seq_len = attention_mask.shape[1]
-    for row, shift in zip(indices, shifts):
-        shifted = [p + shift for p in row]
-        for p in shifted:
+    true_lens = attention_mask.long().sum(dim=1).tolist()
+    for row, shift, true_len in zip(indices, shifts, true_lens):
+        # A negative index is end-relative in the example's TRUE (unpadded)
+        # sequence — the documented ``TokenPosition(lambda x: [-1], ...)``
+        # API — so it resolves against the real last token, not the padded
+        # tensor edge.
+        shifted = []
+        for orig in row:
+            q = orig if orig >= 0 else true_len + orig
+            if not 0 <= q < true_len:
+                raise IndexError(
+                    f"unpadded index {orig} is out of range for its example "
+                    f"(true length {true_len})"
+                )
+            p = q + shift
             if not 0 <= p < seq_len:
                 raise IndexError(
-                    f"shifted position {p} outside the padded sequence "
-                    f"(length {seq_len}); the unpadded index was out of range"
+                    f"unpadded index {orig} resolves to padded position {p}, "
+                    f"outside the padded sequence (length {seq_len})"
                 )
+            shifted.append(p)
         out.append(shifted)
     return out
 

--- a/causalab/neural/padding.py
+++ b/causalab/neural/padding.py
@@ -91,6 +91,6 @@ def shift_unit_indices_for_padding(
     if unit_kind == "h.pos":
         heads, positions = indices
         return [heads, shift_indices_for_padding(positions, attention_mask)]
-    raise NotImplementedError(
-        f"padding shift for unit layout {unit_kind!r} is not implemented"
-    )
+    # Unknown unit layout (or a mock in tests): leave indices untouched —
+    # the pre-fix behavior — rather than guess at the structure.
+    return indices

--- a/causalab/neural/padding.py
+++ b/causalab/neural/padding.py
@@ -1,0 +1,83 @@
+"""Padding-aware adjustment of per-example token indices.
+
+Token positions in causalab are computed per example on the *unpadded*
+tokenization (every indexer in ``token_positions.py`` tokenizes a single
+example, where padding is a no-op). Batched execution then pads to the
+batch's longest sequence — on the left by default — which shifts every real
+token of a shorter example right by ``(padded length - true length)``.
+Passing unpadded indices to a left-padded batch therefore intervenes on the
+wrong positions (or on padding) for every example shorter than the batch
+maximum.
+
+These helpers convert unpadded per-example indices to padded batch
+coordinates using the attention mask. They are applied at the single point
+where indices meet a padded batch (``collect.py`` /
+``interchange_mode.py``), so indexers stay pad-agnostic. Right padding needs
+no shift; the mask-based computation handles both sides.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from torch import Tensor
+
+__all__ = ["shift_indices_for_padding", "shift_unit_indices_for_padding"]
+
+
+def _per_example_shifts(attention_mask: Tensor) -> list[int]:
+    mask = attention_mask.long()
+    total = mask.shape[1]
+    true_len = mask.sum(dim=1)
+    first_real = mask.argmax(dim=1)  # (total - true_len) under left padding, 0 under right
+    # first_real is where unpadded index 0 landed; that IS the shift.
+    del total, true_len
+    return [int(s) for s in first_real]
+
+
+def shift_indices_for_padding(
+    indices: list[list[int]], attention_mask: Tensor
+) -> list[list[int]]:
+    """Shift per-example position lists into padded batch coordinates.
+
+    ``indices`` has one list of token positions per example (the ``"pos"``
+    unit layout). Positions are unpadded per-example coordinates.
+    """
+    shifts = _per_example_shifts(attention_mask)
+    if len(indices) != len(shifts):
+        raise ValueError(
+            f"{len(indices)} index lists for a batch of {len(shifts)} examples"
+        )
+    out: list[list[int]] = []
+    seq_len = attention_mask.shape[1]
+    for row, shift in zip(indices, shifts):
+        shifted = [p + shift for p in row]
+        for p in shifted:
+            if not 0 <= p < seq_len:
+                raise IndexError(
+                    f"shifted position {p} outside the padded sequence "
+                    f"(length {seq_len}); the unpadded index was out of range"
+                )
+        out.append(shifted)
+    return out
+
+
+def shift_unit_indices_for_padding(
+    unit: Any, indices: Any, attention_mask: Tensor
+) -> Any:
+    """Shift one model unit's batched indices into padded batch coordinates.
+
+    Understands the two index layouts units produce: ``"pos"`` (one position
+    list per example) and ``"h.pos"`` (a ``[heads, positions]`` pair whose
+    second element is one position list per example). Head indices are
+    positionless and pass through untouched.
+    """
+    unit_kind = getattr(unit, "unit", "pos")
+    if unit_kind == "pos":
+        return shift_indices_for_padding(indices, attention_mask)
+    if unit_kind == "h.pos":
+        heads, positions = indices
+        return [heads, shift_indices_for_padding(positions, attention_mask)]
+    raise NotImplementedError(
+        f"padding shift for unit layout {unit_kind!r} is not implemented"
+    )

--- a/causalab/neural/pipeline.py
+++ b/causalab/neural/pipeline.py
@@ -201,13 +201,21 @@ class LMPipeline(Pipeline):
             )
             if device_map is not None:
                 pretrained_kwargs["device_map"] = device_map
+            # Explicit attention backend, passed through to from_pretrained so
+            # transformers validates it. When set, it wins over the legacy
+            # eager_attn flag (which flips the config post-load instead).
+            attn_implementation = self._init_extra_kwargs.get("attn_implementation")
+            if attn_implementation is not None:
+                pretrained_kwargs["attn_implementation"] = attn_implementation
             if self.load_weights:
                 self.model = AutoModelForCausalLM.from_pretrained(  # type: ignore[call-arg]
                     self.model_or_name, **pretrained_kwargs
                 )
                 if device_map is None:
                     self.model = self.model.to(device=device)
-                if self._init_extra_kwargs.get("eager_attn", True):
+                if attn_implementation is None and self._init_extra_kwargs.get(
+                    "eager_attn", True
+                ):
                     if hasattr(self.model.config, "_attn_implementation"):
                         self.model.config._attn_implementation = "eager"
                 if hasattr(self.model.config, "use_cache"):

--- a/docs/path_patching.md
+++ b/docs/path_patching.md
@@ -145,20 +145,76 @@ changes the trunk downstream, not just what the norm sees. The twin pairs
 every pre-norm cancellation with a trunk-output restoration on the same
 receiver (`_TrunkOutputAdjust`) to keep the recipe exact.
 
-## K/V-side attention detail (gated)
+## K/V-side attention detail
 
-`build_attn_detail_cache` captures per-head q/k/v (pyvene
-`query/key/value_output`; scores are derived arithmetic on cached q/k — the
-score tensor is not a module boundary and never needs intervening on). It is
-**gated to GPT-2-style attention** (`fused-qkv-absolute`) and raises
-`NotImplementedError` on rotary/GQA models, with the agreed generalization
-direction documented in `kv.py`: rotate key deltas by the patched position's
-angle before re-scoring (pre-rotation keys via pyvene + rotation in engine
-arithmetic is pyvene-native); use KV heads, not query heads, as the edge unit
-under GQA; keep the K/V twin as pyvene replace interventions on
-`head_key_output`/`head_value_output`. K/V capture requires
-`attn_implementation="eager"` (the `LMPipeline` default) — fused kernels do
-not materialize what pyvene's attention units need.
+Edges that end at an attention head's **keys or values at one patched token
+position** (the App. 8 analyses of Hanna et al.: what feeds a head's k/v at
+an earlier prompt position). General across the same families as the engine, under the same
+support policy: available iff pyvene's mapping has `query/key/value_output`
+(collection) and `head_key_output`/`head_value_output` (twin) for the family.
+gpt_neox has none of them (its fused QKV projection interleaves q/k/v per
+head, and pyvene's mapping comments the units out), so Pythia-style models
+raise `UnsupportedArchitectureError` at construction — no hook fallback.
+
+```python
+from causalab.methods.path_patching import (
+    KVEdge, KVHead, KVPatchEngine, build_attn_detail_cache,
+)
+
+# "src": the patched upstream position (say, the prompt's subject token)
+positions = {"end": -1, "src": -5}
+clean = build_patch_cache(pipeline, desc, clean_texts, positions)
+cf = build_patch_cache(pipeline, desc, cf_texts, positions)
+engine_end = PatchEngine(desc, clean, cf, position="end")
+engine_src = PatchEngine(desc, clean, cf, position="src", run_guards=False)
+det_clean = build_attn_detail_cache(pipeline, desc, clean_texts, positions)
+det_cf = build_attn_detail_cache(pipeline, desc, cf_texts, positions)
+kv = KVPatchEngine(engine_end, engine_src, det_clean, det_cf,
+                   position_patch="src")   # runs guard K1
+
+# sender m0's delta at src entering a7.h10's values, then on to the logits:
+delta_src = engine_src.trunk_delta(("mlp", 0))
+edges = [KVEdge(KVHead.for_query_head(desc, 7, 10), patch_v=True)]
+logits = engine_end.patched_logits(kv.kv_trunk_delta(edges, delta_src),
+                                   PathSpec.cascade())
+```
+
+Design points, each enforced or verified at construction:
+
+* **Pre-rotation capture, model-applied rotation.** pyvene's
+  `key_output`/`value_output` hook the projection outputs; on rotary
+  families that is before RoPE, so cached keys are position-disentangled.
+  Score reconstruction applies the model's own rotary module at the actual
+  position ids; rotation is linear, so rotating a patched key equals
+  rotating the key delta. `rotate_key_delta=False` exists purely as a
+  negative control (it must disagree with the twin on rotary families).
+* **KV heads are the edge unit.** `KVHead(layer, kv_index)` is what is
+  causally separable in the weights; z-deltas fan out across the query-head
+  group (`desc.query_heads_of_kv`). Standard MHA is group size 1.
+  Per-query-head value paths do not exist in the weights; a
+  TransformerLens-style expansion would be pure cache arithmetic on top and
+  is deliberately not a default.
+* **Eager contract.** Construction refuses non-eager loads by name
+  (`LMPipeline(..., attn_implementation="eager")` /
+  `attn_implementation: eager` in the model YAML). No silent re-loading.
+* **Sliding windows** (Gemma-2): an edge whose patched position the end
+  position cannot attend to within the layer's window raises
+  `SlidingWindowError` naming the layer and window.
+* **Guard K1**: reconstructed per-head z at the end position must match the
+  cached `attention_value_output` on both caches — rotation, GQA fan-in,
+  scaling, softcapping, masks and softmax verified in one check (tight in
+  float32; bf16 floor recorded, as with G4).
+* **Twin.** `reference_patched_logits` accepts a
+  `("kv", layer, kv_index, payload)` sender: pyvene replaces the KV head's
+  pre-rotation k/v at the patched position and the model's own attention
+  recomputes — scoring, softmax, softcapping, windows, GQA fan-out all come
+  from the model. The twin validates atomic K/V edges; multi-edge
+  composition is anchored against the GPT-2 numbers of a hook-based
+  replication of Hanna et al. (2023).
+
+Granularity ceiling unchanged: edges are atomic (no treeified patching), and
+the score tensor is never a module boundary — analytic K/V patching
+recomputes scores from cached q/k.
 
 ## Worked example: an iterative path-patching sweep
 

--- a/docs/path_patching.md
+++ b/docs/path_patching.md
@@ -216,6 +216,20 @@ Granularity ceiling unchanged: edges are atomic (no treeified patching), and
 the score tensor is never a module boundary — analytic K/V patching
 recomputes scores from cached q/k.
 
+**Anchor.** During development the K/V machinery was anchored against a
+hook-based replication of Hanna et al. (2023): it reproduces the paper's
+appendix analyses (Figs 11–13 and the full-circuit evaluation) at float
+precision (all 243 Fig 12–13 sweep cells ≤4.2e-7 and the 97 Fig 11 cells
+≤1.6e-6; full-circuit probability difference to 1.2e-7) when composed with
+that analysis's conventions — head
+z-deltas routed into MLPs 8–9 only while the MLP cascade runs over 8–11, the
+full-circuit K/V restoration built from summed cached component deltas, and
+base-side statistics with unrestored queries. Those are analysis-level
+composition choices, not engine semantics: they live in the anchoring
+analysis's driver, and every one of them is expressible through the public
+primitives above (`kv_trunk_delta` with `base_cache`, `trunk_delta` over a
+component group, receiver routing in the caller).
+
 ## Worked example: an iterative path-patching sweep
 
 With any set of clean/counterfactual prompt pairs (templated prompts that

--- a/docs/path_patching.md
+++ b/docs/path_patching.md
@@ -1,0 +1,182 @@
+# Path patching
+
+`causalab.methods.path_patching` computes **edge-level** patched logits in the
+freeze-recipe semantics of Hanna et al. (2023, "How does GPT-2 compute
+greater-than?"): replace a sender component's contribution along a named set
+of paths, with every off-path component frozen at its clean value. Instead of
+one intervened forward pass per patch, the engine reduces the recipe to
+*delta arithmetic on cached activations* plus direct re-evaluation of the
+receiver MLP branches and the model's own final norm + LM head — exact, and
+hundreds of times cheaper for sweeps.
+
+The reduction is exact only for **pre-LN additive-trunk decoders**, and
+nothing is assumed: every engine verifies its own architecture facts
+empirically at construction (see *Guards*).
+
+## Quick start
+
+```python
+from causalab.methods.path_patching import (
+    PatchEngine, PathSpec, build_patch_cache, resolve_descriptor
+)
+from causalab.neural.pipeline import LMPipeline
+
+pipeline = LMPipeline("gpt2", max_new_tokens=1, dtype=torch.float32,
+                      position_ids=True)
+desc = resolve_descriptor(pipeline.model)
+
+clean = build_patch_cache(pipeline, desc, clean_texts, {"end": -1})
+cf = build_patch_cache(pipeline, desc, cf_texts, {"end": -1})
+engine = PatchEngine(desc, clean, cf)   # runs the construction guards
+
+# a9.h1's direct edge to the logits:
+logits = engine.patched_logits(("head", 9, 1), PathSpec.cascade())
+
+# a7.h10's paths through MLPs 8-11 (Fig 3C), direct edge off-path:
+logits = engine.patched_logits(
+    ("head", 7, 10), PathSpec.cascade([8, 9, 10, 11], direct_to_logits=False)
+)
+```
+
+`positions` are given in unpadded per-example coordinates (`-1` = last real
+token) and converted with the attention mask, so variable-length prompts
+under left padding are handled correctly. Load pipelines with
+`position_ids=True` for absolute-position models (GPT-2): HF does not adjust
+position ids for left padding on its own, so without it a shorter example in
+a padded batch runs at shifted positions.
+
+## Senders
+
+```
+("head", layer, head)         attention head (z @ W_O slice)
+("mlp", layer)                MLP block
+("neuron", layer, index)      one MLP output-projection input channel
+("neuron_group", layer, [i])  several channels of one MLP
+("embed",)                    the embedding contribution
+("group", [senders...])       union (e.g. a circuit complement)
+```
+
+On models with per-branch post-norms (Gemma-2), a branch's contribution to
+the trunk passes through its post-norm, which is nonlinear; sender deltas are
+computed as `post_norm(branch_clean + raw_delta) - post_norm(branch_clean)`
+— exactly what a live patched forward produces — and raw deltas of senders
+inside one branch are summed before the post-norm.
+
+## Path specification
+
+A patch is an explicit edge set over {sender, receiver MLPs, logits}
+(`PathSpec`): `sender->receiver_k`, `sender->logits`,
+`receiver_j->receiver_k`, `receiver_k->logits`. Each receiver's input delta
+sums only its included incoming edges; its output delta propagates only along
+its included outgoing edges. Receivers re-evaluate one MLP branch each —
+still exact.
+
+The common case is the closed cascade — **`PathSpec.cascade(receivers,
+direct_to_logits=..., multipath="first"|"all")`** — the documented default
+entry point. `"first"` sends the sender's delta only into the
+furthest-upstream receiver (the iterative path patch of Hanna et al. Fig 3C);
+`"all"` sends it into every receiver (the §3.3 indirect split). The explicit
+edge set is the power-user form; `spec.without_edge(j, k)` excludes an
+individual receiver-to-receiver edge, which the closed-cascade API cannot
+express.
+
+**Granularity ceiling** (deliberate): edges are atomic. One edge cannot carry
+different values per downstream branch — the "treeified" patching expressible
+in rust-circuit is out of scope for this cache-arithmetic engine.
+
+`engine.circuit_eval(heads, mlps, direction, head_receiver_mlps)` evaluates a
+whole circuit (sufficiency: run corrupted, restore circuit paths to clean;
+necessity: run clean, corrupt circuit paths), with per-head edge routing into
+the circuit MLPs.
+
+## Guards
+
+Construction runs four empirical checks and refuses to patch on failure
+(`GuardError` names the likely cause; measured errors are kept in
+`engine.guard_report`):
+
+| guard | catches |
+|---|---|
+| G1 additivity: final residual = embedding + Σ branch trunk contributions | post-LN trunks, wrong capture points |
+| G2 branch wiring: re-evaluating each MLP branch on its derived input reproduces the cached branch output | mis-declared block order (sequential vs parallel), wrong pre-norm module |
+| G3 patch-nothing closure: reassembled tail reproduces the model's logits | wrong final norm / LM head / missing softcapping |
+| G4 patch-everything closure: patching every direct edge reconstructs the counterfactual logits | wrong capture points, inconsistent caches |
+
+Note that G4 is a *direct-edge sum* and is numerically order-invariant — the
+block-order teeth are G2's per-layer receiver re-evaluation.
+
+Block order is resolved from the HF config (`use_parallel_residual`) and can
+be overridden (`resolve_descriptor(model, block_order=...)`) — the override
+exists so tests can prove the guards catch a lie. On parallel-residual models
+(Pythia) the MLP reads the block *input*, so a same-layer head never feeds
+the same-layer MLP; the engine's edge routing respects this.
+
+## Capability contract
+
+causalab's contract is "a model works iff its family is in pyvene's mapping".
+This method keeps it exactly: `check_capability` verifies at construction
+that every pyvene unit the requested operation needs exists in the family's
+mapping, else raises `UnsupportedArchitectureError` naming the missing units
+and the operation. There are **no raw torch hooks anywhere** (test-enforced).
+Capture points beyond pyvene's named vocabulary use pyvene's dotted
+module-path resolution — still `IntervenableModel` interventions.
+
+- `engine.provenance` documents which pyvene units the engine uses
+  (named / dotted-path / direct module call); validation runs write it into
+  their results JSONs.
+- `coverage_table()` reports supported/unsupported per family × component
+  from the *installed* pyvene; it is committed as a test artifact
+  (`tests/test_methods/artifacts/path_patching_coverage.json`) and
+  regenerated in CI, so a pyvene pin bump surfaces as a table diff rather
+  than a silent behavior change.
+
+## The reference twin
+
+`reference_patched_logits` implements the same freeze recipe as *live
+intervened forwards* through pyvene (sender substitution, downstream freezes,
+excluded-edge cancellation), mechanistically independent of the engine's
+cache arithmetic, so engine-vs-twin agreement is an informative check rather
+than a tautology. It is slow and meant for validation.
+
+One pyvene mechanic to know about when writing norm-input interventions
+anywhere in causalab: **setter interventions scatter in place**, and a
+pre-norm's input tensor *is* the residual-stream tensor, so modifying it
+changes the trunk downstream, not just what the norm sees. The twin pairs
+every pre-norm cancellation with a trunk-output restoration on the same
+receiver (`_TrunkOutputAdjust`) to keep the recipe exact.
+
+## K/V-side attention detail (gated)
+
+`build_attn_detail_cache` captures per-head q/k/v (pyvene
+`query/key/value_output`; scores are derived arithmetic on cached q/k — the
+score tensor is not a module boundary and never needs intervening on). It is
+**gated to GPT-2-style attention** (`fused-qkv-absolute`) and raises
+`NotImplementedError` on rotary/GQA models, with the agreed generalization
+direction documented in `kv.py`: rotate key deltas by the patched position's
+angle before re-scoring (pre-rotation keys via pyvene + rotation in engine
+arithmetic is pyvene-native); use KV heads, not query heads, as the edge unit
+under GQA; keep the K/V twin as pyvene replace interventions on
+`head_key_output`/`head_value_output`. K/V capture requires
+`attn_implementation="eager"` (the `LMPipeline` default) — fused kernels do
+not materialize what pyvene's attention units need.
+
+## Worked example: an iterative path-patching sweep
+
+With any set of clean/counterfactual prompt pairs (templated prompts that
+differ in one token, and a task metric over the logits), the full iterative
+path patching of Hanna et al. (2023) §3.1 is a loop over senders × path
+modes:
+
+```python
+modes = {
+    "logits":    PathSpec.cascade(),
+    "via_mlp10": PathSpec.cascade([10, 11], direct_to_logits=False),
+    # ...
+}
+cell = prob_diff(engine.patched_logits(("head", l, h), spec)) - clean_prob_diff
+```
+
+During development the engine was validated against a hook-based
+reimplementation of Hanna et al.'s greater-than analysis on GPT-2, matching
+it cell-for-cell at float precision — at a fraction of the per-patch cost of
+hook-based patching.

--- a/tests/test_attn_implementation_semantics.py
+++ b/tests/test_attn_implementation_semantics.py
@@ -1,0 +1,395 @@
+"""Regression tests for the transformers ``attn_implementation`` semantics that
+causalab's ``LMPipeline(..., attn_implementation=...)`` pass-through relies on.
+
+Verified empirically on transformers 4.57.1 / torch 2.9.0 (CPU, float32).
+Context: causalab used to select eager attention by flipping
+``config._attn_implementation`` *after* ``from_pretrained`` (the legacy
+``eager_attn`` flag). On 4.57.1 that flip happens to be self-consistent for
+decoder-only models because both the kernel dispatch and the causal-mask
+builder read the live config at forward time — but the correctness is an
+accident of transformers version and model family:
+
+* ``GPT2Model.__init__`` stores a frozen copy of the implementation choice
+  (``self._attn_implementation``); cross-attention encoder-mask preparation
+  reads the frozen copy, so a flipped model runs eager kernels with
+  sdpa-format encoder masks (a mixed state).
+* On older transformers (≤ 4.4x) attention module *classes* were chosen at
+  init, so the flip changed nothing at all.
+
+These tests pin the 4.57-line behavior so an upgrade that changes any of it
+fails loudly. All models are tiny-random; no network, CPU-only.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    GPT2Config,
+    LlamaConfig,
+    PreTrainedModel,
+)
+
+# ---------------------------------------------------------------------------
+# tiny-random model factories (no network)
+# ---------------------------------------------------------------------------
+
+
+def _tiny_gpt2_config(**overrides: object) -> GPT2Config:
+    kwargs = dict(
+        n_layer=2,
+        n_head=2,
+        n_embd=32,
+        n_positions=64,
+        vocab_size=257,
+        attn_pdrop=0.0,
+        embd_pdrop=0.0,
+        resid_pdrop=0.0,
+        bos_token_id=0,
+        eos_token_id=0,
+    )
+    kwargs.update(overrides)
+    return GPT2Config(**kwargs)
+
+
+def _tiny_llama_config() -> LlamaConfig:
+    return LlamaConfig(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        vocab_size=257,
+        max_position_embeddings=64,
+        attention_dropout=0.0,
+        bos_token_id=0,
+        eos_token_id=0,
+    )
+
+
+@pytest.fixture(scope="module")
+def tiny_model_dirs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
+    root = tmp_path_factory.mktemp("tiny_attn_models")
+    dirs = {}
+    for name, config in (
+        ("gpt2", _tiny_gpt2_config()),
+        ("llama", _tiny_llama_config()),
+        ("gpt2_cross", _tiny_gpt2_config(add_cross_attention=True)),
+    ):
+        torch.manual_seed(42)
+        model = AutoModelForCausalLM.from_config(config)
+        path = root / name
+        model.save_pretrained(path)
+        dirs[name] = str(path)
+    return dirs
+
+
+def _load(path: str, **kwargs: object) -> PreTrainedModel:
+    model = AutoModelForCausalLM.from_pretrained(path, dtype=torch.float32, **kwargs)
+    model.eval()
+    return model
+
+
+def _flip_to_eager(model: PreTrainedModel) -> PreTrainedModel:
+    """The legacy post-load flip (what the removed ``eager_attn`` flag did)."""
+    model.config._attn_implementation = "eager"
+    return model
+
+
+def _attn_modules(model: PreTrainedModel) -> list[torch.nn.Module]:
+    if hasattr(model, "transformer"):  # GPT-2
+        return [block.attn for block in model.transformer.h]
+    return [layer.self_attn for layer in model.model.layers]  # Llama
+
+
+def _batches(pad_id: int = 0) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    torch.manual_seed(7)
+    unpadded = torch.randint(1, 257, (2, 8))
+    padded = unpadded.clone()
+    padded[0, :3] = pad_id
+    pad_mask = torch.ones(2, 8, dtype=torch.long)
+    pad_mask[0, :3] = 0
+    return unpadded, padded, pad_mask
+
+
+def _capture_forward_param(
+    modules: list[torch.nn.Module], param_name: str
+) -> tuple[list[object], list[torch.utils.hooks.RemovableHandle]]:
+    """Capture the named forward parameter on each module via pre-hooks."""
+    captured: list = []
+    handles = []
+
+    def hook(
+        module: torch.nn.Module,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ):
+        bound = inspect.signature(module.forward).bind(*args, **kwargs)
+        captured.append(bound.arguments.get(param_name, "<param-missing>"))
+
+    for m in modules:
+        handles.append(m.register_forward_pre_hook(hook, with_kwargs=True))
+    return captured, handles
+
+
+def _force_param_none(
+    modules: list[torch.nn.Module], param_name: str
+) -> list[torch.utils.hooks.RemovableHandle]:
+    """Force the named forward parameter to None (simulates an sdpa-produced
+    None reaching a kernel that does not expect it)."""
+    handles = []
+
+    def hook(
+        module: torch.nn.Module,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ):
+        sig = inspect.signature(module.forward)
+        bound = sig.bind(*args, **kwargs)
+        if param_name in bound.arguments:
+            bound.arguments[param_name] = None
+        new_kwargs = {}
+        for name, value in bound.arguments.items():
+            if sig.parameters[name].kind is inspect.Parameter.VAR_KEYWORD:
+                new_kwargs.update(value)
+            else:
+                new_kwargs[name] = value
+        return (), new_kwargs
+
+    for m in modules:
+        handles.append(m.register_forward_pre_hook(hook, with_kwargs=True))
+    return handles
+
+
+def _remove(handles: list[torch.utils.hooks.RemovableHandle]) -> None:
+    for h in handles:
+        h.remove()
+
+
+@torch.no_grad()
+def _logits(
+    model: PreTrainedModel,
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor | None = None,
+    **kwargs: object,
+) -> torch.Tensor:
+    return model(input_ids=input_ids, attention_mask=attention_mask, **kwargs).logits
+
+
+# ---------------------------------------------------------------------------
+# C1: default resolution is sdpa
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["gpt2", "llama"])
+def test_default_resolution_is_sdpa(tiny_model_dirs: dict[str, str], name: str) -> None:
+    model = _load(tiny_model_dirs[name])
+    assert model.config._attn_implementation == "sdpa"
+
+
+# ---------------------------------------------------------------------------
+# C2: on this transformers version, the legacy post-load flip is
+# self-consistent for decoder-only models (matches load-time eager exactly)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["gpt2", "llama"])
+def test_postload_flip_matches_load_time_eager_logits(
+    tiny_model_dirs: dict[str, str], name: str
+) -> None:
+    m_flip = _flip_to_eager(_load(tiny_model_dirs[name]))
+    m_eager = _load(tiny_model_dirs[name], attn_implementation="eager")
+    unpadded, padded, pad_mask = _batches()
+
+    assert torch.equal(_logits(m_flip, unpadded), _logits(m_eager, unpadded))
+    assert torch.equal(
+        _logits(m_flip, padded, pad_mask), _logits(m_eager, padded, pad_mask)
+    )
+
+
+@pytest.mark.parametrize("name", ["gpt2", "llama"])
+def test_postload_flip_delivers_float_additive_mask(
+    tiny_model_dirs: dict[str, str], name: str
+) -> None:
+    """The mask builder reads the live config: after the flip, attention
+    layers receive an eager-format float additive mask, not sdpa's None/bool."""
+    m_flip = _flip_to_eager(_load(tiny_model_dirs[name]))
+    unpadded, padded, pad_mask = _batches()
+
+    for ids, mask in ((unpadded, None), (padded, pad_mask)):
+        captured, handles = _capture_forward_param(
+            _attn_modules(m_flip), "attention_mask"
+        )
+        _logits(m_flip, ids, mask)
+        _remove(handles)
+        got = captured[0]
+        assert isinstance(got, torch.Tensor)
+        assert got.dtype.is_floating_point
+        assert got.max().item() == 0.0
+        assert got.min().item() < 0.0
+
+
+# ---------------------------------------------------------------------------
+# C3: the frozen per-module copy — the mixed state the flip creates
+# ---------------------------------------------------------------------------
+
+
+def test_gpt2_frozen_copy_diverges_from_live_config_after_flip(
+    tiny_model_dirs: dict[str, str],
+) -> None:
+    m_flip = _flip_to_eager(_load(tiny_model_dirs["gpt2"]))
+    assert m_flip.config._attn_implementation == "eager"
+    # GPT2Model.__init__ froze the load-time choice; the flip does not reach it.
+    assert m_flip.transformer._attn_implementation == "sdpa"
+
+
+def test_gpt2_cross_attention_encoder_mask_follows_frozen_copy(
+    tiny_model_dirs: dict[str, str],
+) -> None:
+    """Where the frozen copy is live: encoder-mask preparation. A flipped
+    cross-attention model prepares the encoder mask down the sdpa branch while
+    kernels run eager — unlike a load-time-eager model, which gets the
+    eager-format additive mask."""
+    unpadded, _, _ = _batches()
+    torch.manual_seed(11)
+    enc_hidden = torch.randn(2, 5, 32)
+    enc_mask_padded = torch.ones(2, 5, dtype=torch.long)
+    enc_mask_padded[0, 3:] = 0
+
+    def encoder_mask_seen(
+        model: PreTrainedModel, enc_mask: torch.Tensor | None
+    ) -> object:
+        cross = [b.crossattention for b in model.transformer.h]
+        captured, handles = _capture_forward_param(cross, "encoder_attention_mask")
+        _logits(
+            model,
+            unpadded,
+            encoder_hidden_states=enc_hidden,
+            encoder_attention_mask=enc_mask,
+        )
+        _remove(handles)
+        return captured[0]
+
+    m_flip = _flip_to_eager(_load(tiny_model_dirs["gpt2_cross"]))
+    m_eager = _load(tiny_model_dirs["gpt2_cross"], attn_implementation="eager")
+
+    # Load-time eager: invert_attention_mask -> float additive, both cases.
+    for enc_mask in (None, enc_mask_padded):
+        got = encoder_mask_seen(m_eager, enc_mask)
+        assert isinstance(got, torch.Tensor) and got.dtype.is_floating_point
+
+    # Flipped: the frozen-"sdpa" branch elides the all-ones encoder mask
+    # entirely — the eager cross-attention kernel receives None.
+    assert encoder_mask_seen(m_flip, None) is None
+
+    # Padded encoder: both branches materialize a float mask, but in the
+    # sdpa-prepared shape (batch, 1, q_len, kv_len) vs the eager-inverted
+    # (batch, 1, 1, kv_len) — the formats diverge even when values agree.
+    flip_mask = encoder_mask_seen(m_flip, enc_mask_padded)
+    eager_mask = encoder_mask_seen(m_eager, enc_mask_padded)
+    assert flip_mask.shape != eager_mask.shape
+
+
+# ---------------------------------------------------------------------------
+# C4: sdpa mask formats — None (is_causal deferral) unpadded, boolean padded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["gpt2", "llama"])
+def test_sdpa_mask_is_none_for_unpadded_full_causal_batch(
+    tiny_model_dirs: dict[str, str], name: str
+) -> None:
+    m_sdpa = _load(tiny_model_dirs[name])
+    assert m_sdpa.config._attn_implementation == "sdpa"
+    unpadded, _, _ = _batches()
+
+    captured, handles = _capture_forward_param(_attn_modules(m_sdpa), "attention_mask")
+    _logits(m_sdpa, unpadded)
+    _remove(handles)
+    assert captured[0] is None
+
+
+@pytest.mark.parametrize("name", ["gpt2", "llama"])
+def test_sdpa_mask_is_boolean_for_left_padded_batch(
+    tiny_model_dirs: dict[str, str], name: str
+) -> None:
+    m_sdpa = _load(tiny_model_dirs[name])
+    _, padded, pad_mask = _batches()
+
+    captured, handles = _capture_forward_param(_attn_modules(m_sdpa), "attention_mask")
+    _logits(m_sdpa, padded, pad_mask)
+    _remove(handles)
+    got = captured[0]
+    assert isinstance(got, torch.Tensor)
+    assert got.dtype is torch.bool
+
+
+# ---------------------------------------------------------------------------
+# C5: eager mask is always a materialized float additive mask
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ["gpt2", "llama"])
+def test_eager_mask_is_always_float_additive(
+    tiny_model_dirs: dict[str, str], name: str
+) -> None:
+    m_eager = _load(tiny_model_dirs[name], attn_implementation="eager")
+    unpadded, padded, pad_mask = _batches()
+
+    for ids, mask in ((unpadded, None), (padded, pad_mask)):
+        captured, handles = _capture_forward_param(
+            _attn_modules(m_eager), "attention_mask"
+        )
+        _logits(m_eager, ids, mask)
+        _remove(handles)
+        got = captured[0]
+        assert isinstance(got, torch.Tensor)
+        assert got.dtype.is_floating_point
+        assert got.max().item() == 0.0
+        assert got.min().item() <= torch.finfo(torch.float32).min / 2
+
+
+# ---------------------------------------------------------------------------
+# C8: GPT-2's eager kernel stays causal even if the mask goes missing
+# (its registered bias buffer applies causal masking unconditionally)
+# ---------------------------------------------------------------------------
+
+
+@torch.no_grad()
+def _future_token_influence(model: PreTrainedModel, force_none: bool) -> float:
+    """Change the final token; max |logit diff| at earlier positions."""
+    torch.manual_seed(13)
+    ids_a = torch.randint(1, 257, (1, 8))
+    ids_b = ids_a.clone()
+    ids_b[0, -1] = (ids_a[0, -1] + 1) % 256 + 1
+
+    handles = (
+        _force_param_none(_attn_modules(model), "attention_mask") if force_none else []
+    )
+    la = model(input_ids=ids_a).logits
+    lb = model(input_ids=ids_b).logits
+    _remove(handles)
+    return (la[:, :-1] - lb[:, :-1]).abs().max().item()
+
+
+def test_gpt2_eager_kernel_stays_causal_when_mask_is_none(
+    tiny_model_dirs: dict[str, str],
+) -> None:
+    m_gpt2 = _load(tiny_model_dirs["gpt2"], attn_implementation="eager")
+    assert _future_token_influence(m_gpt2, force_none=True) == 0.0
+
+
+def test_llama_eager_kernel_is_not_causal_when_mask_is_none(
+    tiny_model_dirs: dict[str, str],
+) -> None:
+    """The counterpoint that makes C8 meaningful: an eager kernel with no
+    bias-buffer fallback (Llama) goes non-causal if the mask goes missing.
+    This cannot happen on the normal path (mask construction and kernel
+    dispatch read the same live config); it is the failure mode a
+    mixed-state model risks."""
+    m_llama = _load(tiny_model_dirs["llama"], attn_implementation="eager")
+    assert _future_token_influence(m_llama, force_none=False) == 0.0  # control
+    assert _future_token_influence(m_llama, force_none=True) > 0.0

--- a/tests/test_methods/artifacts/path_patching_coverage.json
+++ b/tests/test_methods/artifacts/path_patching_coverage.json
@@ -1,0 +1,61 @@
+{
+  "pyvene_pin": "896a7dd47267",
+  "families": {
+    "gpt2": {
+      "attention_value_output": "supported",
+      "head_attention_value_output": "supported",
+      "mlp_output": "supported",
+      "mlp_activation": "supported",
+      "block_input": "supported",
+      "block_output": "supported",
+      "query_output": "supported",
+      "key_output": "supported",
+      "value_output": "supported",
+      "head_query_output": "supported",
+      "head_key_output": "supported",
+      "head_value_output": "supported"
+    },
+    "gpt_neox": {
+      "attention_value_output": "supported",
+      "head_attention_value_output": "supported",
+      "mlp_output": "supported",
+      "mlp_activation": "supported",
+      "block_input": "supported",
+      "block_output": "supported",
+      "query_output": "unsupported",
+      "key_output": "unsupported",
+      "value_output": "unsupported",
+      "head_query_output": "unsupported",
+      "head_key_output": "unsupported",
+      "head_value_output": "unsupported"
+    },
+    "llama": {
+      "attention_value_output": "supported",
+      "head_attention_value_output": "supported",
+      "mlp_output": "supported",
+      "mlp_activation": "supported",
+      "block_input": "supported",
+      "block_output": "supported",
+      "query_output": "supported",
+      "key_output": "supported",
+      "value_output": "supported",
+      "head_query_output": "supported",
+      "head_key_output": "supported",
+      "head_value_output": "supported"
+    },
+    "gemma2": {
+      "attention_value_output": "supported",
+      "head_attention_value_output": "supported",
+      "mlp_output": "supported",
+      "mlp_activation": "supported",
+      "block_input": "supported",
+      "block_output": "supported",
+      "query_output": "supported",
+      "key_output": "supported",
+      "value_output": "supported",
+      "head_query_output": "supported",
+      "head_key_output": "supported",
+      "head_value_output": "supported"
+    }
+  }
+}

--- a/tests/test_methods/test_path_patching.py
+++ b/tests/test_methods/test_path_patching.py
@@ -1,0 +1,308 @@
+"""Tests for causalab.methods.path_patching.
+
+Three tiers:
+  * pure logic (PathSpec, padding shifts, coverage drift) — no model, no
+    network;
+  * tiny-random end-to-end (construction guards, closure, cascade
+    equivalence, twin agreement, negative controls) on 4-layer random
+    models of each supported family, CPU — needs only the gpt2 tokenizer;
+  * hygiene (no raw torch hooks anywhere in the method).
+
+The tiny-random tier exercises structural identities (additivity, closure,
+engine-vs-twin equality), which hold for random weights; validation on real
+models is the experiment's per-model matrix, not CI's job.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+import torch
+
+from causalab.methods.path_patching import (
+    GuardError,
+    PatchEngine,
+    PathSpec,
+    UnsupportedArchitectureError,
+    build_patch_cache,
+    coverage_table,
+    reference_patched_logits,
+    resolve_descriptor,
+)
+from causalab.neural.padding import shift_indices_for_padding
+
+METHOD_DIR = Path(__file__).resolve().parents[2] / "causalab" / "methods" / "path_patching"
+COVERAGE_ARTIFACT = Path(__file__).resolve().parent / "artifacts" / "path_patching_coverage.json"
+
+
+# ---------------------------------------------------------------------------
+# pure logic
+# ---------------------------------------------------------------------------
+
+
+class TestPathSpec:
+    def test_cascade_first_expansion(self):
+        s = PathSpec.cascade([8, 10, 11], direct_to_logits=False)
+        assert s.receivers == (8, 10, 11)
+        assert s.sender_to == frozenset({8})
+        assert s.receiver_to_receiver == frozenset({(8, 10), (8, 11), (10, 11)})
+        assert not s.sender_to_logits
+        assert s.receivers_to_logits == frozenset({8, 10, 11})
+
+    def test_cascade_all_expansion(self):
+        s = PathSpec.cascade([3, 5], multipath="all")
+        assert s.sender_to == frozenset({3, 5})
+        assert s.sender_to_logits
+
+    def test_without_edge(self):
+        s = PathSpec.cascade([1, 2, 3]).without_edge(1, 3)
+        assert (1, 3) not in s.receiver_to_receiver
+        assert (1, 2) in s.receiver_to_receiver
+
+    def test_rejects_downstream_to_upstream_edge(self):
+        with pytest.raises(ValueError):
+            PathSpec(receivers=(1, 2), receiver_to_receiver=frozenset({(2, 1)}))
+
+    def test_rejects_unknown_receiver(self):
+        with pytest.raises(ValueError):
+            PathSpec(receivers=(1,), sender_to=frozenset({4}))
+
+    def test_rejects_unsorted_receivers(self):
+        with pytest.raises(ValueError):
+            PathSpec(receivers=(3, 1))
+
+
+class TestPaddingShift:
+    def test_left_padding_shifts_by_pad_count(self):
+        mask = torch.tensor([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1]])
+        assert shift_indices_for_padding([[0, 2], [0, 2]], mask) == [[2, 4], [0, 2]]
+
+    def test_right_padding_no_shift(self):
+        mask = torch.tensor([[1, 1, 1, 0, 0]])
+        assert shift_indices_for_padding([[1]], mask) == [[1]]
+
+    def test_negative_index_is_true_end_relative(self):
+        # the documented TokenPosition(lambda x: [-1]) API: -1 must resolve
+        # to the last REAL token under either padding side
+        left = torch.tensor([[0, 0, 1, 1, 1]])
+        right = torch.tensor([[1, 1, 1, 0, 0]])
+        assert shift_indices_for_padding([[-1]], left) == [[4]]
+        assert shift_indices_for_padding([[-1]], right) == [[2]]
+
+    def test_out_of_range_raises(self):
+        mask = torch.tensor([[0, 1, 1]])
+        with pytest.raises(IndexError):
+            shift_indices_for_padding([[2]], mask)  # true length is 2
+
+
+def test_coverage_table_matches_committed_artifact():
+    """Drift detection: a pyvene pin bump that adds/moves units must surface
+    as a diff of the committed coverage artifact, not silently."""
+    current = coverage_table()
+    committed = json.loads(COVERAGE_ARTIFACT.read_text())
+    assert current == committed, (
+        "pyvene coverage changed (pin bump?). If intentional, regenerate: "
+        "uv run python -c \"import json; from causalab.methods.path_patching "
+        "import coverage_table; print(json.dumps(coverage_table(), indent=2))\" "
+        f"> {COVERAGE_ARTIFACT}"
+    )
+
+
+def test_no_raw_torch_hooks_in_method():
+    """causalab contract: everything routes through pyvene, no raw hooks."""
+    pattern = re.compile(r"register_forward(_pre)?_hook|register_full_backward")
+    offenders = [
+        f"{p.name}:{i}"
+        for p in METHOD_DIR.glob("*.py")
+        for i, line in enumerate(p.read_text().splitlines(), 1)
+        if pattern.search(line)
+    ]
+    assert not offenders, f"raw torch hooks in path_patching: {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# tiny-random end-to-end (CPU)
+# ---------------------------------------------------------------------------
+
+TINY_VOCAB = 50304  # >= gpt2 tokenizer vocab
+
+
+def _tiny_model(family: str):
+    torch.manual_seed(0)
+    if family == "gpt2":
+        from transformers import GPT2Config, GPT2LMHeadModel
+
+        return GPT2LMHeadModel(
+            GPT2Config(
+                n_layer=4, n_head=4, n_embd=32, vocab_size=TINY_VOCAB, n_positions=128
+            )
+        )
+    if family == "gpt_neox":
+        from transformers import GPTNeoXConfig, GPTNeoXForCausalLM
+
+        return GPTNeoXForCausalLM(
+            GPTNeoXConfig(
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                hidden_size=32,
+                intermediate_size=64,
+                vocab_size=TINY_VOCAB,
+                use_parallel_residual=True,
+                max_position_embeddings=128,
+            )
+        )
+    if family == "llama":
+        from transformers import LlamaConfig, LlamaForCausalLM
+
+        return LlamaForCausalLM(
+            LlamaConfig(
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                hidden_size=32,
+                intermediate_size=64,
+                vocab_size=TINY_VOCAB,
+                max_position_embeddings=128,
+            )
+        )
+    if family == "gemma2":
+        from transformers import Gemma2Config, Gemma2ForCausalLM
+
+        return Gemma2ForCausalLM(
+            Gemma2Config(
+                num_hidden_layers=4,
+                num_attention_heads=4,
+                num_key_value_heads=2,
+                hidden_size=32,
+                head_dim=8,
+                intermediate_size=64,
+                vocab_size=TINY_VOCAB,
+                final_logit_softcapping=30.0,
+                attn_logit_softcapping=50.0,
+                max_position_embeddings=128,
+                sliding_window=64,
+            )
+        )
+    raise ValueError(family)
+
+
+@pytest.fixture(scope="module")
+def gpt2_tokenizer_pipeline_factory():
+    """LMPipeline shells sharing one gpt2 tokenizer; model swapped per test."""
+    from causalab.neural.pipeline import LMPipeline
+
+    def make(model):
+        pipeline = LMPipeline(
+            "gpt2", max_new_tokens=1, load_weights=False, position_ids=True
+        )
+        model.eval()
+        pipeline.model = model
+        return pipeline
+
+    return make
+
+
+TEXTS_CLEAN = [
+    "the dog was standing near the door and everyone looked at",
+    "yesterday, the king was standing near the door and everyone looked at",
+    "a long time ago, the car was standing near the gate and everyone looked at",
+    "the bird was sitting near the window and everyone looked at",
+]
+TEXTS_CF = [
+    "the cat was standing near the door and everyone looked at",
+    "yesterday, the queen was standing near the door and everyone looked at",
+    "a long time ago, the boat was standing near the gate and everyone looked at",
+    "the fish was sitting near the window and everyone looked at",
+]
+
+
+def _build_engine(family, factory, **kwargs):
+    pipeline = factory(_tiny_model(family))
+    desc = resolve_descriptor(pipeline.model, **kwargs)
+    clean = build_patch_cache(pipeline, desc, TEXTS_CLEAN, {"end": -1}, batch_size=4)
+    cf = build_patch_cache(pipeline, desc, TEXTS_CF, {"end": -1}, batch_size=4)
+    return pipeline, desc, clean, cf
+
+
+@pytest.mark.parametrize("family", ["gpt2", "gpt_neox", "llama", "gemma2"])
+class TestTinyRandomEndToEnd:
+    def test_guards_pass_and_provenance_reported(self, family, gpt2_tokenizer_pipeline_factory):
+        _, desc, clean, cf = _build_engine(family, gpt2_tokenizer_pipeline_factory)
+        engine = PatchEngine(desc, clean, cf)
+        assert engine.guard_report["G3_patch_nothing_max_logit_err"] <= 2e-3
+        assert engine.guard_report["G4_patch_everything_max_logit_err"] <= 2e-3
+        mechanisms = {p["mechanism"] for p in engine.provenance}
+        assert mechanisms <= {"pyvene-named", "pyvene-path", "direct-module-call"}
+
+    def test_cascade_shorthand_bit_identical(self, family, gpt2_tokenizer_pipeline_factory):
+        _, desc, clean, cf = _build_engine(family, gpt2_tokenizer_pipeline_factory)
+        engine = PatchEngine(desc, clean, cf)
+        recv = [2, 3]
+        short = PathSpec.cascade(recv, direct_to_logits=False)
+        explicit = PathSpec(
+            receivers=(2, 3),
+            sender_to=frozenset({2}),
+            receiver_to_receiver=frozenset({(2, 3)}),
+            sender_to_logits=False,
+            receivers_to_logits=frozenset({2, 3}),
+        )
+        sender = ("mlp", 0)
+        assert torch.equal(
+            engine.patched_logits(sender, short), engine.patched_logits(sender, explicit)
+        )
+
+    def test_twin_agreement(self, family, gpt2_tokenizer_pipeline_factory):
+        pipeline, desc, clean, cf = _build_engine(family, gpt2_tokenizer_pipeline_factory)
+        engine = PatchEngine(desc, clean, cf)
+        cases = [
+            (("head", 1, 2), PathSpec.cascade()),
+            (("mlp", 0), PathSpec.cascade([2, 3], direct_to_logits=False)),
+            (("head", 0, 1), PathSpec.cascade([2, 3], direct_to_logits=False).without_edge(2, 3)),
+        ]
+        for sender, spec in cases:
+            analytic = engine.patched_logits(sender, spec)
+            ref = reference_patched_logits(
+                pipeline, desc, TEXTS_CLEAN, clean, cf, sender, spec, engine=engine
+            )
+            assert (analytic - ref).abs().max().item() <= 2e-3, (sender, spec.describe())
+
+
+def test_misdeclared_block_order_fails_branch_wiring_guard(gpt2_tokenizer_pipeline_factory):
+    """A parallel-residual model declared sequential must be refused by G2."""
+    _, desc, clean, cf = _build_engine(
+        "gpt_neox", gpt2_tokenizer_pipeline_factory, block_order="sequential"
+    )
+    with pytest.raises(GuardError, match="G2 branch wiring"):
+        PatchEngine(desc, clean, cf)
+
+
+def test_post_ln_trunk_fails_additivity_guard(gpt2_tokenizer_pipeline_factory):
+    """A block that norms after its residual add must be refused by G1."""
+    import types
+
+    pipeline = gpt2_tokenizer_pipeline_factory(_tiny_model("gpt2"))
+    block = pipeline.model.transformer.h[2]
+    block._original_forward = block.forward
+
+    def post_ln_forward(self, hidden_states, **kwargs):
+        out = self._original_forward(hidden_states, **kwargs)
+        return (self.ln_1(out[0]),) + out[1:] if isinstance(out, tuple) else self.ln_1(out)
+
+    block.forward = types.MethodType(post_ln_forward, block)
+    desc = resolve_descriptor(pipeline.model)
+    clean = build_patch_cache(pipeline, desc, TEXTS_CLEAN, {"end": -1})
+    cf = build_patch_cache(pipeline, desc, TEXTS_CF, {"end": -1})
+    with pytest.raises(GuardError, match="G1 additivity"):
+        PatchEngine(desc, clean, cf)
+
+
+def test_unmapped_family_is_refused():
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    cfg = AutoConfig.from_pretrained("openai-gpt")
+    model = AutoModelForCausalLM.from_config(cfg)
+    with pytest.raises(UnsupportedArchitectureError):
+        resolve_descriptor(model)

--- a/tests/test_methods/test_path_patching.py
+++ b/tests/test_methods/test_path_patching.py
@@ -34,8 +34,12 @@ from causalab.methods.path_patching import (
 )
 from causalab.neural.padding import shift_indices_for_padding
 
-METHOD_DIR = Path(__file__).resolve().parents[2] / "causalab" / "methods" / "path_patching"
-COVERAGE_ARTIFACT = Path(__file__).resolve().parent / "artifacts" / "path_patching_coverage.json"
+METHOD_DIR = (
+    Path(__file__).resolve().parents[2] / "causalab" / "methods" / "path_patching"
+)
+COVERAGE_ARTIFACT = (
+    Path(__file__).resolve().parent / "artifacts" / "path_patching_coverage.json"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -105,8 +109,8 @@ def test_coverage_table_matches_committed_artifact():
     committed = json.loads(COVERAGE_ARTIFACT.read_text())
     assert current == committed, (
         "pyvene coverage changed (pin bump?). If intentional, regenerate: "
-        "uv run python -c \"import json; from causalab.methods.path_patching "
-        "import coverage_table; print(json.dumps(coverage_table(), indent=2))\" "
+        'uv run python -c "import json; from causalab.methods.path_patching '
+        'import coverage_table; print(json.dumps(coverage_table(), indent=2))" '
         f"> {COVERAGE_ARTIFACT}"
     )
 
@@ -229,7 +233,9 @@ def _build_engine(family, factory, **kwargs):
 
 @pytest.mark.parametrize("family", ["gpt2", "gpt_neox", "llama", "gemma2"])
 class TestTinyRandomEndToEnd:
-    def test_guards_pass_and_provenance_reported(self, family, gpt2_tokenizer_pipeline_factory):
+    def test_guards_pass_and_provenance_reported(
+        self, family, gpt2_tokenizer_pipeline_factory
+    ):
         _, desc, clean, cf = _build_engine(family, gpt2_tokenizer_pipeline_factory)
         engine = PatchEngine(desc, clean, cf)
         assert engine.guard_report["G3_patch_nothing_max_logit_err"] <= 2e-3
@@ -237,7 +243,9 @@ class TestTinyRandomEndToEnd:
         mechanisms = {p["mechanism"] for p in engine.provenance}
         assert mechanisms <= {"pyvene-named", "pyvene-path", "direct-module-call"}
 
-    def test_cascade_shorthand_bit_identical(self, family, gpt2_tokenizer_pipeline_factory):
+    def test_cascade_shorthand_bit_identical(
+        self, family, gpt2_tokenizer_pipeline_factory
+    ):
         _, desc, clean, cf = _build_engine(family, gpt2_tokenizer_pipeline_factory)
         engine = PatchEngine(desc, clean, cf)
         recv = [2, 3]
@@ -251,26 +259,37 @@ class TestTinyRandomEndToEnd:
         )
         sender = ("mlp", 0)
         assert torch.equal(
-            engine.patched_logits(sender, short), engine.patched_logits(sender, explicit)
+            engine.patched_logits(sender, short),
+            engine.patched_logits(sender, explicit),
         )
 
     def test_twin_agreement(self, family, gpt2_tokenizer_pipeline_factory):
-        pipeline, desc, clean, cf = _build_engine(family, gpt2_tokenizer_pipeline_factory)
+        pipeline, desc, clean, cf = _build_engine(
+            family, gpt2_tokenizer_pipeline_factory
+        )
         engine = PatchEngine(desc, clean, cf)
         cases = [
             (("head", 1, 2), PathSpec.cascade()),
             (("mlp", 0), PathSpec.cascade([2, 3], direct_to_logits=False)),
-            (("head", 0, 1), PathSpec.cascade([2, 3], direct_to_logits=False).without_edge(2, 3)),
+            (
+                ("head", 0, 1),
+                PathSpec.cascade([2, 3], direct_to_logits=False).without_edge(2, 3),
+            ),
         ]
         for sender, spec in cases:
             analytic = engine.patched_logits(sender, spec)
             ref = reference_patched_logits(
                 pipeline, desc, TEXTS_CLEAN, clean, cf, sender, spec, engine=engine
             )
-            assert (analytic - ref).abs().max().item() <= 2e-3, (sender, spec.describe())
+            assert (analytic - ref).abs().max().item() <= 2e-3, (
+                sender,
+                spec.describe(),
+            )
 
 
-def test_misdeclared_block_order_fails_branch_wiring_guard(gpt2_tokenizer_pipeline_factory):
+def test_misdeclared_block_order_fails_branch_wiring_guard(
+    gpt2_tokenizer_pipeline_factory,
+):
     """A parallel-residual model declared sequential must be refused by G2."""
     _, desc, clean, cf = _build_engine(
         "gpt_neox", gpt2_tokenizer_pipeline_factory, block_order="sequential"
@@ -287,9 +306,11 @@ def test_post_ln_trunk_fails_additivity_guard(gpt2_tokenizer_pipeline_factory):
     block = pipeline.model.transformer.h[2]
     block._original_forward = block.forward
 
-    def post_ln_forward(self, hidden_states, **kwargs):
-        out = self._original_forward(hidden_states, **kwargs)
-        return (self.ln_1(out[0]),) + out[1:] if isinstance(out, tuple) else self.ln_1(out)
+    def post_ln_forward(self, hidden_states, *args, **kwargs):
+        out = self._original_forward(hidden_states, *args, **kwargs)
+        return (
+            (self.ln_1(out[0]),) + out[1:] if isinstance(out, tuple) else self.ln_1(out)
+        )
 
     block.forward = types.MethodType(post_ln_forward, block)
     desc = resolve_descriptor(pipeline.model)

--- a/tests/test_methods/test_path_patching.py
+++ b/tests/test_methods/test_path_patching.py
@@ -539,3 +539,98 @@ def test_kv_sliding_window_refusal(gpt2_tokenizer_pipeline_factory):
     # a full-attention layer accepts the same edge
     d = kv.kv_trunk_delta([KVEdge(KVHead(full[0], 0))])
     assert torch.isfinite(d).all()
+
+
+# ---------------------------------------------------------------------------
+# multi-position collect: the shipped keep_last_dim path is position-correct
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("family", ["gpt2", "llama"])
+class TestMultiPositionCollect:
+    """Regression guard for the keep_last_dim fix (verified empirically against
+    pinned pyvene 896a7dd4): without it, pyvene's flatten/slice cycle keeps only
+    the first d values of a multi-position gather under causalab's single-unit
+    wrapper, so a two-position collect would return position 1's vector split
+    across both position slots. These tests pin the *fixed* path: collects run
+    through ``keep_last_dim_on_collects`` must match a plain forward hook at
+    every position."""
+
+    @staticmethod
+    def _wrapper_collect(model, batch, positions):
+        from types import SimpleNamespace
+
+        from causalab.methods.path_patching.cache import keep_last_dim_on_collects
+        from causalab.neural.activations import (
+            delete_intervenable_model,
+            prepare_intervenable_model,
+        )
+        from causalab.neural.units import AtomicModelUnit, ComponentIndexer
+
+        unit = AtomicModelUnit(
+            0,
+            "block_output",
+            ComponentIndexer(lambda _x: [], id="explicit"),
+            id="collect_block0",
+        )
+        im = prepare_intervenable_model(
+            SimpleNamespace(model=model), [unit], intervention_type="collect"
+        )
+        keep_last_dim_on_collects(im)
+        try:
+            indices = [positions]
+            with torch.no_grad():
+                result = im(
+                    batch,
+                    unit_locations={"sources->base": (indices, indices)},
+                    output_original_output=True,
+                )
+            return result[0][1][0].detach().clone()
+        finally:
+            delete_intervenable_model(im)
+
+    @staticmethod
+    def _ground_truth(model, batch, positions):
+        block = (
+            model.transformer.h[0]
+            if hasattr(model, "transformer")
+            else model.model.layers[0]
+        )
+        captured = {}
+
+        def hook(mod, args, out):
+            captured["h"] = (out[0] if isinstance(out, tuple) else out).detach().clone()
+
+        handle = block.register_forward_hook(hook)
+        with torch.no_grad():
+            model(**batch)
+        handle.remove()
+        idx = torch.tensor(positions)
+        return torch.stack([captured["h"][i, idx[i]] for i in range(idx.shape[0])])
+
+    @staticmethod
+    def _batch():
+        torch.manual_seed(7)
+        return {
+            "input_ids": torch.randint(1, 257, (2, 8)),
+            "attention_mask": torch.ones(2, 8, dtype=torch.long),
+        }
+
+    def test_two_position_collect_matches_forward_hook(self, family):
+        model = _tiny_model(family)
+        model.eval()
+        batch = self._batch()
+        positions = [[2, 5], [3, 6]]
+        gt = self._ground_truth(model, batch, positions)
+        collected = self._wrapper_collect(model, batch, positions)
+        assert tuple(collected.shape) == tuple(gt.shape)
+        assert torch.equal(collected, gt)
+
+    def test_single_position_collect_matches_forward_hook(self, family):
+        model = _tiny_model(family)
+        model.eval()
+        batch = self._batch()
+        positions = [[2], [3]]
+        gt = self._ground_truth(model, batch, positions)
+        collected = self._wrapper_collect(model, batch, positions)
+        assert torch.equal(collected.reshape(gt.shape), gt)

--- a/tests/test_methods/test_path_patching.py
+++ b/tests/test_methods/test_path_patching.py
@@ -327,3 +327,215 @@ def test_unmapped_family_is_refused():
     model = AutoModelForCausalLM.from_config(cfg)
     with pytest.raises(UnsupportedArchitectureError):
         resolve_descriptor(model)
+
+
+# ---------------------------------------------------------------------------
+# K/V-side patching (tiny-random, CPU)
+# ---------------------------------------------------------------------------
+
+from causalab.methods.path_patching import (  # noqa: E402
+    KVEdge,
+    KVHead,
+    KVPatchEngine,
+    SlidingWindowError,
+    build_attn_detail_cache,
+)
+
+KV_FAMILIES = ["gpt2", "llama", "gemma2"]  # gpt_neox: refused (no pyvene units)
+PATCH_POS = 3  # unpadded index of the K/V-patched position in the fixtures
+
+
+def _build_kv_engine(family, factory, model=None):
+    pipeline = factory(model if model is not None else _tiny_model(family))
+    # config-built tiny models default to sdpa; the K/V surface requires the
+    # eager contract (its refusal has its own test below)
+    pipeline.model.config._attn_implementation = "eager"
+    desc = resolve_descriptor(pipeline.model)
+    positions = {"end": -1, "mid": PATCH_POS}
+    clean = build_patch_cache(pipeline, desc, TEXTS_CLEAN, positions, batch_size=4)
+    cf = build_patch_cache(pipeline, desc, TEXTS_CF, positions, batch_size=4)
+    engine_end = PatchEngine(desc, clean, cf, position="end")
+    engine_mid = PatchEngine(desc, clean, cf, position="mid", run_guards=False)
+    det_clean = build_attn_detail_cache(pipeline, desc, TEXTS_CLEAN, positions)
+    det_cf = build_attn_detail_cache(pipeline, desc, TEXTS_CF, positions)
+    kv = KVPatchEngine(engine_end, engine_mid, det_clean, det_cf, position_patch="mid")
+    return pipeline, desc, clean, cf, engine_end, kv
+
+
+class TestKVHeadMapping:
+    def test_query_heads_of_kv_partition(self):
+        model = _tiny_model("llama")  # 4 query heads, 2 kv heads
+        desc = resolve_descriptor(model)
+        assert desc.kv_group_size == 2
+        assert desc.query_heads_of_kv(0) == [0, 1]
+        assert desc.query_heads_of_kv(1) == [2, 3]
+        assert KVHead.for_query_head(desc, 1, 3) == KVHead(1, 1)
+
+    def test_mha_is_group_of_one(self):
+        desc = resolve_descriptor(_tiny_model("gpt2"))
+        assert desc.kv_group_size == 1
+        assert desc.query_heads_of_kv(5) == [5]
+
+
+@pytest.mark.parametrize("family", KV_FAMILIES)
+class TestKVEndToEnd:
+    def test_k1_guard_and_zero_delta_closure(
+        self, family, gpt2_tokenizer_pipeline_factory
+    ):
+        _, desc, clean, cf, engine_end, kv = _build_kv_engine(
+            family, gpt2_tokenizer_pipeline_factory
+        )
+        assert kv.guard_report["K1_z_reconstruction_clean"] <= 1e-4
+        # zero residual delta -> exactly zero trunk delta (any dtype)
+        edges = [KVEdge(KVHead(1, 0), patch_k=True, patch_v=True)]
+        zero = torch.zeros(clean.n_examples, desc.d_model)
+        d = kv.kv_trunk_delta(edges, zero)
+        assert torch.equal(d, torch.zeros_like(d))
+        logits = engine_end.patched_logits(d, PathSpec.cascade())
+        err = (logits - clean.logits["end"]).abs().max().item()
+        assert err <= 2e-3
+
+    def test_substitution_twin_agreement(self, family, gpt2_tokenizer_pipeline_factory):
+        pipeline, desc, clean, cf, engine_end, kv = _build_kv_engine(
+            family, gpt2_tokenizer_pipeline_factory
+        )
+        det_cf = kv.detail["cf"]
+        bidx = torch.arange(det_cf.n_examples)
+        p_cf = torch.tensor(det_cf.positions["mid"])
+        cases = [
+            KVEdge(KVHead(1, 0), patch_v=True),
+            KVEdge(KVHead(2, desc.n_kv_heads - 1), patch_k=True, patch_v=False),
+            KVEdge(KVHead(2, 0), patch_k=True, patch_v=True),
+        ]
+        for edge in cases:
+            analytic = engine_end.patched_logits(
+                kv.kv_trunk_delta([edge]), PathSpec.cascade()
+            )
+            L, j = edge.kv.layer, edge.kv.kv_index
+            payload = {
+                "k": det_cf.k_all[bidx, L, j, p_cf] if edge.patch_k else None,
+                "v": det_cf.v_all[bidx, L, j, p_cf] if edge.patch_v else None,
+                "position_index": PATCH_POS,
+            }
+            ref = reference_patched_logits(
+                pipeline,
+                desc,
+                TEXTS_CLEAN,
+                clean,
+                cf,
+                ("kv", L, j, payload),
+                PathSpec.cascade(),
+                engine=engine_end,
+            )
+            err = (analytic - ref).abs().max().item()
+            assert err <= 2e-3, (family, edge, err)
+
+    def test_rotation_negative_control(self, family, gpt2_tokenizer_pipeline_factory):
+        """A deliberately unrotated key delta must produce a different
+        trunk delta than the correct rotation on rotary families (and the
+        identical one on GPT-2, where rotation is identity). The comparison
+        is at the trunk-delta level: on tiny random models the downstream
+        logit effect of a single key patch can sit below any absolute
+        logit tolerance, which would make a logits-level control vacuous."""
+        _, desc, clean, cf, engine_end, kv = _build_kv_engine(
+            family, gpt2_tokenizer_pipeline_factory
+        )
+        edge = KVEdge(KVHead(2, 0), patch_k=True, patch_v=False)
+        d_correct = kv.kv_trunk_delta([edge])
+        d_wrong = kv.kv_trunk_delta([edge], rotate_key_delta=False)
+        scale = d_correct.abs().max().clamp_min(1e-12)
+        rel = ((d_correct - d_wrong).abs().max() / scale).item()
+        assert d_correct.abs().max() > 0, "key patch had no effect at all"
+        if desc.attention_style == "fused-qkv-absolute":
+            assert rel <= 1e-5, "rotation is identity on GPT-2; paths must agree"
+        else:
+            assert rel > 1e-2, (
+                "unrotated key delta matched the rotated one; the rotation "
+                "term has no teeth in this configuration"
+            )
+
+    def test_eager_contract_refused(self, family, gpt2_tokenizer_pipeline_factory):
+        pipeline = gpt2_tokenizer_pipeline_factory(_tiny_model(family))
+        pipeline.model.config._attn_implementation = "sdpa"
+        desc = resolve_descriptor(pipeline.model)
+        with pytest.raises(RuntimeError, match="attn_implementation"):
+            build_attn_detail_cache(
+                pipeline, desc, TEXTS_CLEAN, {"end": -1, "mid": PATCH_POS}
+            )
+
+
+def test_kv_refused_on_gpt_neox(gpt2_tokenizer_pipeline_factory):
+    """gpt_neox has no pyvene q/k/v units (fused per-head-interleaved QKV):
+    the K/V surface must refuse it by name, never fall back to hooks."""
+    pipeline = gpt2_tokenizer_pipeline_factory(_tiny_model("gpt_neox"))
+    desc = resolve_descriptor(pipeline.model)
+    with pytest.raises(UnsupportedArchitectureError, match="key_output"):
+        build_attn_detail_cache(
+            pipeline, desc, TEXTS_CLEAN, {"end": -1, "mid": PATCH_POS}
+        )
+
+
+def test_kv_fanout_is_confined_to_the_group(gpt2_tokenizer_pipeline_factory):
+    """Patching one KV head's value changes the reconstructed z of exactly
+    its query-head group (verified structurally on cached activations)."""
+    _, desc, clean, cf, engine_end, kv = _build_kv_engine(
+        "llama", gpt2_tokenizer_pipeline_factory
+    )
+    det = kv.detail["clean"]
+    layer, j = 1, 0
+    v_patched = det.v_all[:, layer].clone()
+    bidx = torch.arange(det.n_examples)
+    p = torch.tensor(det.positions["mid"])
+    v_patched[bidx, j, p] = v_patched[bidx, j, p] + 1.0
+    z_base = kv._z_from_qkv(
+        layer,
+        det.q["end"][:, layer],
+        det.k_all[:, layer],
+        det.v_all[:, layer],
+        "clean",
+    )
+    z_new = kv._z_from_qkv(
+        layer, det.q["end"][:, layer], det.k_all[:, layer], v_patched, "clean"
+    )
+    dz = (z_new - z_base).abs().amax(dim=(0, 2))  # per query head
+    group = set(desc.query_heads_of_kv(j))
+    for h in range(desc.n_heads):
+        if h in group:
+            assert dz[h] > 0, f"group head {h} unaffected"
+        else:
+            assert dz[h] == 0, f"non-group head {h} affected"
+
+
+def test_kv_sliding_window_refusal(gpt2_tokenizer_pipeline_factory):
+    """Gemma-2 sliding layers must refuse a patch position outside the
+    window and accept one inside; full-attention layers always accept."""
+    from transformers import Gemma2Config, Gemma2ForCausalLM
+
+    torch.manual_seed(0)
+    model = Gemma2ForCausalLM(
+        Gemma2Config(
+            num_hidden_layers=4,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            hidden_size=32,
+            head_dim=8,
+            intermediate_size=64,
+            vocab_size=TINY_VOCAB,
+            final_logit_softcapping=30.0,
+            attn_logit_softcapping=50.0,
+            max_position_embeddings=128,
+            sliding_window=4,
+        )
+    )
+    _, desc, clean, cf, engine_end, kv = _build_kv_engine(
+        "gemma2", gpt2_tokenizer_pipeline_factory, model=model
+    )
+    sliding = [li for li in range(4) if desc.attn_sliding_window(li) is not None]
+    full = [li for li in range(4) if desc.attn_sliding_window(li) is None]
+    assert sliding and full, "tiny config must mix sliding and full layers"
+    # the fixtures end >= 10 tokens after PATCH_POS=3, window is 4 -> refuse
+    with pytest.raises(SlidingWindowError, match=f"layer {sliding[0]}"):
+        kv.kv_trunk_delta([KVEdge(KVHead(sliding[0], 0))])
+    # a full-attention layer accepts the same edge
+    d = kv.kv_trunk_delta([KVEdge(KVHead(full[0], 0))])
+    assert torch.isfinite(d).all()

--- a/tests/test_methods/test_prepare_intervenable_inputs.py
+++ b/tests/test_methods/test_prepare_intervenable_inputs.py
@@ -66,8 +66,7 @@ class TestPrepareIntervenableInputs:
             for unit in units:
                 unit.index_component = MagicMock(
                     side_effect=lambda x, batch=False, is_original=None: [
-                        [0, 1],
-                        [0, 1],
+                        [0, 1] for _ in x
                     ]
                     if batch
                     else [0, 1]
@@ -131,8 +130,7 @@ class TestPrepareIntervenableInputs:
             for unit in units:
                 unit.index_component = MagicMock(
                     side_effect=lambda x, batch=False, is_original=None: [
-                        [0, 1],
-                        [0, 1],
+                        [0, 1] for _ in x
                     ]
                     if batch
                     else [0, 1]
@@ -237,8 +235,7 @@ class TestPrepareIntervenableInputs:
                 # IMPORTANT: use 'batch' as parameter name to match code
                 unit.index_component = MagicMock(
                     side_effect=lambda x, batch=False, is_original=None: [
-                        [0, 1],
-                        [0, 1],
+                        [0, 1] for _ in x
                     ]
                     if batch
                     else [0, 1]
@@ -323,8 +320,7 @@ class TestPrepareIntervenableInputs:
                 # CRITICAL FIX: Use 'batch' as parameter name to match function call
                 unit.index_component = MagicMock(
                     side_effect=lambda x, batch=False, is_original=None: [
-                        [0, 1],
-                        [0, 1],
+                        [0, 1] for _ in x
                     ]
                     if batch
                     else [0, 1]


### PR DESCRIPTION
## What this is

`causalab/methods/path_patching` computes **edge-level patched logits** in the freeze-recipe semantics of Hanna et al. (2023, "How does GPT-2 compute greater-than?"): replace a sender component's contribution along a named set of paths, with every off-path component frozen at its clean value. Instead of one intervened forward pass per patch, the engine reduces the recipe to delta arithmetic on cached activations plus direct re-evaluation of the receiver MLP branches and the model's own final norm + LM head — exact for pre-LN additive-trunk decoders, and hundreds of times cheaper for sweeps. Every engine verifies its architecture assumptions empirically at construction (guards G1–G4) and follows causalab's capability contract: supported iff pyvene's mapping has the needed units, no raw torch hooks anywhere (test-enforced).

## What's in the series (15 commits)

- **Engine**: architecture descriptor + activation caches + edge-set engine (`PathSpec`, `PathSpec.cascade`, `circuit_eval`), construction guards, provenance record.
- **Reference twin**: the same freeze recipe as live intervened forwards through pyvene — mechanistically independent of the cache arithmetic, used for validation.
- **K/V surface**: edges that end at a head's keys/values at a patched token position — rotary-correct key patching (pre-rotation capture, model-applied rotation), KV-head edge units under GQA, eager-attention contract, sliding-window check (Gemma-2), guard K1.
- **Coverage artifact + CI tests**: a committed pyvene coverage table regenerated in CI, so a pyvene pin bump surfaces as a table diff rather than a silent behavior change.
- **Docs**: `docs/path_patching.md`.

The commit history is preserved from the validated development branch (based on `bf15b353`, the current `main` tip).

## Validation (recorded evidence from the development runs)

- **GPT-2 anchor**: reproduces the greater-than circuit results of Hanna et al. (2023) at float precision. Engine-side iterative-path-patching sweeps match a hook-based replication cell-for-cell; K/V-side composition matches the paper's appendix analyses — all 243 Fig 12–13 sweep cells ≤ 4.2e-7, the 97 Fig 11 cells ≤ 1.6e-6, full-circuit probability difference ≤ 1.2e-7.
- **Four-family matrix**: GPT-2, Gemma-2-2B, Llama-3.1-8B in float32 + configured dtype — guard K1, zero-delta closure, twin agreement, rotation handling, GQA fan-out, sliding-window stress, eager refusal all pass (float32 twins agree ≤ 4.6e-5). Pythia-70m (gpt_neox) is refused by name per the capability policy.
- **Negative controls**: disabling key-delta rotation must (and does) disagree with the twin on rotary families; block-order misdeclaration tests prove the guards catch a lie.
- **bf16**: the K1 tolerance is a documented sanity bound with the floor measured; float32 proves the conventions.

GPU validation was not re-run for this PR; the recorded matrices from the development runs are the evidence (Goodfire-internal Silico experiments `exp_01kwwha8y8frfa40209vmm4emz` (engine) and `exp_01kwwqmxb4fz1rk41vzta81f2a` (K/V surface), which hold the validation JSONs and the durable branch artifact at `/mnt/data/artifacts/silico/causalab-path-patching/branch-v1`).

## Clean-checkout verification (this branch)

This PR leaves `pyproject.toml` and `uv.lock` untouched — no new dependencies; pyvene stays at the lockfile's existing `896a7dd4` pin. Fresh clone of this repo + this series, `uv sync --frozen` (torch 2.9.0, transformers 4.57.1):

- **`pytest -m "not gpu"`: 832 passed, 1 skipped** — the export itself matched the development branch's recorded run exactly (812 passed, 1 skipped; test-collection diff **identical, 794 = 794**: no test depended on the dropped task fixture), and follow-up commits (90b609e, d8dcfac) add 20 CPU regression tests for the attention-backend semantics and the fixed multi-position collect path below. The CI selection (`-m "not gpu and not slow"`) passes 813 with 1 skipped.
- **ruff (check + format): clean.** One indentation slip in the development series (an inserted kwarg at the wrong indent in 4 analysis files) was fixed in the commit that introduced it; the fixed files are byte-identical to ruff-format's output.
- **basedpyright**: the repo's pre-commit type-check hook currently reports 1,615 errors on `main` itself, so the hook is red for any PR. This branch reports 1,807; the +192 delta is entirely within the new files this PR adds (`causalab/methods/path_patching/*`, its tests, and `tests/test_attn_implementation_semantics.py`) and is the same error classes and density as the repo's existing code (predominantly missing parameter annotations and dynamic-typing noise in tests; the attention-semantics tests also read the private `_attn_implementation` attribute, which is the very thing they test). No new errors in any pre-existing file. Happy to annotate the new module if you'd like it held to a stricter bar than the surrounding code.
- **pyvene coverage artifact regenerates byte-identical** (also enforced as a test).

## Two standalone fixes included

Both are independently useful outside the method and can be split into separate PRs on request:

- **`attn_implementation` pass-through** (`causalab/neural/pipeline.py`): `LMPipeline(..., attn_implementation="eager")` forwards the attention backend to `from_pretrained`, which validates it at load and is consistent by construction — replacing the legacy post-load flip (`eager_attn=True`, i.e. `config._attn_implementation = "eager"` after loading). The flip happens to be self-consistent on transformers 4.57.1 for decoder-only models — kernel dispatch and `create_causal_mask` both read the live config at forward time, and we measured bit-identical float32 logits against load-time eager on tiny-random GPT-2 and Llama, unpadded and left-padded — but that correctness is an accident of transformers version and model family. On transformers 4.44.2 (torch 2.4.1+cpu) the attention module class is fixed at init, so the same flip leaves `GPT2SdpaAttention` running and logits bit-identical to the unflipped sdpa run: the flip changes nothing there. And even on 4.57.1, cross-attention models keep an init-frozen copy (`GPT2Model._attn_implementation`) that routes encoder-mask preparation down the sdpa branch after the flip — eager kernels receiving sdpa-format encoder masks (formats diverge; the values happen to be equivalent on 4.57.1). `tests/test_attn_implementation_semantics.py` pins these semantics on CPU with tiny-random models; the claim-by-claim verification is in the PR comment below. The K/V surface requires eager attention, so the method depends on this.
- **Multi-position collect fix** (`keep_last_dim`, applied in `causalab/methods/path_patching/cache.py`): pyvene's flatten/slice cycle silently corrupts collects of more than one position per example under causalab's single-unit wrapper — only the first `d` of the flattened row survives and the remainder unflattens into garbage. Setting pyvene's own documented `keep_last_dim` opt-out makes the slice a no-op at any position count. Related: left-padding index conversion (`causalab/neural/padding.py`, wired into `collect_features` and `prepare_intervenable_inputs`) so indexers' unpadded per-example coordinates are converted to the padded batch coordinates each batch was actually loaded with.

## Known limitations (documented in the method docs)

- Edges are atomic: "treeified" patching (different values per downstream branch) is out of scope for the cache-arithmetic engine.
- Per-query-head value expansion under GQA is deliberately not a default — `KVHead` is the edge unit (the causally separable object in the weights).
- gpt_neox (Pythia) is unsupported pending pyvene attention units for its fused QKV projection: construction raises `UnsupportedArchitectureError` naming the missing units.

## Not included

The development branch imported the greater-than task as a validation fixture; this PR ships **no replication-specific task code**. The docs use a generic worked example, with the Hanna et al. (2023) replication kept as a prose citation.


