### PR TITLE
Protocol: an "all positions" spelling for reads and writes

### DIFF
--- a/causalab/neural/pytorch_hooks/encoding.py
+++ b/causalab/neural/pytorch_hooks/encoding.py
@@ -18,6 +18,10 @@ Position rules implemented against this frame (spec §2.3, §6.1):
   value must occur exactly once in the row's text — zero or several
   occurrences refuse loudly rather than address the wrong tokens.
 * ``{"span": [a, b]}`` — the content-frame window ``[a, b)``.
+* ``{"all": true}`` — every content token of the row: past the left
+  padding and past any chat prefix, through the last real token. Rows of
+  different lengths make this ragged, which reads carry natively and the
+  v1 write path does not (see the executor's write refusal).
 * ``scope`` — the index/span interpreted inside the variable's token run;
   ``relative_to`` — an index offset from the run (``+1`` = first token
   after it, ``-1`` = last token before it; ``0`` is refused).
@@ -191,6 +195,11 @@ def resolve_position(
             raise ProtocolError("P2", "variable-anchored positions need a dataset row")
         anchor_value = variable_value(dataset_row, field, anchor_name)
         anchor_run = _variable_token_run(batch, row, anchor_value)
+
+    if spec.all is not None:
+        # content_start is already past the pad and any chat prefix; left
+        # padding right-aligns content, so the row runs to the padded end
+        return check(list(range(start, padded)))
 
     if spec.variable is not None:
         if dataset_row is None or field is None:

--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -423,7 +423,9 @@ class PointExecutor:
                 if len(widths) != 1:
                     raise NotImplementedError(
                         f"write {ename!r}: ragged position widths {sorted(widths)} "
-                        "are not batchable in the v1 reference backend"
+                        "are not batchable in the v1 reference backend — an "
+                        "all-positions or variable write needs every row to be "
+                        "the same length"
                     )
                 idx = torch.tensor(per_row, dtype=torch.long, device=tensor.device)
                 rows = torch.arange(tensor.shape[0], device=tensor.device).unsqueeze(1)

--- a/causalab/protocol/canonical.py
+++ b/causalab/protocol/canonical.py
@@ -3,8 +3,9 @@
 The authored file is for humans; the canonical form is the record. It
 materializes every default (optimizer betas, dtypes, the implicit
 ``revision``), every resolved reference (dataset content digests, artifact
-file hashes), every derived width, expands sugar (int positions, the
-``neural_model`` alias), sorts unordered lists (IM write lists), and rejects
+file hashes), every derived width, expands sugar (int and ``"all"``
+positions, the ``neural_model`` alias), sorts unordered lists (IM write
+lists), and rejects
 out-of-range addresses against the model's static config.
 
 ``digest = sha256(canonical bytes)`` with sorted keys and canonical floats —
@@ -38,6 +39,7 @@ from causalab.protocol.errors import ValidationError
 from causalab.protocol.registry import ModelInfo, component_width
 from causalab.protocol.resolve import ResolutionEnv
 from causalab.protocol.schema import (
+    ALL_POSITIONS,
     FEATURIZER_SLOTS,
     LAYERLESS_COMPONENTS,
     OPTIMIZER_DEFAULTS,
@@ -208,6 +210,8 @@ def _canon_write_list(writes: Any) -> Any:
 def _canon_position_spec(value: Any) -> Any:
     if isinstance(value, int) and not isinstance(value, bool):
         return {"index": value}  # §6.1 sugar
+    if value == ALL_POSITIONS:
+        return {"all": True}  # §6.1 sugar
     return value
 
 
@@ -254,10 +258,13 @@ def _canon_site(
 def _canon_read_or_edit(entry: Mapping[str, Any]) -> dict[str, Any]:
     out = dict(entry)
     if "pos" in out:
+        pos = out["pos"]
+        # a string pos is a positions-table name and stays one — except the
+        # reserved "all", which is sugar and expands like a bare int
         out["pos"] = (
-            out["pos"]
-            if isinstance(out["pos"], str)
-            else _canon_position_entry(out["pos"])  # sugar expands inside sweeps too
+            pos
+            if isinstance(pos, str) and pos != ALL_POSITIONS
+            else _canon_position_entry(pos)  # sugar expands inside sweeps too
         )
     return out
 

--- a/causalab/protocol/schema.py
+++ b/causalab/protocol/schema.py
@@ -14,9 +14,10 @@ Parsing owns the *shape* rules of the spec:
   (§5.1); closed enums reject with suggestions; derived fields (§6) may not
   be authored;
 * section order (§1) and the ``save``-last rule;
-* sugar — a bare int ``pos`` means ``{"index": n}`` (§2.3), ``neural_model``
-  is an alias of ``model`` (§2.1); sugar is expanded here, so the object
-  model only ever holds the canonical spelling;
+* sugar — a bare int ``pos`` means ``{"index": n}`` and the bare string
+  ``"all"`` means ``{"all": true}`` (§2.3), ``neural_model`` is an alias of
+  ``model`` (§2.1); sugar is expanded here, so the object model only ever
+  holds the canonical spelling;
 * the two value wrappers — ``{"sweep": …}`` (§3) and
   ``{"artifact": …, "key": …}`` (§1) — are accepted anywhere a scalar-,
   list- or spec-typed *leaf* is expected and preserved as
@@ -36,6 +37,7 @@ from typing import Any, Callable, Iterable, Literal, Mapping, Sequence, Union, g
 from causalab.protocol.errors import ParseError, ValidationError, suggest
 
 __all__ = [
+    "ALL_POSITIONS",
     "ArtifactRef",
     "COMPONENTS",
     "Component",
@@ -163,9 +165,16 @@ METRIC_FIELDS: dict[str, tuple[str, ...]] = {
     "match": ("expected",),
 }
 
+#: The bare-string spelling of an all-positions spec (§2.3 sugar). Reserved as
+#: a name so a ``positions`` entry can never shadow the sugar.
+ALL_POSITIONS: str = "all"
+
 #: Names no section may declare (§1): the input roles, the un-intervened
-#: model, and the indexed-counterfactual family (checked by prefix for ``counterfactual[``).
-RESERVED_NAMES: frozenset[str] = frozenset({"base", "counterfactual", "original"})
+#: model, the indexed-counterfactual family (checked by prefix for
+#: ``counterfactual[``), and the all-positions sugar.
+RESERVED_NAMES: frozenset[str] = frozenset(
+    {"base", "counterfactual", "original", ALL_POSITIONS}
+)
 
 #: Top-level sections in mandatory order (§1). ``neural_model`` is accepted
 #: at position 3 as an alias of ``model`` and canonicalizes away.
@@ -312,14 +321,16 @@ class DataRole:
 @dataclasses.dataclass(frozen=True)
 class PositionSpec:
     """§2.3 — a token-position spec. Exactly one of ``index`` / ``span`` /
-    ``variable`` is set; ``scope`` / ``relative_to`` (each a prompt-variable
-    name) only modify ``index``/``span`` and are mutually exclusive.
-    Positions are never resolved to integers in the document — resolution is
-    a backend service against a ``PositionFrame`` (§2.3, §8)."""
+    ``variable`` / ``all`` is set; ``scope`` / ``relative_to`` (each a
+    prompt-variable name) only modify ``index``/``span`` and are mutually
+    exclusive. ``all`` selects every content token of the row and takes no
+    modifiers. Positions are never resolved to integers in the document —
+    resolution is a backend service against a ``PositionFrame`` (§2.3, §8)."""
 
     index: Leaf | None = None
     span: Leaf | None = None
     variable: Leaf | None = None
+    all: Leaf | None = None
     scope: Leaf | None = None
     relative_to: Leaf | None = None
 
@@ -730,13 +741,23 @@ def _parse_data(raw: Any, path: str) -> dict[str, DataRole | tuple[DataRole, ...
 def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
     if isinstance(raw, int) and not isinstance(raw, bool):
         return PositionSpec(index=raw)  # §6.1 int sugar
+    if raw == ALL_POSITIONS:
+        return PositionSpec(all=True)  # §6.1 "all" sugar
     obj = _require_mapping(raw, path)
-    _check_keys(obj, ("index", "span", "variable", "scope", "relative_to"), path)
-    anchors = [k for k in ("index", "span", "variable") if k in obj]
+    _check_keys(obj, ("index", "span", "variable", "all", "scope", "relative_to"), path)
+    anchors = [k for k in ("index", "span", "variable", "all") if k in obj]
     if len(anchors) != 1:
         raise ParseError(
             "P2",
-            f"a position spec needs exactly one of index/span/variable, got {anchors}",
+            "a position spec needs exactly one of index/span/variable/all, got "
+            f"{anchors}",
+            path=path,
+        )
+    if "all" in obj and obj["all"] is not True:
+        raise ParseError(
+            "P2",
+            f'all is the flag {{"all": true}} — got {obj["all"]!r}; there is no '
+            "other all-positions selection to spell",
             path=path,
         )
     index = (
@@ -748,6 +769,7 @@ def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
         if "variable" in obj
         else None
     )
+    every = True if "all" in obj else None
     scope = (
         _wrapped(obj["scope"], _parse_var_ref, f"{path}.scope")
         if "scope" in obj
@@ -758,10 +780,12 @@ def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
         if "relative_to" in obj
         else None
     )
-    if (scope is not None or relative_to is not None) and variable is not None:
+    if (scope is not None or relative_to is not None) and (
+        variable is not None or every is not None
+    ):
         raise ParseError(
             "P2",
-            "scope/relative_to modify an index or span, not a variable spec",
+            "scope/relative_to modify an index or span, not a variable or all spec",
             path=path,
         )
     if scope is not None and relative_to is not None:
@@ -786,7 +810,12 @@ def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
                 "P2", f"scoped span [{lo}, {hi}) is statically empty", path=path
             )
     return PositionSpec(
-        index=index, span=span, variable=variable, scope=scope, relative_to=relative_to
+        index=index,
+        span=span,
+        variable=variable,
+        all=every,
+        scope=scope,
+        relative_to=relative_to,
     )
 
 
@@ -934,8 +963,10 @@ def _parse_params(raw: Any, path: str) -> dict[str, ParamSpec]:
 
 
 def _parse_pos_field(value: Any, path: str) -> Any:
-    """A read/write ``pos``: a positions-table name or an inline spec."""
-    if isinstance(value, str):
+    """A read/write ``pos``: a positions-table name or an inline spec. The
+    bare string ``"all"`` is the all-positions sugar, never a name — it is
+    reserved (§5.3), so no entry can be declared under it."""
+    if isinstance(value, str) and value != ALL_POSITIONS:
         return value
     return _parse_position_spec(value, path)
 

--- a/causalab/protocol/validate.py
+++ b/causalab/protocol/validate.py
@@ -16,7 +16,10 @@ Interpretations this module commits to (each surfaced in the PR notes):
   same sign, non-intersecting spans in the same frame, or two different
   prompt variables (template variables occupy disjoint spans). An index
   compared against a variable window is unknowable at load and treated as
-  overlapping — refuse-before-run rather than collide-at-run.
+  overlapping — refuse-before-run rather than collide-at-run. An
+  all-positions spec overlaps every other spec by construction, itself
+  included: it is never provably disjoint. Note the rules compare *writes*
+  only, so an all-positions read collides with nothing.
 * **Rules 8 and 9 compose.** Full-width writes have ``dims = all``. At one
   (site, overlapping pos, model) address: at most one full-width absolute
   write (rule 8), and no two *absolute* writes may intersect in dims
@@ -474,6 +477,8 @@ def _pos_key(doc: Document, pos: Any) -> PositionSpec:
 def _provably_disjoint(a: PositionSpec, b: PositionSpec) -> bool:
     """True when two position specs cannot address a common token on any row
     (see the module docstring for the conservative reading)."""
+    if a.all is not None or b.all is not None:
+        return False  # every content token — nothing is disjoint from it
     if a.scope != b.scope or a.relative_to != b.relative_to:
         return False  # different frames — incomparable, assume overlap
     if a.variable is not None and b.variable is not None:

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -72,15 +72,24 @@ Named entries; a read/write `pos` is a name here, or an inline spec.
 | form | resolves to |
 |---|---|
 | `-1` (bare int, sugar) | `{"index": -1}` |
+| `"all"` (bare string, sugar) | `{"all": true}` |
 | `{"index": n}` | one token per row. `n < 0` counts from the end of the sequence; `n ≥ 0` is rebased past any chat prefix |
 | `{"variable": "x"}` | all tokens of prompt variable `x` — a per-row window, ragged across rows |
 | `{"span": [a, b]}` | fixed window `[a, b)` |
+| `{"all": true}` | every content token of the row — ragged across rows |
 | + `"scope": {"variable": "x"}` | interpret the index/span inside `x`'s span |
 | + `"relative_to": {"variable": "x"}` | offset from `x`'s span |
 
 - Positions are **never resolved to integers in the document**. Resolution is
   a backend service against a `PositionFrame` (pad side, packing, sequence
   shard map) — sec. 8.
+- **`{"all": true}`** selects the row's real tokens only: padding is excluded,
+  and so is any chat prefix — the same frame `{"index": n}` uses for `n ≥ 0`.
+  It takes no `scope` or `relative_to` (there is nothing left to narrow), and
+  `all` is a reserved name, so `"pos": "all"` is always the sugar and never a
+  lookup in this table. Rows of unequal length make it ragged: reads carry
+  that natively, a write at `all` needs every row to be the same length in
+  v1.
 
 ### 2.4 `sites`
 
@@ -319,7 +328,8 @@ A conforming loader rejects the document unless all of these hold:
    suggestions. Derived fields (sec. 7) may not be authored.
 2. Section order per sec. 1; `save` last.
 3. Global namespace: no duplicate names across sections 6–13; no reserved
-   names (`base`, `counterfactual`, `counterfactual[j]`, `original`) declared.
+   names (`base`, `counterfactual`, `counterfactual[j]`, `original`, `all`)
+   declared.
 4. Every reference resolves: sites (declared inventory only), positions,
    featurizers, params, reads, writes, intervened_models, metrics.
 5. Reads: `model` ∈ `original` ∪ IMs; `input` a valid role; if `model` is an
@@ -373,8 +383,9 @@ A conforming loader rejects the document unless all of these hold:
 - **Canonical-stamp principle**: the authored file may be minimal; the
   canonical form materializes *everything* — every default (constant LR,
   optimizer betas, dtypes), every resolved reference (dataset digests,
-  artifact values), every derived width, sugar expanded (int positions,
-  alias `neural_model` → `model`), unordered lists sorted (IM write lists),
+  artifact values), every derived width, sugar expanded (int and `"all"`
+  positions, alias `neural_model` → `model`), unordered lists sorted (IM
+  write lists),
   sweeps expanded to points.
 - `digest = sha256(canonical bytes)` — sorted keys, canonical floats; each
   param replaced by its content hash. Document digest = campaign; point

--- a/docs/test_migration.md
+++ b/docs/test_migration.md
@@ -308,5 +308,9 @@ site tooling that hooks in via the CLI's `--points` shard selector.
   (`test_walking_skeleton.py`) need the dataset-serialization seam before a
   protocol document can drive a real task's counterfactual dataset.
 - **Dynamic per-row positions** — no v1 spelling; position specs resolve
-  statically per row (index / variable / span), with no per-row computed
+  statically per row (index / variable / span / all), with no per-row computed
   indexer.
+- **Per-position metric grids** — `{"all": true}` makes an every-token *read*
+  expressible, but metric lowering still reduces exactly one position per
+  example, so a logit-lens grid comes out as a saved tensor, not a metric
+  table. A per-position metric needs a `position` column in the metric table.

--- a/tests/golden/test_paper_goldens.py
+++ b/tests/golden/test_paper_goldens.py
@@ -185,7 +185,7 @@ def test_rome_hidden_state_aie_peak(tmp_path):
 
 
 def test_rome_mlp_window_aie_peak(tmp_path):
-    """Fig 2b: restore a 10-layer MLP window [l-4, l+5] (clipped) at the
+    """Fig 2b: restore a 10-layer MLP window [layer-4, layer+5] (clipped) at the
     last subject token in the corrupted run. Ten simultaneous swap sites
     cannot ride one sweep axis, so one document per window center is
     generated here (the parity-goldens build-doc-per-case pattern) —
@@ -198,7 +198,9 @@ def test_rome_mlp_window_aie_peak(tmp_path):
     aie: dict[int, list[pd.Series]] = {}
     for width in (2, 3, 4, 5):
         for center in centers:
-            layers = [l for l in range(center - 4, center + 6) if 0 <= l < 48]
+            layers = [
+                layer for layer in range(center - 4, center + 6) if 0 <= layer < 48
+            ]
             doc = {
                 "version": "1",
                 "description": f"generated: ROME MLP window restore, center {center}, width-{width} shard",
@@ -213,8 +215,8 @@ def test_rome_mlp_window_aie_peak(tmp_path):
                     "emb": {"component": "embeddings"},
                     "lm_head": {"component": "lm_head"},
                     **{
-                        f"mlp{l}": {"component": "mlp_output", "layer": l}
-                        for l in layers
+                        f"mlp{layer}": {"component": "mlp_output", "layer": layer}
+                        for layer in layers
                     },
                 },
                 "reads": {
@@ -231,13 +233,13 @@ def test_rome_mlp_window_aie_peak(tmp_path):
                         "input": "base",
                     },
                     **{
-                        f"v{l}": {
-                            "site": f"mlp{l}",
+                        f"v{layer}": {
+                            "site": f"mlp{layer}",
                             "pos": "last_subject",
                             "model": "original",
                             "input": "base",
                         }
-                        for l in layers
+                        for layer in layers
                     },
                 },
                 "writes": {
@@ -253,19 +255,19 @@ def test_rome_mlp_window_aie_peak(tmp_path):
                         },
                     },
                     **{
-                        f"rest{l}": {
-                            "site": f"mlp{l}",
+                        f"rest{layer}": {
+                            "site": f"mlp{layer}",
                             "pos": "last_subject",
-                            "do": {"swap": f"v{l}"},
+                            "do": {"swap": f"v{layer}"},
                         }
-                        for l in layers
+                        for layer in layers
                     },
                 },
                 "intervened_models": {
                     "corrupted": {"input": "base", "writes": ["noise"]},
                     "restored": {
                         "input": "base",
-                        "writes": ["noise"] + [f"rest{l}" for l in layers],
+                        "writes": ["noise"] + [f"rest{layer}" for layer in layers],
                     },
                 },
                 "metrics": {

--- a/tests/neural/pytorch_hooks/test_positions_frame.py
+++ b/tests/neural/pytorch_hooks/test_positions_frame.py
@@ -118,6 +118,39 @@ def test_span_is_a_content_frame_window(tokenizer):
     assert window == [start, start + 1]
 
 
+def test_all_is_every_content_token(tokenizer):
+    """``{"all": true}`` is the row's real tokens: contiguous from the row's
+    content start to the padded end, nothing under the left pad."""
+    batch = encode(tokenizer, ["one two three", "a much longer sentence right here"])
+    for row in range(2):
+        positions = resolve_position(PositionSpec(all=True), batch, row)
+        start = batch.content_start(row)
+        assert positions == list(range(start, batch.padded_len))
+        assert all(batch.attention_mask[row, p] == 1 for p in positions)
+    # the short row is genuinely shorter — the ragged case reads must carry
+    assert len(resolve_position(PositionSpec(all=True), batch, 0)) < len(
+        resolve_position(PositionSpec(all=True), batch, 1)
+    )
+
+
+def test_all_needs_no_dataset_row(tokenizer):
+    """Unlike a variable window, an all spec is frame-only — it resolves
+    without the dataset row, which is what makes it usable in any document."""
+    batch = encode(tokenizer, ["one two three"])
+    positions = resolve_position(PositionSpec(all=True), batch, 0)
+    assert positions == list(range(batch.content_start(0), batch.padded_len))
+
+
+def test_all_covers_the_index_forms(tokenizer):
+    """The endpoints agree with the index spellings they generalize."""
+    batch = encode(tokenizer, ["one two three", "a much longer sentence right here"])
+    for row in range(2):
+        positions = resolve_position(PositionSpec(all=True), batch, row)
+        (first,) = resolve_position(PositionSpec(index=0), batch, row)
+        (last,) = resolve_position(PositionSpec(index=-1), batch, row)
+        assert positions[0] == first and positions[-1] == last
+
+
 def test_out_of_bounds_refuses(tokenizer):
     batch = encode(tokenizer, ["one two three"])
     with pytest.raises(ProtocolError) as err:

--- a/tests/neural/pytorch_hooks/test_read_oracle.py
+++ b/tests/neural/pytorch_hooks/test_read_oracle.py
@@ -237,3 +237,138 @@ def test_variable_position_reads_the_substring_tokens(llama_bundle):
     value = executor.read_value("r")
     embeddings = llama_bundle.model.model.embed_tokens(batch.input_ids)
     torch.testing.assert_close(value[:, :, :], embeddings[:, positions, :], **TOL)
+
+
+# --------------------------------------------------------------------------- #
+#  all positions — the (layer × position) read grid                            #
+# --------------------------------------------------------------------------- #
+
+
+def logit_lens_grid_doc() -> dict:
+    """The grid the all spelling exists for: the residual stream at every
+    layer (the sweep axis) × every token (the all spec), alongside the
+    model's own logits at every token."""
+    return {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=False),
+        "sites": {
+            "resid": {"component": "block_output", "layer": {"sweep": [0, 1]}},
+            "lm_head": {"component": "lm_head"},
+        },
+        "reads": {
+            "r_resid": {
+                "site": "resid",
+                "pos": "all",  # bare-string sugar
+                "model": "original",
+                "input": "base",
+            },
+            "r_logits": {
+                "site": "lm_head",
+                "pos": {"all": True},  # the explicit anchor
+                "model": "original",
+                "input": "base",
+            },
+        },
+        "save": [
+            {
+                "value": "r_resid",
+                "model": "original",
+                "input": "base",
+                "file_path": "resid.safetensors",
+            },
+            {
+                "value": "r_logits",
+                "model": "original",
+                "input": "base",
+                "file_path": "logits.safetensors",
+            },
+        ],
+    }
+
+
+def test_all_positions_grid_matches_oracle(bundle, oracle: OracleShim):
+    """Every point of the swept grid loads, validates, executes, and the
+    read is the oracle's full-sequence capture — not just its last column."""
+    from causalab.protocol.sweep import expand
+
+    from tests.protocol._docs import in_order
+
+    expansion = expand(in_order(logit_lens_grid_doc()))
+    assert len(expansion.points) == 2  # one per layer
+
+    inputs = _inputs(bundle)
+    seq = int(inputs["input_ids"].shape[1])
+    for point in expansion.points:
+        layer = point.raw["sites"]["resid"]["layer"]
+        executor = executor_for(point.raw, bundle, base_texts=[BASE_TEXT])
+        have = executor.read_value("r_resid")
+        want = oracle_lib.capture_residual(oracle, layer, inputs)
+        assert have.shape[1] == seq  # every position, not the last one
+        torch.testing.assert_close(have, want, **TOL)
+
+    # anti-vacuity: the two layers genuinely differ
+    l0 = oracle_lib.capture_residual(oracle, 0, inputs)
+    l1 = oracle_lib.capture_residual(oracle, 1, inputs)
+    assert not torch.allclose(l0, l1, atol=1e-4)
+
+
+def test_all_positions_lm_head_matches_the_models_logits(bundle):
+    """The other half of a logit lens: the whole logit sequence, not the
+    single next-token column every other read takes."""
+    from causalab.protocol.sweep import expand
+
+    from tests.protocol._docs import in_order
+
+    point = expand(in_order(logit_lens_grid_doc())).points[0]
+    executor = executor_for(point.raw, bundle, base_texts=[BASE_TEXT])
+    have = executor.read_value("r_logits")
+    with torch.no_grad():
+        want = bundle.model(**_inputs(bundle)).logits
+    torch.testing.assert_close(have, want, **TOL)
+
+
+def test_all_positions_is_ragged_across_rows(llama_bundle):
+    """Rows of different lengths make an all read ragged; the flat gather
+    and its widths are the row-wise captures, padding excluded."""
+    from causalab.neural.pytorch_hooks.executor import RaggedValue
+
+    texts = ["one two three", "a much longer sentence right here"]
+    doc = {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=False),
+        "sites": {"emb": {"component": "embeddings"}},
+        "reads": {
+            "r": {"site": "emb", "pos": "all", "model": "original", "input": "base"}
+        },
+        "save": [
+            {
+                "value": "r",
+                "model": "original",
+                "input": "base",
+                "file_path": "r.safetensors",
+            }
+        ],
+    }
+    executor = executor_for(doc, llama_bundle, base_texts=texts)
+    value = executor.read_value("r")
+    assert isinstance(value, RaggedValue)
+
+    batch = encode(llama_bundle.tokenizer, texts)
+    widths = tuple(
+        batch.padded_len - batch.content_start(row) for row in range(len(texts))
+    )
+    assert value.widths == widths
+    assert widths[0] != widths[1]  # the ragged case is real, not incidental
+
+    embeddings = llama_bundle.model.model.embed_tokens(batch.input_ids)
+    offset = 0
+    for row, width in enumerate(widths):
+        start = batch.content_start(row)
+        torch.testing.assert_close(
+            value.flat[offset : offset + width],
+            embeddings[row, start : start + width, :],
+            **TOL,
+        )
+        offset += width

--- a/tests/neural/pytorch_hooks/test_write_oracle.py
+++ b/tests/neural/pytorch_hooks/test_write_oracle.py
@@ -416,3 +416,75 @@ def test_composed_chain_sizes_stages_by_chain_width(llama_bundle):
     clean = oracle_lib.next_token_logits(shim, base_inputs)
     assert not torch.allclose(want, clean, atol=1e-4)  # non-vacuity
     torch.testing.assert_close(have, want, **TOL)
+
+
+# --------------------------------------------------------------------------- #
+#  all positions — writes                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def zero_ablate_all_doc() -> dict:
+    """Zero-ablate a whole layer: the write case the all spelling makes
+    expressible without naming every index."""
+    return {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=False),
+        "sites": {
+            "tgt": {"component": "block_output", "layer": 0},
+            "lm_head": {"component": "lm_head"},
+        },
+        "reads": {
+            "logits": {
+                "site": "lm_head",
+                "pos": {"index": -1},
+                "model": "ablated",
+                "input": "base",
+            }
+        },
+        "writes": {"zero": {"site": "tgt", "pos": "all", "do": {"swap": 0.0}}},
+        "intervened_models": {"ablated": {"input": "base", "writes": ["zero"]}},
+        "save": [
+            {
+                "value": "logits",
+                "model": "ablated",
+                "input": "base",
+                "file_path": "l.safetensors",
+            }
+        ],
+    }
+
+
+def test_all_positions_write_matches_oracle(bundle, oracle: OracleShim):
+    """An all-positions swap writes every content token — the oracle patch
+    covers the whole sequence, and the result differs from clean."""
+    executor = executor_for(zero_ablate_all_doc(), bundle, base_texts=[BASE_TEXT])
+    have = executor.read_value("logits")[:, 0, :]
+
+    base_inputs = _inputs(bundle, BASE_TEXT)
+    seq = int(base_inputs["input_ids"].shape[1])
+    resid = oracle_lib.capture_residual(oracle, 0, base_inputs)
+    want = oracle_lib.next_token_logits(
+        oracle,
+        base_inputs,
+        layer=0,
+        positions=list(range(seq)),
+        patch_values=torch.zeros_like(resid),
+    )
+    clean = oracle_lib.next_token_logits(oracle, base_inputs)
+    assert not torch.allclose(want, clean, atol=1e-4)  # non-vacuity
+    torch.testing.assert_close(have, want, **TOL)
+
+
+def test_ragged_all_positions_write_refuses(llama_bundle):
+    """The documented v1 limit (spec §2.3): rows of unequal length make an
+    all write ragged, which the reference backend refuses rather than
+    silently writing a rectangle over the padding."""
+    texts = ["one two", "a much longer sentence right here indeed and then some more"]
+    batch = encode(llama_bundle.tokenizer, texts)
+    assert batch.content_start(0) != batch.content_start(1)  # genuinely ragged
+
+    executor = executor_for(zero_ablate_all_doc(), llama_bundle, base_texts=texts)
+    with pytest.raises(NotImplementedError) as err:
+        executor.read_value("logits")
+    assert "all-positions" in str(err.value)

--- a/tests/protocol/test_canonical.py
+++ b/tests/protocol/test_canonical.py
@@ -20,6 +20,23 @@ def test_pos_sugar_and_alias_canonicalize(env):
     assert canonical["model"] == {"key": "gpt2", "revision": "main"}
 
 
+def test_all_pos_sugar_canonicalizes(env):
+    """Both spellings land on one canonical form, so a document authored
+    either way digests identically."""
+    sugar, explicit = base_doc(), base_doc()
+    sugar["reads"]["v_cf"]["pos"] = "all"
+    explicit["reads"]["v_cf"]["pos"] = {"all": True}
+    assert canonicalize(sugar, env)["reads"]["v_cf"]["pos"] == {"all": True}
+    assert digest(canonicalize(sugar, env)) == digest(canonicalize(explicit, env))
+
+
+def test_all_positions_changes_the_digest(env):
+    """The position is part of the address, so it is part of the record."""
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = "all"
+    assert digest(canonicalize(raw, env)) != digest(canonicalize(base_doc(), env))
+
+
 def test_dataset_digest_stamped(env):
     canonical = canonicalize(base_doc(), env)
     stamped = canonical["data"]["base"]["digest"]

--- a/tests/protocol/test_schema.py
+++ b/tests/protocol/test_schema.py
@@ -75,6 +75,47 @@ def test_position_spec_needs_exactly_one_anchor():
         parse_document(in_order(raw))
 
 
+def test_all_pos_sugar_expands():
+    """The bare string ``"all"`` is the all-positions sugar, not a lookup in
+    the positions table (§2.3)."""
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = "all"
+    pos = parse_document(raw).reads["v_cf"].pos
+    assert isinstance(pos, PositionSpec) and pos.all is True
+
+
+def test_all_anchor_parses_inline():
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"all": True}
+    pos = parse_document(raw).reads["v_cf"].pos
+    assert isinstance(pos, PositionSpec) and pos.all is True and pos.index is None
+
+
+def test_all_is_exclusive_with_the_other_anchors():
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"all": True, "index": -1}
+    with pytest.raises(ParseError):
+        parse_document(raw)
+
+
+@pytest.mark.parametrize("modifier", ["scope", "relative_to"])
+def test_all_takes_no_modifier(modifier):
+    """``scope``/``relative_to`` narrow an index or span; there is nothing
+    left to narrow inside "every token"."""
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"all": True, modifier: {"variable": "subject"}}
+    with pytest.raises(ParseError):
+        parse_document(raw)
+
+
+def test_all_is_a_flag_not_a_selection():
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"all": [0, 1]}
+    with pytest.raises(ParseError) as err:
+        parse_document(raw)
+    assert "all" in str(err.value)
+
+
 def test_layerless_component_rejects_layer():
     raw = base_doc()
     raw["sites"]["lm_head"]["layer"] = 0

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -118,6 +118,14 @@ def test_rule_3_reserved_name():
     expect_rule(3, doc)
 
 
+def test_rule_3_all_is_reserved():
+    """A positions entry named ``all`` would shadow the bare-string sugar,
+    so the name is reserved outright (§5.3)."""
+    doc = base_doc()
+    doc["positions"] = {"all": {"index": -1}}
+    expect_rule(3, doc)
+
+
 # rule 4 — every reference resolves ------------------------------------------- #
 
 
@@ -190,6 +198,60 @@ def test_rule_8_two_absolute_writes_same_address():
     doc["writes"]["patch2"] = {"site": "tgt", "pos": -1, "do": {"swap": "v_cf"}}
     doc["intervened_models"]["patched"]["writes"].append("patch2")
     expect_rule(8, doc)
+
+
+def test_rule_8_all_positions_overlaps_everything():
+    """An all-positions write covers every token, so it is never provably
+    disjoint from another write at the same site — including one pinned to a
+    single index."""
+    doc = base_doc()
+    doc["writes"]["patch_all"] = {
+        "site": "tgt",
+        "pos": {"all": True},
+        "do": {"swap": "v_cf"},
+    }
+    doc["intervened_models"]["patched"]["writes"].append("patch_all")
+    expect_rule(8, doc)
+
+
+def test_rule_8_all_positions_overlaps_itself():
+    doc = base_doc()
+    doc["writes"]["patch"]["pos"] = "all"
+    doc["writes"]["patch_all"] = {
+        "site": "tgt",
+        "pos": "all",
+        "do": {"swap": "v_cf"},
+    }
+    doc["intervened_models"]["patched"]["writes"].append("patch_all")
+    expect_rule(8, doc)
+
+
+def test_rule_8_all_positions_absolute_plus_additive_composes():
+    """The mechanism-class order (§2.8) still applies at an all address —
+    overlap only forbids a *second absolute* write."""
+    doc = base_doc()
+    doc["writes"]["patch"]["pos"] = "all"
+    doc["writes"]["nudge"] = {
+        "site": "tgt",
+        "pos": "all",
+        "do": {"add_scaled": {"op": "v_cf", "alpha": 0.5}},
+    }
+    doc["intervened_models"]["patched"]["writes"].append("nudge")
+    parse_and_validate(doc)
+
+
+def test_rule_9_all_positions_dims_must_be_disjoint():
+    """Rule 9 composes with the all spelling exactly as it does elsewhere."""
+    doc = base_doc()
+    doc["writes"]["patch"]["dims"] = [0, 1]
+    doc["writes"]["patch_all"] = {
+        "site": "tgt",
+        "pos": "all",
+        "dims": [1, 2],
+        "do": {"swap": "v_cf"},
+    }
+    doc["intervened_models"]["patched"]["writes"].append("patch_all")
+    expect_rule(9, doc)
 
 
 def test_rule_8_additive_write_composes():


### PR DESCRIPTION
Closes #22. **Stacked on #20** — base is `can/protocol-refactor`, so the diff
here is only the all-positions work; review #20 first.

## What

Spec question 6 from #20: there was no way to say "read (or write) at every
token position", so a logit-lens (layer × position) grid had no position axis.

`{"all": true}` becomes a fourth position anchor, with the bare string `"all"`
as sugar exactly the way a bare int is sugar for `{"index": n}`:

```json
"reads": {"r": {"site": "resid", "pos": "all",        "model": "original", "input": "base"}}
"reads": {"r": {"site": "resid", "pos": {"all": true}, "model": "original", "input": "base"}}
```

`all` joins the reserved names, so a `positions` entry can never shadow the
sugar and `"pos": "all"` is never a table lookup. There is no need to declare
the spec in the `positions` table — it takes no parameters, and rule 11 would
report an unreferenced entry as a dead declaration anyway.

**Semantics.** Per row, the content tokens only: past the left padding and past
any chat prefix — the same frame `{"index": n}` uses for `n ≥ 0`. `scope` and
`relative_to` are refused (they narrow an index or span; there is nothing left
to narrow inside "every token").

## Three findings that shaped the diff

1. **The ragged machinery already existed.** `{"variable": …}` is already
   ragged, so `_gather`/`RaggedValue` and the flat+`.widths` save path carry an
   all-positions read end to end with no new plumbing.
2. **The overlap worry does not materialize.** Rules 8/9 compare *writes*, so an
   all-positions read collides with nothing — reads and edits need no separate
   overlap rules. For writes, `_provably_disjoint` now returns `False` for an
   `all` spec explicitly rather than by fallthrough, so rule 8 refuses a second
   absolute write at that address and rule 9's dims disjointness composes
   unchanged.
3. **Digests are untouched.** `canonicalize` walks the raw tree, so the new
   optional field changes no existing document's canonical form —
   `tests/protocol/corpus_digests.json` is unchanged by this PR, which is
   asserted by the existing corpus test.

## Diff

| file | change |
|---|---|
| `causalab/protocol/schema.py` | the `all` anchor, its exclusivity + flag-shape refusals, the `"all"` sugar, `ALL_POSITIONS` in `RESERVED_NAMES` |
| `causalab/protocol/canonical.py` | `"all"` expands to `{"all": true}` — in the positions table and on a read/write `pos`, where a string is otherwise a name |
| `causalab/neural/pytorch_hooks/encoding.py` | resolution: `range(content_start(row), padded_len)` |
| `causalab/protocol/validate.py` | `all` is never provably disjoint (explicit, commented, tested) |
| `causalab/neural/pytorch_hooks/executor.py` | the existing ragged-write refusal now names the case |
| `docs/intervention_protocol.md` | §2.3 table rows, the pad/chat-prefix sentence, reserved names in rule 3, sugar in the canonical-stamp principle |
| `docs/test_migration.md` | the metric-grid limit below, recorded in the coverage-gap ledger |

## Tests (+13)

- **Frame** (`test_positions_frame.py`): `all` is each row's unmasked tokens,
  contiguous; endpoints agree with `{"index": 0}` and `{"index": -1}`; it needs
  no dataset row.
- **Oracle** (`test_read_oracle.py`): the acceptance case — a swept
  (layer × all-positions) grid document loads, validates, executes, and every
  point matches `capture_residual`'s *full sequence*, with an anti-vacuity check
  that the layers differ; an all-positions `lm_head` read equals the model's own
  logit sequence; a two-row ragged read matches the per-row captures with
  padding excluded.
- **Writes** (`test_write_oracle.py`): a zero-ablation at `all` matches a
  hand-hooked whole-sequence patch (non-vacuous vs clean); the ragged case
  refuses.
- **Rules** (`test_validation_rules.py`): `all` is reserved (rule 3); it
  overlaps a single index and itself (rule 8); absolute + additive still
  composes at an all address; dims must still be disjoint (rule 9).
- **Schema / canonical**: both spellings parse and digest identically; a
  second anchor, a modifier, a non-`true` value, and a shadowing name each
  refuse.

`uv run pytest -m "not golden"`: **1435 passed**. `ruff format` clean;
`ruff check` unchanged from base (the 5 pre-existing E741s in a test file);
basedpyright reports 0 errors in `causalab/`.

## Known limit (not fixed here, recorded in the docs)

Metric lowering still reduces exactly one position per example, so a logit lens
authored this way comes out as a **saved tensor, not a metric table**. A
per-position metric grid needs a metric-domain change plus a `position` column
in the metric parquet — separate work, and it is now written into
`docs/test_migration.md`'s gap ledger rather than left implicit.

A write at `all` over rows of unequal length also still refuses in the v1
reference backend (uniform-length rows work). A masked write path is follow-up
work.

## CI

`lint` and `test` are green. The lint gate needed a second commit: the base
branch carries five `E741`s in `tests/golden/test_paper_goldens.py` that
`pre-commit`'s auto-fix step cannot repair, so every branch stacked on
`can/protocol-refactor` inherits a red lint job — and because the job checks out
`pull_request.head.sha` rather than the merge ref, fixing it only in the shared
base would not clear it here. The fix is a pure rename of the loop variable `l`
to `layer`; the interpolated site/read/write names are unchanged, so no
document, digest or pin moves. **The sibling stacks need the same commit.**

`claude-review` fails with `is_error: true` after one turn, ~2s and $0 cost —
the same signature on every PR in this repo where it actually runs (`#27`,
`can/dataset-seam`, `can/tensor-bundle-entries`). It is an action-side auth or
quota failure, unrelated to this diff and not fixable from the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
