### PR TITLE
Thread train.seed into the subspace featurizer init

### DIFF
--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -51,10 +51,28 @@ from causalab.protocol.errors import ProtocolError
 from causalab.protocol.registry import component_width
 from causalab.protocol.schema import Document, WriteSpec, PositionSpec, ReadSpec
 
-__all__ = ["PointExecutor", "RaggedValue"]
+__all__ = ["PointExecutor", "RaggedValue", "document_seed"]
 
 
 import dataclasses
+
+
+def document_seed(doc: Document) -> int:
+    """The one seed a document implies: ``train.seed``, or **0** when it
+    declares no fit.
+
+    Read in one place so the three consumers cannot drift apart: the
+    ``subspace`` featurizer's initial rotation (:func:`build_stack`),
+    ``torch.manual_seed`` at train-loop entry, and the batch-order RNG.
+
+    The 0 for a document with no ``train`` block is deliberate rather than
+    accidental: an apply/inference document has no seed to name, and pinning
+    it means the same document builds the same (unfitted) featurizer whether
+    or not a fit is running — which a global-RNG init could not promise."""
+    train = doc.train
+    if train is None:
+        return 0
+    return int(train.seed) if isinstance(train.seed, int) else 0
 
 
 @dataclasses.dataclass(frozen=True)
@@ -98,6 +116,9 @@ class PointExecutor:
             stage_cache if stage_cache is not None else {}
         )
         self.grad_enabled = grad_enabled
+        # the seed every freshly built featurizer initialises from; the stage
+        # cache is keyed by name alone, so it belongs to this one point
+        self.seed = document_seed(doc)
         self._read_values: dict[str, torch.Tensor | RaggedValue] = {}
         self._groups_run: set[tuple[str, str]] = set()
         self._batches: dict[str, EncodedBatch] = {}
@@ -141,6 +162,7 @@ class PointExecutor:
                 load_tensors=self.load_tensors,
                 stage_cache=self.stage_cache,
                 device=self.bundle.device,
+                seed=self.seed,
             )
         return self.stage_cache[name]
 
@@ -317,6 +339,7 @@ class PointExecutor:
             load_tensors=self.load_tensors,
             stage_cache=self.stage_cache,
             device=self.bundle.device,
+            seed=self.seed,
         )
 
     def _finalize_read(

--- a/causalab/neural/pytorch_hooks/featurizers.py
+++ b/causalab/neural/pytorch_hooks/featurizers.py
@@ -27,6 +27,16 @@ tensors that arrive from files on CPU and are moved by the same step.
 Dtype is deliberately *not* forced: every stage casts at the boundary
 (``x.to(q.dtype)``, ``mask.to(x.dtype)``), so featurizers stay fp32 against
 a bf16/fp16 backbone.
+
+**Seed.** ``subspace`` is the only kind with a random initialisation, and it
+draws from a *local* ``torch.Generator`` rather than the global RNG, so its
+starting rotation cannot depend on how many stages were built before it or on
+whether a train loop ran at all. The value comes down the ``seed`` argument of
+:func:`build_stack` — the caller resolves it (the executor reads the
+document's ``train.seed``, and pins 0 for a document with no fit) — because
+``build_stack`` is also called from apply/inference paths that never touch the
+global RNG. ``gate`` initialises ``θ`` to zeros and every other kind loads its
+tensors from a file, so nothing else here is seed-sensitive.
 """
 
 from __future__ import annotations
@@ -66,7 +76,11 @@ class Identity(Stage):
 
 class Subspace(Stage):
     """An orthonormal ``(d, k)`` map ``Q``; features are the coordinates in
-    its column space, ``err`` the complement (module docstring)."""
+    its column space, ``err`` the complement (module docstring).
+
+    ``seed`` picks the initial rotation and is kept on the instance so a
+    cached stage can be checked against the seed a later use site asks for
+    (:func:`build_stack`)."""
 
     kind = "subspace"
 
@@ -75,6 +89,7 @@ class Subspace(Stage):
     ) -> None:
         super().__init__()
         self.k = k
+        self.seed = seed
         generator = torch.Generator().manual_seed(seed)
         init = torch.linalg.qr(torch.randn(width, k, generator=generator))[0]
         self.weight = torch.nn.Parameter(init)
@@ -272,6 +287,7 @@ def build_stack(
     load_tensors: Any,
     stage_cache: dict[str, Stage],
     device: str | torch.device = "cpu",
+    seed: int = 0,
 ) -> FeaturizerStack:
     """Build (or reuse from ``stage_cache``) the stack a read/write
     references. ``width`` is the SITE width; each later stage in a
@@ -284,7 +300,16 @@ def build_stack(
     ``device`` is the run's device: stages are built on CPU and moved here
     (module docstring), so a ``--device cuda`` run does not multiply a cuda
     activation by a cpu parameter. Callers pass ``bundle.device``; the
-    ``"cpu"`` default keeps the CPU-only call sites unchanged."""
+    ``"cpu"`` default keeps the CPU-only call sites unchanged.
+
+    ``seed`` is the document's featurizer-init seed (``train.seed``, 0 when
+    the document declares no fit — see ``executor.document_seed``). It is an
+    explicit argument rather than a read of the global RNG because this
+    function also runs on apply/inference paths that never seed the global
+    stream; a global-RNG init would make a rotation depend on construction
+    order. Because the cache is keyed by name alone, a cached stage built
+    from a *different* seed is a contradiction and refuses — the same rule as
+    the width check."""
     if ref is None:
         return FeaturizerStack(names=(), stages=(Identity(),))
     chain = (ref,) if isinstance(ref, str) else tuple(ref)
@@ -301,6 +326,15 @@ def build_stack(
                     f"featurizer {name!r} is used at width {running} here but was "
                     f"built for width {built_for} — one featurizer, one width",
                 )
+            built_seed = getattr(stage, "seed", None)
+            if built_seed is not None and built_seed != seed:
+                raise ProtocolError(
+                    "P2",
+                    f"featurizer {name!r} is used at init seed {seed} here but the "
+                    f"cached stage was initialised from seed {built_seed} — one "
+                    "featurizer, one seed; a stage cache belongs to one point, so "
+                    "two points differing in train.seed must not share one",
+                )
         else:
             if running is None:
                 raise ProtocolError(
@@ -308,7 +342,9 @@ def build_stack(
                     f"cannot size featurizer {name!r}: the preceding stage's "
                     "output width is not derivable from its spec",
                 )
-            stage = _build_stage(name, spec, width=running, load_tensors=load_tensors)
+            stage = _build_stage(
+                name, spec, width=running, load_tensors=load_tensors, seed=seed
+            )
             # built on CPU (seeded inits stay bit-identical across devices),
             # then moved onto the run's device — parameters and registered
             # buffers alike, so nothing is left behind for a cuda forward to
@@ -327,7 +363,7 @@ def build_stack(
 
 
 def _build_stage(
-    name: str, spec: FeaturizerSpec, *, width: int, load_tensors: Any
+    name: str, spec: FeaturizerSpec, *, width: int, load_tensors: Any, seed: int = 0
 ) -> Stage:
     kind = spec.kind if isinstance(spec.kind, str) else "identity"
     if isinstance(spec.file_path, str):
@@ -352,8 +388,9 @@ def _build_stage(
         )
         if k is None:
             raise ProtocolError("P2", f"subspace featurizer {name!r} needs k")
-        return Subspace(width, k, parametrization)
+        return Subspace(width, k, parametrization, seed=seed)
     if kind == "gate":
+        # θ starts at zeros — no draw, so nothing for `seed` to influence
         return Gate(width)
     raise ProtocolError(
         "P2",

--- a/causalab/neural/pytorch_hooks/train.py
+++ b/causalab/neural/pytorch_hooks/train.py
@@ -4,10 +4,15 @@ backend owns the loop.
 Semantics implemented exactly as declared — none of the legacy loop's
 ambient state survives:
 
-* ``seed`` drives featurizer init, data order, and every draw
-  (``torch.manual_seed`` at loop entry — the one deliberate use of the
-  global RNG, so a ``{"sweep": [0,1,2]}`` on ``seed`` yields three
-  genuinely different fits);
+* ``seed`` drives featurizer init, data order, and every draw, so a
+  ``{"sweep": [0,1,2]}`` on ``seed`` yields three genuinely different fits.
+  Init reaches the featurizer as an explicit argument (``executor.seed`` →
+  ``build_stack(seed=…)``, a *local* generator) rather than through the
+  global RNG, because the same construction runs on apply paths where no
+  loop entry ever executes; the batch order has its own local ``order_rng``;
+  ``torch.manual_seed`` at loop entry — the one deliberate use of the global
+  RNG — covers everything else that draws (dropout, and torch's own
+  orthogonal-parametrization basis);
 * ``objective`` terms are differentiable metric tensors plus regularizers
   (``l1``/``l2`` over a featurizer's params; a ``gate``'s l1 is the mean
   soft mask — the DBM sparsity semantics);
@@ -29,7 +34,7 @@ from typing import Any, Mapping
 
 import torch
 
-from causalab.neural.pytorch_hooks.executor import PointExecutor
+from causalab.neural.pytorch_hooks.executor import PointExecutor, document_seed
 from causalab.neural.pytorch_hooks.featurizers import Gate, Stage
 from causalab.neural.pytorch_hooks.metrics import column_token_ids
 from causalab.protocol.backend import ExecutionRequest
@@ -124,7 +129,9 @@ def run_training(
     it later evaluates are the fitted ones."""
     train = doc.train
     assert train is not None
-    seed = int(train.seed) if isinstance(train.seed, int) else 0
+    # one reader of train.seed, shared with the featurizer inits the executor
+    # builds below — the loop and the init cannot disagree about the seed
+    seed = document_seed(doc)
     torch.manual_seed(seed)
 
     trained_names = sorted({p.split(".", 1)[0] for p in train.params})

--- a/tests/golden/test_paper_goldens.py
+++ b/tests/golden/test_paper_goldens.py
@@ -198,7 +198,7 @@ def test_rome_mlp_window_aie_peak(tmp_path):
     aie: dict[int, list[pd.Series]] = {}
     for width in (2, 3, 4, 5):
         for center in centers:
-            layers = [l for l in range(center - 4, center + 6) if 0 <= l < 48]
+            layers = [i for i in range(center - 4, center + 6) if 0 <= i < 48]
             doc = {
                 "version": "1",
                 "description": f"generated: ROME MLP window restore, center {center}, width-{width} shard",
@@ -213,8 +213,8 @@ def test_rome_mlp_window_aie_peak(tmp_path):
                     "emb": {"component": "embeddings"},
                     "lm_head": {"component": "lm_head"},
                     **{
-                        f"mlp{l}": {"component": "mlp_output", "layer": l}
-                        for l in layers
+                        f"mlp{i}": {"component": "mlp_output", "layer": i}
+                        for i in layers
                     },
                 },
                 "reads": {
@@ -231,13 +231,13 @@ def test_rome_mlp_window_aie_peak(tmp_path):
                         "input": "base",
                     },
                     **{
-                        f"v{l}": {
-                            "site": f"mlp{l}",
+                        f"v{i}": {
+                            "site": f"mlp{i}",
                             "pos": "last_subject",
                             "model": "original",
                             "input": "base",
                         }
-                        for l in layers
+                        for i in layers
                     },
                 },
                 "writes": {
@@ -253,19 +253,19 @@ def test_rome_mlp_window_aie_peak(tmp_path):
                         },
                     },
                     **{
-                        f"rest{l}": {
-                            "site": f"mlp{l}",
+                        f"rest{i}": {
+                            "site": f"mlp{i}",
                             "pos": "last_subject",
-                            "do": {"swap": f"v{l}"},
+                            "do": {"swap": f"v{i}"},
                         }
-                        for l in layers
+                        for i in layers
                     },
                 },
                 "intervened_models": {
                     "corrupted": {"input": "base", "writes": ["noise"]},
                     "restored": {
                         "input": "base",
-                        "writes": ["noise"] + [f"rest{l}" for l in layers],
+                        "writes": ["noise"] + [f"rest{i}" for i in layers],
                     },
                 },
                 "metrics": {

--- a/tests/neural/pytorch_hooks/test_featurizer_seed.py
+++ b/tests/neural/pytorch_hooks/test_featurizer_seed.py
@@ -21,7 +21,7 @@ Two traps the fix has to clear, both pinned below:
 * the stage cache is keyed by **name alone** and can be injected from
   outside, so a cache shared across two points would hand the seed-0 stage
   to seed 1 and swallow the fix. The end-to-end guard is
-  ``test_run_corpus.py::test_08_seed_sweep_fits_three_different_rotations``;
+  ``test_run_corpus.py::test_08_seed_sweep_fits_three_genuinely_different_rotations``;
   here we pin the refusal that makes such a sharing loud instead of silent.
 
 ``subspace`` is the only kind with a random init — ``gate`` starts at zeros

--- a/tests/neural/pytorch_hooks/test_featurizer_seed.py
+++ b/tests/neural/pytorch_hooks/test_featurizer_seed.py
@@ -1,0 +1,271 @@
+"""``train.seed`` reaches the ``subspace`` init (spec §2.11, §8).
+
+The bug this guards: ``Subspace.__init__`` took a ``seed`` and drew its
+initial rotation from a *local* ``torch.Generator``, but ``_build_stage``
+never passed one — so every subspace in every document initialised from
+seed 0, and because the generator was local the ``torch.manual_seed(seed)``
+at train-loop entry could not reach it either. A ``{"sweep": [0,1,2]}`` on
+``train.seed`` therefore produced three fits from the *same* starting
+rotation. It looked fine from the outside: the batch order does vary with
+the seed (``order_rng``), so the fits were not bit-identical — just launched
+from one point, which is the dominant source of run-to-run variance for a
+DAS fit. Anyone reading such a sweep as evidence of stability was getting a
+much weaker guarantee than they thought.
+
+Two traps the fix has to clear, both pinned below:
+
+* the init must **not** move to the global RNG. ``build_stack`` also runs on
+  apply/inference documents that have no ``train`` block and never call
+  ``torch.manual_seed``, and stages are cached, so a global-RNG init would
+  make a rotation depend on how many stages happened to be built first.
+* the stage cache is keyed by **name alone** and can be injected from
+  outside, so a cache shared across two points would hand the seed-0 stage
+  to seed 1 and swallow the fix. The end-to-end guard is
+  ``test_run_corpus.py::test_08_seed_sweep_fits_three_different_rotations``;
+  here we pin the refusal that makes such a sharing loud instead of silent.
+
+``subspace`` is the only kind with a random init — ``gate`` starts at zeros
+and every other kind loads its tensors from a file — which the gate test at
+the bottom keeps honest.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from causalab.neural.pytorch_hooks.executor import document_seed
+from causalab.neural.pytorch_hooks.featurizers import Gate, build_stack
+from causalab.protocol.errors import ProtocolError
+from causalab.protocol.schema import FeaturizerSpec, parse_document
+
+from tests.neural.pytorch_hooks._drive import executor_for
+from tests.neural.pytorch_hooks.test_train import (
+    ANSWERS,
+    BASES,
+    COUNTERFACTUALS,
+    das_doc,
+)
+from tests.protocol._docs import in_order
+
+pytestmark = pytest.mark.unit
+
+WIDTH = 16
+K = 4
+
+SPECS: dict[str, FeaturizerSpec] = {
+    "rot": FeaturizerSpec(kind="subspace", k=K, parametrization="cayley"),
+    "gate": FeaturizerSpec(kind="gate"),
+}
+
+
+def _no_tensors(path: str) -> dict[str, torch.Tensor]:
+    raise KeyError(path)
+
+
+def _rotation(seed: int | None = None, name: str = "rot") -> torch.Tensor:
+    kwargs = {} if seed is None else {"seed": seed}
+    stack = build_stack(
+        name,
+        SPECS,
+        width=WIDTH,
+        load_tensors=_no_tensors,
+        stage_cache={},
+        **kwargs,  # type: ignore[arg-type]
+    )
+    return stack.stages[0].slot_params()["weight"].detach().clone()
+
+
+def _subspace_distance(a: torch.Tensor, b: torch.Tensor) -> float:
+    """Distance between the *column spaces*, ``‖QaQaᵀ − QbQbᵀ‖_F`` — invariant
+    to the arbitrary choice of basis within each frame, unlike an elementwise
+    diff. 0 is the same subspace; ``√(2k)`` ≈ 2.83 here is orthogonal ones."""
+    return float((a @ a.T - b @ b.T).norm())
+
+
+# --------------------------------------------------------------------- #
+# the seed reaches the init at all
+# --------------------------------------------------------------------- #
+
+
+def test_different_seeds_give_different_initial_rotations() -> None:
+    """The headline: this is what a ``{"sweep": [0,1,2]}`` on ``train.seed``
+    is buying, and what it silently did not buy."""
+    rotations = [_rotation(seed) for seed in (0, 1, 2)]
+    for i, a in enumerate(rotations):
+        for b in rotations[i + 1 :]:
+            assert not torch.equal(a, b)
+            # not merely different floats — a genuinely different subspace
+            assert _subspace_distance(a, b) > 1.0
+
+
+def test_the_same_seed_reproduces_bit_identically() -> None:
+    """The other half of a usable seed: differing is worthless without
+    repeating. Bit-identity, not ``allclose`` — a fit is only comparable
+    across runs if the starting point is exact."""
+    assert torch.equal(_rotation(7), _rotation(7))
+
+
+def test_the_init_seed_defaults_to_zero() -> None:
+    """A document with no ``train`` block has no seed to name, so its
+    featurizer inits are pinned at 0 — explicit, so an apply document and a
+    ``train.seed: 0`` fit build the same rotation."""
+    assert torch.equal(_rotation(None), _rotation(0))
+
+
+def test_the_init_ignores_the_global_rng() -> None:
+    """Deliberately *not* the fix: the local generator is what keeps a build
+    reproducible on apply paths (no ``torch.manual_seed`` there) and
+    independent of how many stages were constructed before it."""
+    torch.manual_seed(0)
+    first = _rotation(3)
+    torch.manual_seed(999_999)
+    torch.randn(128)  # advance the global stream for good measure
+    assert torch.equal(first, _rotation(3))
+
+
+# --------------------------------------------------------------------- #
+# the seed a document implies
+# --------------------------------------------------------------------- #
+
+
+def test_document_seed_reads_train_seed() -> None:
+    for seed in (0, 1, 42):
+        doc = parse_document(in_order(das_doc(seed=seed)))
+        assert document_seed(doc) == seed
+
+
+def test_document_seed_is_zero_without_a_train_block() -> None:
+    raw = das_doc(seed=5)
+    del raw["train"]
+    raw["save"] = [entry for entry in raw["save"] if entry["value"] != "rot"]
+    assert document_seed(parse_document(in_order(raw))) == 0
+
+
+def _executor_for_seed(bundle, seed: int):
+    return executor_for(
+        das_doc(seed=seed),
+        bundle,
+        base_texts=BASES,
+        counterfactual_texts=COUNTERFACTUALS,
+        extra_columns={"label": ANSWERS},
+    )
+
+
+def test_the_executor_initialises_from_the_documents_seed(llama_bundle) -> None:
+    """The end of the wire the bug broke: ``train.seed`` → ``executor.seed``
+    → the rotation the fit starts from. Nothing is trained here — the point
+    is the *starting* point, which was identical across seeds."""
+
+    def initial(seed: int) -> torch.Tensor:
+        executor = _executor_for_seed(llama_bundle, seed)
+        assert executor.seed == seed
+        return executor.stage("rot").slot_params()["weight"].detach().clone()
+
+    zero, one = initial(0), initial(1)
+    assert not torch.equal(zero, one)
+    assert _subspace_distance(zero, one) > 1.0
+    assert torch.equal(zero, initial(0))
+
+
+# --------------------------------------------------------------------- #
+# trap 1: the stage cache is keyed by name alone
+# --------------------------------------------------------------------- #
+
+
+def test_a_stage_cache_refuses_a_second_seed() -> None:
+    """A cache is one point's. Reusing it under a second seed would hand
+    back the first seed's rotation and quietly undo the fix, so it refuses
+    — the same rule, and the same P2, as the one-featurizer-one-width check
+    that already lives beside it."""
+    cache: dict[str, object] = {}
+    build_stack(
+        "rot", SPECS, width=WIDTH, load_tensors=_no_tensors, stage_cache=cache, seed=0
+    )
+    with pytest.raises(ProtocolError) as excinfo:
+        build_stack(
+            "rot",
+            SPECS,
+            width=WIDTH,
+            load_tensors=_no_tensors,
+            stage_cache=cache,
+            seed=1,
+        )
+    assert "one featurizer, one seed" in str(excinfo.value)
+
+
+def test_a_stage_cache_still_shares_one_stage_within_a_seed() -> None:
+    """The refusal must not break what the cache is *for*: one stage
+    instance per name, so training a featurizer updates every use site."""
+    cache: dict[str, object] = {}
+    first = build_stack(
+        "rot", SPECS, width=WIDTH, load_tensors=_no_tensors, stage_cache=cache, seed=4
+    ).stages[0]
+    second = build_stack(
+        "rot", SPECS, width=WIDTH, load_tensors=_no_tensors, stage_cache=cache, seed=4
+    ).stages[0]
+    assert first is second
+
+
+def test_two_points_do_not_share_a_stage_cache(llama_bundle) -> None:
+    """Why a seed sweep works at all: an executor with no ``stage_cache``
+    handed in starts empty, and the backend builds one executor per point
+    (``PytorchHooksBackend._execute_point``), so the seed-0 stage is never
+    handed to seed 1. Were that ever hoisted, the refusal above turns it
+    into a P2 rather than a silently shared rotation."""
+    zero = _executor_for_seed(llama_bundle, 0)
+    one = _executor_for_seed(llama_bundle, 1)
+    assert zero.stage_cache is not one.stage_cache
+    assert not torch.equal(
+        zero.stage("rot").slot_params()["weight"].detach(),
+        one.stage("rot").slot_params()["weight"].detach(),
+    )
+
+
+# --------------------------------------------------------------------- #
+# trap 2: the other stages
+# --------------------------------------------------------------------- #
+
+
+def test_the_gate_has_no_seed_to_thread() -> None:
+    """``Gate`` initialises ``θ`` to zeros, so there is no draw for a seed to
+    influence — the reason ``build_stack`` passes its seed only to
+    ``subspace``. If this ever starts failing, the gate grew a random init
+    and needs the same threading."""
+    gate = build_stack(
+        "gate", SPECS, width=WIDTH, load_tensors=_no_tensors, stage_cache={}, seed=11
+    ).stages[0]
+    assert isinstance(gate, Gate)
+    assert torch.equal(gate.theta.detach(), torch.zeros(WIDTH))
+
+
+@pytest.mark.parametrize("kind", ["identity", "subspace", "gate"])
+def test_only_subspace_is_seed_sensitive(kind: str) -> None:
+    """The whole seed surface, kind by kind: of the kinds a spec can build
+    without a file (``pca``/``standardize``/``sae``/an applied ``subspace``
+    fit all arrive from ``load_tensors``), only ``subspace`` may respond to
+    the seed. A new random-init kind trips this and needs the threading."""
+    specs = {
+        "identity": FeaturizerSpec(kind="identity"),
+        "subspace": FeaturizerSpec(kind="subspace", k=K, parametrization="cayley"),
+        "gate": FeaturizerSpec(kind="gate"),
+    }
+    tensors = {
+        seed: [
+            t.detach().clone()
+            for t in build_stack(
+                kind,
+                specs,
+                width=WIDTH,
+                load_tensors=_no_tensors,
+                stage_cache={},
+                seed=seed,
+            )
+            .stages[0]
+            .slot_params()
+            .values()
+        ]
+        for seed in (0, 1)
+    }
+    responded = any(not torch.equal(a, b) for a, b in zip(tensors[0], tensors[1]))
+    assert responded == (kind == "subspace")

--- a/tests/neural/pytorch_hooks/test_run_corpus.py
+++ b/tests/neural/pytorch_hooks/test_run_corpus.py
@@ -3,10 +3,17 @@
 The golden corpus authors Llama-3.1-8B; ``--set`` overrides (spec §9)
 retarget the model key and layer/head indices at tiny scale — the
 documents' semantics are untouched, which is exactly what the override
-mechanism is for. The sweep/train corpus files (04, 05, 07, 08) stay off
-the CPU budget per the phase plan; the fit→apply roundtrip below covers
-the train path end to end at tiny scale instead, including the
+mechanism is for. The sweep/train corpus files (04, 05, 07) stay off the
+CPU budget per the phase plan; the fit→apply roundtrip below covers the
+train path end to end at tiny scale instead, including the
 ArtifactIdentity stamp-and-check cycle that corpus 09 specifies.
+
+Corpus 08 is the one exception, run at a single ``k`` and one epoch (~10 s):
+it is the only document in the corpus that sweeps ``train.seed``, and a
+seed sweep is the one thing a single-point fit cannot check — the stage
+cache is keyed by featurizer name alone, so a cache shared across points
+would hand seed 0's rotation to every other seed and no unit test on
+``build_stack`` would notice. See ``test_featurizer_seed.py``.
 """
 
 from __future__ import annotations
@@ -166,6 +173,51 @@ def test_fit_then_apply_roundtrip(roots, tmp_path):
         "featurizers.rot.file_path=artifacts/tiny/rot_k4.safetensors",
     )
     assert code == 1
+
+
+def test_08_seed_sweep_fits_three_genuinely_different_rotations(roots, tmp_path):
+    """A ``{"sweep": [0,1,2]}`` on ``train.seed`` must fit three rotations
+    from three *different* starting points (§2.11).
+
+    The bug this guards end to end: ``train.seed`` never reached the
+    ``subspace`` init, so all three points started from the identical
+    rotation and drifted apart only by batch order. The three fits still
+    differed — by ~1e-3, a subspace distance of ~0.015 — so nothing looked
+    obviously wrong, but a sweep read as evidence of stability was really
+    measuring data-order jitter around one initialisation.
+
+    Asserted on the *column space*, ``‖QaQaᵀ − QbQbᵀ‖_F``, which ignores the
+    arbitrary basis inside each frame: 0 is the same subspace, ``√(2k)`` ≈
+    2.83 orthogonal ones. Pre-fix this measured ≤ 0.016 for every pair;
+    the threshold below is an order of magnitude above that and an order of
+    magnitude below what independent inits give (~2.4).
+    """
+    import torch
+
+    out = tmp_path / "sweep"
+    code = _run(
+        "08_weekdays_das_sweep_im.json",
+        roots,
+        out,
+        "sites.target.layer=1",
+        "featurizers.rot.k=4",  # one k, so the sweep is over seed alone
+        'train.steps={"epochs": 1}',
+        'train.batch={"pairs": 2}',
+    )
+    assert code == 0
+    fitted = load_file(str(out / "rot.safetensors"))
+    assert sorted(fitted) == [f"weight[seed={s}]" for s in (0, 1, 2)]
+
+    names = sorted(fitted)
+    for i, a in enumerate(names):
+        for b in names[i + 1 :]:
+            qa, qb = fitted[a], fitted[b]
+            distance = float((qa @ qa.T - qb @ qb.T).norm())
+            assert distance > 0.5, f"{a} and {b} fit the same subspace ({distance:.4f})"
+            # each is still a frame, not just noise
+            torch.testing.assert_close(
+                qa.T @ qa, torch.eye(qa.shape[1]), atol=1e-5, rtol=1e-4
+            )
 
 
 def test_explain_and_digest_work_on_every_corpus_file(roots, capsys):


### PR DESCRIPTION
`train.seed` never reached the subspace featurizer, so a seed sweep could fit every point from the same starting rotation.

Stacked on #21 — targets `can/pr20-token-form-and-device`.

## The bug

`Subspace.__init__` takes a `seed`, but `_build_stage` never passed one, so it always defaulted to 0. And the generator is *local*, so `torch.manual_seed(seed)` at train-loop entry could not reach it either:

```python
generator = torch.Generator().manual_seed(seed)     # local; global seeding can't touch it
...
return Subspace(width, k, parametrization)          # seed never passed
```

`train.py`'s own docstring states the intended behavior — "`seed` drives featurizer init … so a `{"sweep": [0,1,2]}` on `seed` yields three" — so this is a bug against its own spec.

**Why it survived:** data order *does* vary with the seed (`order_rng`), so sweep points are not identical end to end, and at real scale optimizer drift pulls the fits apart enough to look like a working sweep. On an 8B DAS fit the three pre-fix rotations sat 1.892 apart — plausible on its own. The tell is that **not one of the 24 principal angles exceeded 80°**: all three "independent" fits stayed in one cone around the shared init. A seed sweep was measuring optimizer drift from a single starting point, and how much you got depended on learning rate and step count.

## The fix

`build_stack(..., seed)` → `_build_stage(..., seed)` → `Subspace(..., seed=seed)`. One reader, `executor.document_seed(doc)`, returns `train.seed` or 0 for a document with no fit; `run_training` uses the same function for `torch.manual_seed` and `order_rng`, so the loop and the init cannot disagree.

The local generator is kept deliberately: `build_stack` also runs on apply/inference paths that never seed the global stream, and a global-RNG init would make a rotation depend on construction order. Construction stays on CPU then `.to(device)`, so #21's cross-device bit-identity test still holds — now over a meaningful seed rather than a constant 0.

**Stage cache.** The cache is keyed by name alone, so a shared cache across sweep points would have defeated this. It is per point — `_execute_point` builds a fresh `PointExecutor` with an empty cache — verified by instrumenting `Subspace.__init__` during a real 3-point sweep: `seeds seen: [0,0,0]` before, `[0,1,2]` after. Since the invariant is load-bearing but incidental, a cached stage whose seed differs from the requested one now refuses (`P2`), matching the existing one-featurizer-one-width check.

## Verification

Llama-3.1-8B, DAS at `block_output` L18, k=8, bf16, 10 epochs — and the identical job on the pre-fix commit as a control:

| | mean pairwise subspace distance (max 4.0) | mean principal angle | angles > 80° |
|---|---|---|---|
| pre-fix | 1.892 | 27.3° | **0 / 24** |
| post-fix | **3.313** | **62.1°** | **11 / 24** |

`train.seed: 0` is untouched at real scale: the seed-0 rotation is **bit-identical** pre- and post-fix (max abs diff 0.0), point digests identical. Seeds 1 and 2 move by 3.21.

**Tests:** new `test_featurizer_seed.py` (11 unit) + a corpus-08 smoke over the real `{"sweep":[0,1,2]}`. On revert it fails for the right reason — `weight[seed=0] and weight[seed=1] fit the same subspace (0.0157)`. `pytest -m "not golden"` 1462 passed; `-m golden` 8 passed.

**No pins moved.** The digests pin canonicalization, which this doesn't touch; no golden document has a `train` block or a fitted `subspace`. Nothing re-baselined.

`gate` inits to zeros and every other kind loads from a file, so `subspace` is the only seed-sensitive stage — pinned by `test_only_subspace_is_seed_sensitive`.

## Found, not fixed

- `train.params: ["rot.weight"]` crashes with `ValueError: can't optimize a non-leaf Tensor` — under the orthogonal parametrization `slot_params()["weight"]` is the computed tensor, not the leaf. Only the bare `["rot"]` form works, which is what every corpus document happens to use.
- `.safetensors` output is not byte-reproducible: `__metadata__` serializes in nondeterministic map order, so identical tensors hash differently. Would defeat any future saved-tensor file digest.
- Two subspace featurizers in one document share the document seed, so they start from the same rotation. Unfixable without moving seed 0.
