### PR TITLE
Protocol: address entries inside a tensor bundle, and reduce a read at save time

### DIFF
--- a/causalab/configs/methods/weekdays_das_apply.json
+++ b/causalab/configs/methods/weekdays_das_apply.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "description": "Apply a previously fitted DAS rotation on the test split instead of re-computing it: the featurizer's file_path loads the artifact, and its ArtifactIdentity (model, site, k, parametrization, dtype) is checked on load - a mismatch refuses. No train section; a featurizer with file_path may not appear in train.params.",
+  "description": "Apply a previously fitted DAS rotation on the test split instead of re-computing it: the featurizer's file_path loads the artifact, and its ArtifactIdentity (model, site, k, parametrization, dtype) is checked on load - a mismatch refuses. 'entry' names which fit to apply: against this single-bundle artifact it is documentation, but the same document loaded against a swept fit's bundle (one entry per k x seed point) is how one rotation is picked out. No train section; a featurizer with file_path may not appear in train.params.",
   "model": {"key": "meta-llama/Llama-3.1-8B", "revision": "main"},
   "causal_model": {"key": "weekdays.causal_model"},
   "data": {
@@ -13,7 +13,8 @@
   },
   "featurizers": {
     "rot": {"kind": "subspace", "k": 8, "parametrization": "cayley",
-            "file_path": "artifacts/weekdays/llama31_8b/subspace/rot_k8.safetensors"}
+            "file_path": "artifacts/weekdays/llama31_8b/subspace/rot_k8.safetensors",
+            "entry": {"k": 8, "seed": 0}}
   },
   "reads": {
     "v_cf":  {"site": "target",  "pos": -1, "model": "original", "input": "counterfactual", "featurizer": "rot"},

--- a/causalab/configs/workflows/weekdays_8b.json
+++ b/causalab/configs/workflows/weekdays_8b.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "description": "weekdays-8b: locate the best layer x position cell by interchange scan, fit DAS rotations (k x seed) at it, apply the fit on the test split; scan heatmap and IIA-vs-k curves. The workflow-protocol worked example (docs/workflow_protocol.md sec. 10).",
+  "description": "weekdays-8b: locate the best layer x position cell by interchange scan, fit DAS rotations (k x seed) at it, pick the best fit, apply it on the test split; scan heatmap and IIA-vs-k curves. The workflow-protocol worked example (docs/workflow_protocol.md sec. 10). The fit step is a 3 x 3 sweep, so its bundle holds nine rotations - 'best_fit' names the winning (k, seed) and 'apply' selects that entry.",
   "steps": {
     "locate": {"type": "protocol", "document": "../methods/weekdays_locate_scan.json"},
     "best": {
@@ -15,9 +15,21 @@
         "sites.target.layer": {"artifact": "best", "key": "best_layer"}
       }
     },
+    "best_fit": {
+      "type": "select", "from": "fit", "table": "iia.parquet",
+      "choose": "max",
+      "emit": {"best_k": "featurizers.rot.k", "best_seed": "train.seed"}
+    },
     "apply": {
       "type": "protocol", "document": "../methods/weekdays_das_apply.json",
-      "set": {"featurizers.rot.file_path": "fit/rot.safetensors"}
+      "set": {
+        "featurizers.rot.file_path": "fit/rot.safetensors",
+        "featurizers.rot.k": {"artifact": "best_fit", "key": "best_k"},
+        "featurizers.rot.entry": {
+          "k": {"artifact": "best_fit", "key": "best_k"},
+          "seed": {"artifact": "best_fit", "key": "best_seed"}
+        }
+      }
     },
     "scan_heatmap": {
       "type": "plot", "plot": "heatmap", "from": "locate", "table": "iia.parquet",
@@ -32,6 +44,7 @@
   },
   "save": [
     {"step": "best", "value": "values.json", "file_path": "best_cell.json"},
+    {"step": "best_fit", "value": "values.json", "file_path": "best_fit.json"},
     {"step": "fit", "value": "iia.parquet", "file_path": "fit_iia.parquet"},
     {"step": "apply", "value": "iia.parquet", "file_path": "apply_iia.parquet"},
     {"step": "scan_heatmap", "value": "scan_iia.png", "file_path": "scan_iia.png"},

--- a/causalab/neural/pytorch_hooks/backend.py
+++ b/causalab/neural/pytorch_hooks/backend.py
@@ -12,13 +12,13 @@ routing refuses those documents before anything runs.
 from __future__ import annotations
 
 import functools
+import json
 from pathlib import Path
 from typing import Any, Mapping
 
-import torch
 
 from causalab.neural.pytorch_hooks.executor import PointExecutor
-from causalab.neural.pytorch_hooks.loading import load_model
+from causalab.neural.pytorch_hooks.loading import TensorBundle, load_model
 from causalab.neural.pytorch_hooks.metrics import compute_metric
 from causalab.neural.pytorch_hooks.outputs import (
     MetricTable,
@@ -82,7 +82,12 @@ class PytorchHooksBackend(Backend):
     # ------------------------------------------------------------------ #
 
     def _executor(
-        self, doc: Document, request: ExecutionRequest, *, grad_enabled: bool = False
+        self,
+        doc: Document,
+        request: ExecutionRequest,
+        *,
+        grad_enabled: bool = False,
+        coords: Mapping[str, Any] | None = None,
     ) -> PointExecutor:
         bundle = load_model(
             str(doc.model.key),
@@ -98,6 +103,7 @@ class PytorchHooksBackend(Backend):
             role_fields=role_fields,
             load_tensors=functools.partial(_load_tensors, request),
             grad_enabled=grad_enabled,
+            coords=coords,
         )
 
     def _execute_point(
@@ -110,7 +116,7 @@ class PytorchHooksBackend(Backend):
         tensor_files: dict[str, TensorFile],
         metric_files: dict[str, MetricTable],
     ) -> Mapping[str, Any]:
-        executor = self._executor(doc, request)
+        executor = self._executor(doc, request, coords=coords)
         trained_stages: dict[str, Any] = {}
         if doc.train is not None:
             from causalab.neural.pytorch_hooks.train import run_training
@@ -137,7 +143,11 @@ class PytorchHooksBackend(Backend):
                 )
             elif entry.value in doc.reads:
                 tensor_files.setdefault(entry.file_path, TensorFile()).add(
-                    entry.value, executor.read_value(entry.value), coords
+                    entry.value,
+                    executor.read_value(entry.value),
+                    coords,
+                    reduce=entry.reduce,
+                    identity={"produced_by": point_digest},
                 )
             else:  # a trained featurizer bundle
                 stage = trained_stages.get(entry.value)
@@ -146,11 +156,21 @@ class PytorchHooksBackend(Backend):
                         "P2", f"featurizer {entry.value!r} was not trained this run"
                     )
                 bundle_file = tensor_files.setdefault(entry.file_path, TensorFile())
-                for slot, param in stage.slot_params().items():
-                    bundle_file.add(slot, param.detach(), coords)
-                bundle_file.metadata.update(
-                    _featurizer_identity(doc, entry.value, entry.site, point_digest)
+                identity = _featurizer_identity(
+                    doc, entry.value, entry.site, point_digest
                 )
+                for slot, param in stage.slot_params().items():
+                    # per entry, not per file: a swept fit writes one file from
+                    # many points, and only the entry table can say which point
+                    # produced which rotation (§8)
+                    bundle_file.add(
+                        slot,
+                        param.detach(),
+                        coords,
+                        label_entry=entry.value,
+                        identity=identity,
+                    )
+                bundle_file.record_common(identity)
         return {
             "point": point_digest,
             "coords": dict(coords),
@@ -234,17 +254,46 @@ def _resolve_roles(
     return role_rows, role_fields
 
 
-def _load_tensors(request: ExecutionRequest, file_path: str) -> dict[str, torch.Tensor]:
+@functools.lru_cache(maxsize=32)
+def _read_bundle(path: str, _stamp: tuple[int, int]) -> TensorBundle:
+    """One bundle, read once. The cache matters: a write operand resolves
+    its ``params`` tensor on every application, so an uncached read would
+    re-open the same file for every batch of every point.
+
+    ``_stamp`` is the file's (mtime, size), so a path rewritten in the same
+    process — a step re-run into an existing run tree — is a cache miss
+    rather than a stale tensor."""
+    from safetensors.torch import load_file
+
+    from causalab.protocol.resolve import read_safetensors_metadata
+
+    meta = read_safetensors_metadata(Path(path)) or {}
+    raw_entries = meta.get("entries")
+    entry_coords: dict[str, Any] = {}
+    if isinstance(raw_entries, str):
+        try:
+            decoded = json.loads(raw_entries)
+        except json.JSONDecodeError as err:
+            raise ProtocolError(
+                "P2", f"{path}: unreadable 'entries' table in the header — {err}"
+            ) from err
+        if isinstance(decoded, dict):
+            entry_coords = decoded
+    return TensorBundle(tensors=load_file(path), entry_coords=entry_coords)
+
+
+def _load_tensors(request: ExecutionRequest, file_path: str) -> TensorBundle:
     """Load a tensor bundle referenced by a featurizer/params file_path,
     resolved through the artifact store (which owns the run-tree/external
     overlay inside a workflow)."""
-    from safetensors.torch import load_file
-
     artifacts = request.env.artifacts
     resolve = getattr(artifacts, "resolve_path", None)
     if resolve is not None:
-        return load_file(str(resolve(file_path)))
-    root = getattr(artifacts, "root", None)
-    if root is None:
-        raise ProtocolError("P2", "artifact store exposes no filesystem root")
-    return load_file(str(Path(root) / file_path))
+        target = Path(resolve(file_path))
+    else:
+        root = getattr(artifacts, "root", None)
+        if root is None:
+            raise ProtocolError("P2", "artifact store exposes no filesystem root")
+        target = Path(root) / file_path
+    stat = target.stat()
+    return _read_bundle(str(target), (stat.st_mtime_ns, stat.st_size))

--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -47,6 +47,7 @@ from causalab.neural.pytorch_hooks.mechanisms import (
     operand_names,
 )
 from causalab.neural.pytorch_hooks.sites import ResolvedSite, resolve_site
+from causalab.protocol.bundles import entry_selection, selector_slot
 from causalab.protocol.errors import ProtocolError
 from causalab.protocol.registry import component_width
 from causalab.protocol.schema import Document, WriteSpec, PositionSpec, ReadSpec
@@ -103,9 +104,10 @@ class PointExecutor:
         *,
         role_rows: Mapping[str, list[dict[str, Any]]],
         role_fields: Mapping[str, str],
-        load_tensors: Callable[[str], dict[str, torch.Tensor]],
+        load_tensors: Callable[[str], Any],
         stage_cache: dict[str, Stage] | None = None,
         grad_enabled: bool = False,
+        coords: Mapping[str, Any] | None = None,
     ) -> None:
         self.doc = doc
         self.bundle = bundle
@@ -119,6 +121,9 @@ class PointExecutor:
         # the seed every freshly built featurizer initialises from; the stage
         # cache is keyed by name alone, so it belongs to this one point
         self.seed = document_seed(doc)
+        #: this point's sweep coordinates — they select the matching entry of
+        #: a swept bundle a loaded featurizer/param points at (§2.5)
+        self.coords = dict(coords or {})
         self._read_values: dict[str, torch.Tensor | RaggedValue] = {}
         self._groups_run: set[tuple[str, str]] = set()
         self._batches: dict[str, EncodedBatch] = {}
@@ -163,6 +168,7 @@ class PointExecutor:
                 stage_cache=self.stage_cache,
                 device=self.bundle.device,
                 seed=self.seed,
+                coords=self.coords,
             )
         return self.stage_cache[name]
 
@@ -340,6 +346,7 @@ class PointExecutor:
             stage_cache=self.stage_cache,
             device=self.bundle.device,
             seed=self.seed,
+            coords=self.coords,
         )
 
     def _finalize_read(
@@ -394,7 +401,13 @@ class PointExecutor:
         if value in self.doc.params:
             spec = self.doc.params[value]
             if isinstance(spec.file_path, str):
-                return self.load_tensors(spec.file_path)["value"]
+                want, implicit = entry_selection(spec.entry, self.coords, value)
+                slot = selector_slot(spec.entry, "value")
+                what = f"params entry {value!r} ({spec.file_path})"
+                point = self.load_tensors(spec.file_path).point(
+                    slot, want, what=what, implicit=implicit
+                )
+                return point.tensor(slot)
             raise NotImplementedError(
                 f"trainable free params ({value!r}) arrive with the train loop"
             )

--- a/causalab/neural/pytorch_hooks/featurizers.py
+++ b/causalab/neural/pytorch_hooks/featurizers.py
@@ -33,12 +33,13 @@ declares no fit). ``gate`` inits to zeros and the rest load from files.
 from __future__ import annotations
 
 import dataclasses
-from typing import Any, Sequence
+from typing import Any, Mapping, Sequence
 
 import torch
 
+from causalab.protocol.bundles import entry_selection
 from causalab.protocol.errors import ProtocolError
-from causalab.protocol.schema import FeaturizerSpec
+from causalab.protocol.schema import FEATURIZER_SLOTS, FeaturizerSpec
 
 __all__ = ["FeaturizerStack", "Stage", "build_stack"]
 
@@ -279,6 +280,7 @@ def build_stack(
     stage_cache: dict[str, Stage],
     device: str | torch.device = "cpu",
     seed: int = 0,
+    coords: Mapping[str, Any] | None = None,
 ) -> FeaturizerStack:
     """Build (or reuse from ``stage_cache``) the stack a read/write
     references. ``width`` is the SITE width; each later stage in a
@@ -295,7 +297,11 @@ def build_stack(
     fit — ``executor.document_seed``). Explicit rather than read from the global
     RNG because this also runs on apply/inference paths, where a global-RNG init
     would make a rotation depend on construction order. The cache is keyed by
-    name, so a cached stage built from a different seed refuses, as with width."""
+    name, so a cached stage built from a different seed refuses, as with width.
+
+    ``coords`` are the executing point's sweep coordinates: they select the
+    matching entry of a swept bundle when the spec authored no ``entry``
+    (§2.5)."""
     if ref is None:
         return FeaturizerStack(names=(), stages=(Identity(),))
     chain = (ref,) if isinstance(ref, str) else tuple(ref)
@@ -329,7 +335,12 @@ def build_stack(
                     "output width is not derivable from its spec",
                 )
             stage = _build_stage(
-                name, spec, width=running, load_tensors=load_tensors, seed=seed
+                name,
+                spec,
+                width=running,
+                load_tensors=load_tensors,
+                seed=seed,
+                coords=coords,
             )
             stage.to(device)  # parameters and registered buffers alike
             # inference documents get eval semantics (a gate's hard split);
@@ -344,20 +355,63 @@ def build_stack(
     return FeaturizerStack(names=chain, stages=tuple(stages))
 
 
+def _check_entry_identity(
+    record: Mapping[str, Any], spec: FeaturizerSpec, what: str
+) -> None:
+    """Refuse an entry whose stamped fit contradicts the spec that selected
+    it (§2.5).
+
+    The load-time check (``loader._check_loaded_featurizers``) covers a
+    bundle whose entry is knowable there; when the selection is the
+    executing point's — implicit matching against a swept producer — this is
+    where the claim is finally tested, so "apply the k=8 fit" cannot quietly
+    apply the k=32 one. Only the per-entry fields are compared: everything
+    file-level was already checked at load.
+    """
+    for field, value in (
+        ("k", spec.k),
+        ("parametrization", spec.parametrization),
+    ):
+        if value is None or not isinstance(value, (int, str)):
+            continue
+        stamped = record.get(field)
+        if stamped is not None and str(stamped) != str(value):
+            raise ProtocolError(
+                "P2",
+                f"{what}: the document says {field}={value!r} but the selected "
+                f"entry was fitted with {field}={stamped!r}",
+            )
+
+
 def _build_stage(
-    name: str, spec: FeaturizerSpec, *, width: int, load_tensors: Any, seed: int = 0
+    name: str,
+    spec: FeaturizerSpec,
+    *,
+    width: int,
+    load_tensors: Any,
+    seed: int = 0,
+    coords: Mapping[str, Any] | None = None,
 ) -> Stage:
     kind = spec.kind if isinstance(spec.kind, str) else "identity"
     if isinstance(spec.file_path, str):
-        tensors = load_tensors(spec.file_path)
-        if kind in ("subspace", "pca"):
-            return LoadedLinear(kind, tensors["weight"])
-        if kind == "standardize":
-            return Standardize(tensors["mu"], tensors["sigma"])
-        if kind == "sae":
-            return Sae(
-                tensors["enc"], tensors["dec"], tensors["b_enc"], tensors["b_dec"]
+        slots = FEATURIZER_SLOTS.get(kind, ())
+        if not slots:
+            raise ProtocolError(
+                "P2", f"featurizer kind {kind!r} cannot be loaded from a file"
             )
+        want, implicit = entry_selection(spec.entry, coords, name)
+        what = f"featurizer {name!r} ({spec.file_path})"
+        point = load_tensors(spec.file_path).point(
+            slots[0], want, what=what, implicit=implicit
+        )
+        _check_entry_identity(point.record, spec, what)
+        slot = point.tensor
+        if kind in ("subspace", "pca"):
+            return LoadedLinear(kind, slot("weight"))
+        if kind == "standardize":
+            return Standardize(slot("mu"), slot("sigma"))
+        if kind == "sae":
+            return Sae(slot("enc"), slot("dec"), slot("b_enc"), slot("b_dec"))
         raise ProtocolError(
             "P2", f"featurizer kind {kind!r} cannot be loaded from a file"
         )

--- a/causalab/neural/pytorch_hooks/loading.py
+++ b/causalab/neural/pytorch_hooks/loading.py
@@ -1,4 +1,4 @@
-"""Model + tokenizer loading for the reference backend.
+"""Model, tokenizer and tensor-bundle loading for the reference backend.
 
 One bundle per (key, revision, dtype, device): the HF causal-LM, its
 tokenizer configured for the backend's one padding convention
@@ -19,13 +19,14 @@ from typing import Any
 
 import torch
 
+from causalab.protocol.errors import ProtocolError
 from causalab.protocol.registry import (
     ModelInfo,
     model_info_from_hf_config,
     register_model,
 )
 
-__all__ = ["ModelBundle", "load_model"]
+__all__ = ["BundlePoint", "ModelBundle", "TensorBundle", "load_model"]
 
 _DTYPES = {"fp32": torch.float32, "bf16": torch.bfloat16, "fp16": torch.float16}
 
@@ -87,3 +88,73 @@ def load_model(
         device=device,
         dtype=dtype,
     )
+
+
+@dataclasses.dataclass(frozen=True)
+class BundlePoint:
+    """One producing point's slice of a bundle: the tensors sharing a
+    coordinate suffix, plus that entry's stamped record.
+
+    Slicing by suffix rather than selecting each slot on its own is what
+    keeps a multi-slot bundle coherent — an SAE's ``enc`` and ``dec`` must
+    come from the same fit, not from whichever entries each lookup found.
+    """
+
+    tensors: dict[str, torch.Tensor]
+    suffix: str
+    record: dict[str, Any]
+    what: str
+
+    def tensor(self, slot: str) -> torch.Tensor:
+        key = f"{slot}{self.suffix}"
+        if key not in self.tensors:
+            raise ProtocolError(
+                "P2",
+                f"{self.what}: the bundle has no {key!r} — an entry's slots "
+                f"must be complete (has {sorted(self.tensors)})",
+            )
+        return self.tensors[key]
+
+
+@dataclasses.dataclass(frozen=True)
+class TensorBundle:
+    """One loaded ``.safetensors`` file: its tensors plus the ``entries``
+    table from the header (§8, :mod:`causalab.protocol.bundles`).
+
+    :meth:`point` is the only way in. A bundle written by a swept document
+    holds one entry per point per slot, so asking for a bare slot name would
+    either ``KeyError`` or — worse — silently take whichever entry a plain
+    dict lookup happened to find.
+    """
+
+    tensors: dict[str, torch.Tensor]
+    entry_coords: dict[str, Any]
+
+    def point(
+        self,
+        slot: str,
+        want: Any,
+        *,
+        what: str,
+        implicit: bool = False,
+    ) -> BundlePoint:
+        """The entry for ``slot`` selected by ``want`` (a coordinate
+        mapping; ``implicit`` when derived from the consuming point rather
+        than authored), as a coherent slice of the bundle."""
+        from causalab.protocol.bundles import select_entry
+
+        key = select_entry(
+            self.tensors.keys(),
+            slot,
+            want,
+            what=what,
+            coords_by_key=self.entry_coords or None,
+            implicit=implicit,
+        )
+        record = self.entry_coords.get(key, {})
+        return BundlePoint(
+            tensors=self.tensors,
+            suffix=key[len(slot) :],
+            record=record if isinstance(record, dict) else {},
+            what=what,
+        )

--- a/causalab/neural/pytorch_hooks/outputs.py
+++ b/causalab/neural/pytorch_hooks/outputs.py
@@ -4,18 +4,29 @@ Tensors (reads, featurizer bundles) land in ``.safetensors`` with the
 point's ``ArtifactIdentity`` in the header; per-example metric tables land
 in ``.parquet``. In swept documents the authored ``file_path`` is
 unchanged: axis coordinates become columns of the metric tables and key
-suffixes on tensor entries (``rot[k=8,seed=0]``)."""
+suffixes on tensor entries (``rot[k=8,seed=0]``).
+
+**Per-entry provenance.** A swept document writes one file from many points,
+so file-level identity can only carry what *every* point agrees on: the
+fields that vary (``k``, the point digest, a swept site) live in an
+``entries`` table in the safetensors ``__metadata__``, one record per tensor
+key. That table is what makes an entry both selectable
+(:mod:`causalab.protocol.bundles`) and provable — before it, whichever point
+executed last silently stamped the whole file."""
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 from typing import Any, Mapping
 
 import torch
 
+from causalab.protocol.bundles import RAGGED_SUFFIX, entry_key
+from causalab.protocol.errors import ProtocolError
 from causalab.protocol.resolve import build_artifact_identity
-from causalab.protocol.sweep import coordinate_label
+from causalab.protocol.sweep import coordinate_label, short_coords
 
 __all__ = ["MetricTable", "TensorFile", "write_outputs"]
 
@@ -26,17 +37,89 @@ class TensorFile:
     def __init__(self) -> None:
         self.entries: dict[str, torch.Tensor] = {}
         self.metadata: dict[str, str] = {}
+        #: key -> {"slot", "coords", …identity}; serialized as ``entries``
+        self.entry_meta: dict[str, dict[str, Any]] = {}
+        self._common_seen = False
 
-    def add(self, name: str, value: Any, coords: Mapping[str, Any]) -> None:
-        key = f"{name}{coordinate_label(coords, entry=name)}" if coords else name
+    def add(
+        self,
+        name: str,
+        value: Any,
+        coords: Mapping[str, Any],
+        *,
+        label_entry: str | None = None,
+        reduce: str | None = None,
+        identity: Mapping[str, Any] | None = None,
+    ) -> None:
+        """Add one point's value under ``name``.
+
+        ``label_entry`` is the *declared* entity the coordinates belong to,
+        which for a featurizer bundle is the featurizer, not the slot: the
+        axis ``featurizers.rot.k`` shortens to ``k`` against ``rot`` and to
+        ``rot.k`` against ``weight``, and only the former is a name a
+        consuming document can write in an ``entry`` selector."""
+        entity = label_entry or name
+        key = entry_key(name, coordinate_label(coords, entry=entity) if coords else "")
+        self.entry_meta[key] = {
+            "slot": name,
+            "coords": {
+                short: _plain(coord)
+                for short, coord in short_coords(coords, entry=entity).items()
+            },
+            **{k: str(v) for k, v in (identity or {}).items()},
+        }
         from causalab.neural.pytorch_hooks.executor import RaggedValue
 
+        if reduce is not None:
+            self.entries[key] = _reduce_rows(value, reduce)
+            return
         if isinstance(value, RaggedValue):
             # ragged reads persist as the flat gather + per-row widths
             self.entries[key] = value.flat.detach().to("cpu").contiguous()
-            self.entries[f"{key}.widths"] = torch.tensor(value.widths, dtype=torch.long)
+            self.entries[f"{key}{RAGGED_SUFFIX}"] = torch.tensor(
+                value.widths, dtype=torch.long
+            )
             return
         self.entries[key] = value.detach().to("cpu").contiguous()
+
+    def record_common(self, identity: Mapping[str, Any]) -> None:
+        """Fold one point's identity into the file-level stamp, keeping only
+        the fields every point so far agrees on.
+
+        A single-point document therefore stamps exactly what it always did;
+        a swept one drops the fields that differ (``k``, the point digest)
+        rather than letting the last point speak for the file. The dropped
+        fields are still provable per entry via the ``entries`` table."""
+        stamped = {key: str(value) for key, value in identity.items()}
+        if not self._common_seen:
+            self.metadata.update(stamped)
+            self._common_seen = True
+            return
+        for key in list(self.metadata):
+            if self.metadata[key] != stamped.get(key):
+                del self.metadata[key]
+
+
+def _reduce_rows(value: Any, reduce: str) -> torch.Tensor:
+    """§2.12 ``reduce``: a statistic over a read's gathered rows instead of
+    the rows themselves — ``(…, width)`` collapses to ``(width,)``, the
+    broadcast form a write operand takes.
+
+    Reducing here rather than downstream is the point: the un-reduced
+    harvest never reaches disk, which for an ablation grid is the difference
+    between gigabytes of activations and kilobytes of means. The
+    accumulation is fp32 regardless of the run's dtype — a bf16 sum over
+    thousands of rows loses the low bits it is meant to average.
+    """
+    from causalab.neural.pytorch_hooks.executor import RaggedValue
+
+    rows = value.flat if isinstance(value, RaggedValue) else value
+    flat = (
+        rows.detach().to(device="cpu", dtype=torch.float32).reshape(-1, rows.shape[-1])
+    )
+    if reduce == "mean":
+        return flat.mean(dim=0).contiguous()
+    raise ProtocolError("P2", f"unknown save reduction {reduce!r}")
 
 
 class MetricTable:
@@ -98,6 +181,7 @@ def write_outputs(
         target.parent.mkdir(parents=True, exist_ok=True)
         metadata = build_artifact_identity(**identity_base)
         metadata.update(tensors.metadata)
+        metadata["entries"] = json.dumps(tensors.entry_meta, sort_keys=True)
         save_file(tensors.entries, str(target), metadata=metadata)
         written[rel] = target
     for rel, table in metric_files.items():

--- a/causalab/neural/pytorch_hooks/train.py
+++ b/causalab/neural/pytorch_hooks/train.py
@@ -188,6 +188,7 @@ def run_training(
             load_tensors=executor.load_tensors,
             stage_cache=executor.stage_cache,  # shared: one stage per name
             grad_enabled=True,
+            coords=executor.coords,
         )
         for indices in batches
     ]
@@ -344,6 +345,7 @@ def _run_eval(
         load_tensors=executor.load_tensors,
         stage_cache=executor.stage_cache,
         grad_enabled=False,
+        coords=executor.coords,
     )
     assert doc.train is not None and doc.train.eval is not None
     scores: dict[str, float] = {}

--- a/causalab/protocol/bundles.py
+++ b/causalab/protocol/bundles.py
@@ -1,0 +1,212 @@
+"""Addressing one entry inside a ``.safetensors`` bundle (§2.5, §2.6).
+
+A run writes **one file per ``save`` entry**, across every point of a swept
+document: the backend suffixes each tensor key with the point's coordinate
+label (``weight[k=8,seed=0]``, ``v_mean[target.layer=12]`` —
+:func:`causalab.protocol.sweep.coordinate_label`). Consumers, on the other
+side, name a *slot* (``weight`` for a subspace/pca bundle, ``value`` for a
+``params`` constant). Without a selector the two vocabularies only coincide
+for an un-swept producer, so every swept handoff fails at run time with a
+``KeyError`` — the gap this module closes.
+
+The selector is the optional ``entry`` field on a spec that also carries
+``file_path``: a mapping of coordinate name to value
+(``{"k": 8, "seed": 0}``), matched against the coordinates parsed back out
+of the bundle's keys. Matching is on **(name, value) pairs**, never on the
+rendered label string as a whole — the label's field order follows the
+producing document's axis order, which the consumer has no way to know.
+
+Three resolution rules, in order:
+
+1. exactly one entry for the slot ⇒ that one (an un-swept producer keeps
+   working, and an external bundle needs no ``entry``);
+2. otherwise, the entries matching every requested pair — exactly one is
+   the answer;
+3. anything else (no match, or several) is an error that lists what the
+   bundle actually holds. Never first-hit-wins: silently applying the wrong
+   fit is the failure mode this whole seam exists to prevent.
+
+``entry`` may be omitted on a swept consumer: the requested pairs then come
+from the consuming point's own sweep coordinates, so an ``apply`` document
+swept on ``featurizers.rot.k`` selects the fit at *its* ``k`` — axis
+identity is name identity (§3), so the same axis name means the same axis
+on both sides, and the sweeps zip instead of crossing.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable, Mapping
+
+from causalab.protocol.errors import ValidationError
+from causalab.protocol.sweep import label_value, short_coords
+
+__all__ = [
+    "RAGGED_SUFFIX",
+    "SLOT_KEY",
+    "entry_key",
+    "entry_selection",
+    "parse_entry_key",
+    "select_entry",
+]
+
+#: Sidecar key holding a ragged read's per-row widths (``outputs.TensorFile``).
+RAGGED_SUFFIX = ".widths"
+
+#: Reserved key inside an ``entry`` selector: the producer's *name* for the
+#: tensor, as opposed to its coordinates. A ``params`` constant defaults to
+#: ``value``, but a bundle harvested from a read is keyed by the read's name,
+#: so the consumer has to be able to say which.
+SLOT_KEY = "slot"
+
+_KEY = re.compile(r"^(?P<slot>[^\[]+)\[(?P<coords>.*)\]$")
+
+
+def entry_key(slot: str, label: str) -> str:
+    """The bundle key for ``slot`` under a coordinate ``label`` (possibly
+    empty, for an un-swept document)."""
+    return f"{slot}{label}"
+
+
+def parse_entry_key(key: str) -> tuple[str, dict[str, str]]:
+    """Split a bundle key into its slot and its coordinate pairs, as
+    strings — ``"weight[k=8,seed=0]"`` → ``("weight", {"k": "8",
+    "seed": "0"})``.
+
+    This is the *fallback* reader, for bundles written before the entry
+    table existed or by hand. It deliberately gives up (whole key as slot,
+    no coordinates) on a label carrying a structured value — a swept
+    position renders as ``tap={index:-1}`` and a swept list keeps its own
+    brackets and commas, neither of which survives a flat split. Those
+    bundles are addressed through the ``__metadata__`` entry table instead,
+    which stores coordinates as data.
+    """
+    match = _KEY.match(key)
+    if match is None:
+        return key, {}
+    coords_text = match.group("coords")
+    if not coords_text:
+        return match.group("slot"), {}
+    if any(ch in coords_text for ch in "{}[]"):
+        return key, {}
+    coords: dict[str, str] = {}
+    for part in coords_text.split(","):
+        name, sep, value = part.partition("=")
+        if not sep:  # not a coordinate pair — treat the key as opaque
+            return key, {}
+        coords[name] = value
+    return match.group("slot"), coords
+
+
+def select_entry(
+    keys: Iterable[str],
+    slot: str,
+    want: Mapping[str, Any] | None,
+    *,
+    what: str,
+    coords_by_key: Mapping[str, Mapping[str, Any]] | None = None,
+    implicit: bool = False,
+) -> str:
+    """The single bundle key for ``slot`` matching every requested
+    coordinate (module docstring).
+
+    ``coords_by_key`` is the producer's ``__metadata__`` entry table when it
+    has one; it is authoritative, because it stores coordinates as data
+    rather than as a rendered label. ``what`` names the consumer in errors.
+
+    ``implicit`` marks a selection derived from the consuming point's own
+    coordinates rather than authored: axes the producer never had are then
+    dropped instead of matching nothing, so a consumer swept on a layer it
+    shares with nobody still resolves a bundle keyed only by ``k``.
+    """
+    candidates: list[tuple[str, Mapping[str, Any]]] = []
+    for key in keys:
+        if key.endswith(RAGGED_SUFFIX):
+            continue  # a sidecar, addressed via its parent key
+        if coords_by_key is not None and key in coords_by_key:
+            stored = coords_by_key[key]
+            parsed_slot = str(stored.get("slot", parse_entry_key(key)[0]))
+            coords: Mapping[str, Any] = stored.get("coords", {})
+        else:
+            parsed_slot, coords = parse_entry_key(key)
+        if parsed_slot == slot:
+            candidates.append((key, coords))
+    if not candidates:
+        raise ValidationError(
+            15,
+            f"{what}: the bundle holds no {slot!r} entry "
+            f"(has {sorted(str(k) for k in keys)})",
+        )
+    if len(candidates) == 1 and (not want or not candidates[0][1]):
+        # one entry, and either nothing asked or nothing recorded to ask
+        # about: a hand-made or un-swept bundle carries no coordinates, so it
+        # cannot answer a coordinate question — and cannot contradict one
+        # either. What the entry actually *is* stays guarded by its
+        # ArtifactIdentity.
+        return candidates[0][0]
+    requested = {name: label_value(value) for name, value in (want or {}).items()}
+    if implicit:
+        known = {name for _, coords in candidates for name in coords}
+        requested = {name: value for name, value in requested.items() if name in known}
+    matched = [
+        key
+        for key, coords in candidates
+        if all(
+            name in coords and label_value(coords[name]) == value
+            for name, value in requested.items()
+        )
+    ]
+    if len(matched) == 1:
+        return matched[0]
+    available = sorted(key for key, _ in candidates)
+    if not requested:
+        raise ValidationError(
+            15,
+            f"{what}: the bundle holds {len(candidates)} {slot!r} entries "
+            f"({available}) and the document selects none — add an 'entry' "
+            "selector, or sweep the consumer on the producer's axis (§2.5)",
+        )
+    shown = ", ".join(f"{name}={value}" for name, value in sorted(requested.items()))
+    if not matched:
+        raise ValidationError(
+            15,
+            f"{what}: no {slot!r} entry matches {{{shown}}} (has {available})",
+        )
+    raise ValidationError(
+        15,
+        f"{what}: {len(matched)} {slot!r} entries match {{{shown}}} "
+        f"({sorted(matched)}) — the selection must be unique, so name the "
+        "remaining coordinates",
+    )
+
+
+def entry_selection(
+    authored: Any,
+    coords: Mapping[str, Any] | None,
+    name: str,
+) -> tuple[Mapping[str, Any] | None, bool]:
+    """What one loaded spec selects, and whether it was implied.
+
+    An authored ``entry`` wins as written. Otherwise the consuming point's
+    own coordinates stand in — that is what lets an ``apply`` document swept
+    on ``featurizers.rot.k`` pick up the fit at *its* ``k`` without naming a
+    single entry, and what keeps the two sweeps zipped instead of crossed
+    (§3: axis identity is name identity). An un-swept consumer implies
+    nothing, so a single-entry bundle still resolves by slot alone.
+    """
+    if authored:
+        return {
+            key: value for key, value in authored.items() if key != SLOT_KEY
+        } or None, False
+    if coords:
+        return short_coords(coords, entry=name), True
+    return None, False
+
+
+def selector_slot(authored: Any, default: str) -> str:
+    """The slot an ``entry`` selector names, or ``default``."""
+    if isinstance(authored, Mapping):
+        slot = authored.get(SLOT_KEY)
+        if isinstance(slot, str):
+            return slot
+    return default

--- a/causalab/protocol/loader.py
+++ b/causalab/protocol/loader.py
@@ -25,9 +25,15 @@ from pathlib import Path
 from typing import Any, Mapping
 
 from causalab.protocol import canonical as _canonical
+from causalab.protocol.bundles import select_entry, selector_slot
 from causalab.protocol.errors import ParseError, ValidationError
 from causalab.protocol.resolve import ResolutionEnv, resolve_artifact_fields
-from causalab.protocol.schema import Document, load_raw, parse_document
+from causalab.protocol.schema import (
+    FEATURIZER_SLOTS,
+    Document,
+    load_raw,
+    parse_document,
+)
 from causalab.protocol.sweep import DEFAULT_POINT_CAP, Expansion, expand
 from causalab.protocol.validate import validate_document
 
@@ -160,7 +166,16 @@ def _check_loaded_featurizers(doc: Document, env: ResolutionEnv) -> None:
     ``params`` entry's file must exist, and its identity — when stamped —
     must name the same model (free constant tensors may come from outside
     causalab, so an unstamped params file is existence-checked only; a
-    stamped one must not contradict the document)."""
+    stamped one must not contradict the document).
+
+    A bundle written by a *swept* producer stamps per entry, not per file
+    (§8): the fields that differ between points live in the header's
+    ``entries`` table. The check therefore looks at the record of the entry
+    this document selects, whenever that entry is knowable here — an
+    authored ``entry``, or a bundle holding exactly one record for the slot.
+    A selection that only the executing point can make (implicit matching
+    off its own coordinates, §2.5) is checked when the stage is built, where
+    the point is known."""
     import dataclasses as _dc
 
     from causalab.protocol.resolve import check_artifact_identity
@@ -173,6 +188,13 @@ def _check_loaded_featurizers(doc: Document, env: ResolutionEnv) -> None:
         if defers is not None and defers(pspec.file_path):
             continue  # a run-tree path inside a workflow — checked at run time
         stamped = env.artifacts.read_identity(pspec.file_path)  # V15 if missing
+        if stamped is not None:
+            stamped = _entry_identity(
+                stamped,
+                slot=selector_slot(pspec.entry, "value"),
+                authored=pspec.entry,
+                what=f"params entry {pname!r} ({pspec.file_path})",
+            )
         if stamped is not None:
             check_artifact_identity(
                 stamped,
@@ -211,12 +233,69 @@ def _check_loaded_featurizers(doc: Document, env: ResolutionEnv) -> None:
                 for key, value in _dc.asdict(site).items()
                 if value is not None
             }
+        what = f"featurizer {fname!r} ({spec.file_path})"
         stamped = env.artifacts.read_identity(spec.file_path)
-        check_artifact_identity(
-            stamped,
-            {key: value for key, value in expected.items() if value is not None},
-            what=f"featurizer {fname!r} ({spec.file_path})",
+        slot = FEATURIZER_SLOTS.get(
+            spec.kind if isinstance(spec.kind, str) else "identity", ()
         )
+        resolved = (
+            _entry_identity(stamped, slot=slot[0], authored=spec.entry, what=what)
+            if stamped is not None and slot
+            else stamped
+        )
+        if resolved is None:
+            continue  # only the executing point can select — checked at build
+        check_artifact_identity(
+            resolved,
+            {key: value for key, value in expected.items() if value is not None},
+            what=what,
+        )
+
+
+def _entry_identity(
+    stamped: Mapping[str, Any],
+    *,
+    slot: str,
+    authored: Any,
+    what: str,
+) -> Mapping[str, Any] | None:
+    """The identity of the one bundle entry a spec selects: the file-level
+    stamp, overlaid with that entry's record from the header's ``entries``
+    table (§8).
+
+    Returns ``None`` when the table holds several candidates and the
+    document authored no ``entry`` — the selection is then the executing
+    point's, and so is the check. A bundle with no table at all is
+    file-level only, which is exactly what an un-swept or hand-made bundle
+    stamps.
+    """
+    raw = stamped.get("entries")
+    if not isinstance(raw, str):
+        return stamped
+    try:
+        table = json.loads(raw)
+    except json.JSONDecodeError:
+        return stamped
+    if not isinstance(table, dict) or not table:
+        return stamped
+    try:
+        key = select_entry(
+            table.keys(),
+            slot,
+            authored,
+            what=what,
+            coords_by_key=table,
+        )
+    except ValidationError as err:
+        if authored:
+            raise  # an authored selection that misses is a load error
+        if "selects none" in str(err):
+            return None
+        raise
+    record = table[key]
+    merged = {k: v for k, v in stamped.items() if k != "entries"}
+    merged.update({k: v for k, v in record.items() if k not in ("slot", "coords")})
+    return merged
 
 
 _INDEX = re.compile(r"^(.*)\[(\d+)\]$")

--- a/causalab/protocol/schema.py
+++ b/causalab/protocol/schema.py
@@ -369,16 +369,19 @@ class FeaturizerSpec:
     init: Leaf | None = None
     dtype: Leaf | None = None
     file_path: Leaf | None = None
+    entry: Any = None
     description: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
 class ParamSpec:
     """§2.6 — a free tensor owned by no featurizer: either a loaded constant
-    (``file_path``) or a trainable free tensor (``shape`` + ``init``, which
-    must then appear in ``train.params``)."""
+    (``file_path``, optionally narrowed to one bundle entry by ``entry``) or
+    a trainable free tensor (``shape`` + ``init``, which must then appear in
+    ``train.params``)."""
 
     file_path: Leaf | None = None
+    entry: Any = None
     shape: Leaf | None = None
     init: Leaf | None = None
     description: str | None = None
@@ -467,13 +470,16 @@ class TrainSpec:
 class SaveEntry:
     """§2.12 — one manifest entry. Read/metric entries carry
     ``model``/``input``; trained-featurizer entries carry ``site``. The
-    restated binding is cross-checked at validation, never trusted."""
+    restated binding is cross-checked at validation, never trusted.
+    ``reduce`` (reads only) saves a statistic over the gathered rows
+    instead of the rows themselves (§2.12)."""
 
     value: str
     file_path: str
     model: str | None = None
     input: str | None = None
     site: str | None = None
+    reduce: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -657,6 +663,51 @@ def _parse_sweep(spec: Any, elem: Callable[[Any, str], Any], path: str) -> Sweep
     return Sweep(
         values=tuple(elem(v, f"{path}.sweep[{i}]") for i, v in enumerate(values))
     )
+
+
+#: Reductions a ``save`` entry may apply to a read (§2.12). Closed, and
+#: deliberately one entry wide: ``mean`` is what mean-ablation needs, and a
+#: second kind should arrive with the consumer that needs it.
+SAVE_REDUCTIONS: tuple[str, ...] = ("mean",)
+
+
+def _entry_selector(
+    value: Any, path: str, *, allow_slot: bool = False
+) -> dict[str, Any]:
+    """§2.5/§2.6 ``entry``: a mapping of coordinate name to scalar value,
+    naming one entry inside a loaded bundle
+    (:mod:`causalab.protocol.bundles`). Names are the coordinate names as
+    they appear in the producer's keys (``k``, ``seed``,
+    ``target.layer``) — not full axis ids, which the consuming document has
+    no reason to know."""
+    obj = _require_mapping(value, path)
+    if not obj:
+        raise ParseError(
+            "P2", "an 'entry' selector names at least one coordinate", path=path
+        )
+    selector: dict[str, Any] = {}
+    for name, coord in obj.items():
+        if name == "slot":
+            if not allow_slot:
+                raise ParseError(
+                    "P2",
+                    "a featurizer bundle's slots are fixed by its kind — "
+                    "'slot' selects only inside a params bundle",
+                    path=f"{path}.slot",
+                )
+            if not isinstance(coord, str):
+                raise ParseError("P2", "'slot' names one tensor", path=f"{path}.slot")
+            selector[name] = coord
+            continue
+        if isinstance(coord, (dict, list)):
+            raise ParseError(
+                "P2",
+                f"entry coordinate {name!r} must be a scalar — a bundle key "
+                "records one value per coordinate",
+                path=f"{path}.{name}",
+            )
+        selector[name] = coord
+    return selector
 
 
 def _scalar_str(value: Any, path: str) -> str:
@@ -887,10 +938,16 @@ def _parse_featurizer(raw: Any, path: str) -> FeaturizerSpec:
         f"{path}.kind",
     )
     kind_key = kind if isinstance(kind, str) else "identity"
-    allowed = {"kind", "file_path", "dtype", "description"} | set(
+    allowed = {"kind", "file_path", "entry", "dtype", "description"} | set(
         FEATURIZER_FIELDS.get(kind_key, frozenset())
     )
     _check_keys(obj, allowed, path)
+    if "entry" in obj and "file_path" not in obj:
+        raise ParseError(
+            "P2",
+            "'entry' selects inside a loaded bundle — it needs a file_path",
+            path=path,
+        )
     parametrization = None
     if "parametrization" in obj:
         parametrization = _wrapped(
@@ -913,6 +970,9 @@ def _parse_featurizer(raw: Any, path: str) -> FeaturizerSpec:
         file_path=_wrapped(obj["file_path"], _scalar_str, f"{path}.file_path")
         if "file_path" in obj
         else None,
+        entry=_wrapped(obj["entry"], _entry_selector, f"{path}.entry")
+        if "entry" in obj
+        else None,
         description=obj.get("description"),
     )
 
@@ -926,9 +986,15 @@ def _parse_featurizers(raw: Any, path: str) -> dict[str, FeaturizerSpec]:
 
 def _parse_param(raw: Any, path: str) -> ParamSpec:
     obj = _require_mapping(raw, path)
-    _check_keys(obj, ("file_path", "shape", "init", "description"), path)
+    _check_keys(obj, ("file_path", "entry", "shape", "init", "description"), path)
     loaded = "file_path" in obj
     trainable = "shape" in obj or "init" in obj
+    if "entry" in obj and not loaded:
+        raise ParseError(
+            "P2",
+            "'entry' selects inside a loaded bundle — it needs a file_path",
+            path=path,
+        )
     if loaded == trainable:
         raise ParseError(
             "P2",
@@ -942,6 +1008,13 @@ def _parse_param(raw: Any, path: str) -> ParamSpec:
     return ParamSpec(
         file_path=_wrapped(obj["file_path"], _scalar_str, f"{path}.file_path")
         if loaded
+        else None,
+        entry=_wrapped(
+            obj["entry"],
+            lambda v, p: _entry_selector(v, p, allow_slot=True),
+            f"{path}.entry",
+        )
+        if "entry" in obj
         else None,
         shape=_wrapped(obj["shape"], _int_list, f"{path}.shape")
         if "shape" in obj
@@ -1387,7 +1460,7 @@ def _parse_save(raw: Any, path: str) -> tuple[SaveEntry, ...]:
     for i, entry_raw in enumerate(raw):
         p = f"{path}[{i}]"
         obj = _require_mapping(entry_raw, p)
-        _check_keys(obj, ("value", "model", "input", "site", "file_path"), p)
+        _check_keys(obj, ("value", "model", "input", "site", "file_path", "reduce"), p)
         for field in ("value", "file_path"):
             if field not in obj:
                 raise ParseError("P2", f"a save entry needs {field!r}", path=p)
@@ -1418,6 +1491,9 @@ def _parse_save(raw: Any, path: str) -> tuple[SaveEntry, ...]:
                 if "input" in obj
                 else None,
                 site=_scalar_str(obj["site"], f"{p}.site") if "site" in obj else None,
+                reduce=_enum(obj["reduce"], SAVE_REDUCTIONS, f"{p}.reduce")
+                if "reduce" in obj
+                else None,
             )
         )
     return tuple(entries)

--- a/causalab/protocol/sweep.py
+++ b/causalab/protocol/sweep.py
@@ -26,7 +26,16 @@ from typing import Any, Iterator, Mapping
 
 from causalab.protocol.errors import ValidationError
 
-__all__ = ["Axis", "Expansion", "Point", "expand", "find_axes"]
+__all__ = [
+    "Axis",
+    "Expansion",
+    "Point",
+    "coordinate_label",
+    "expand",
+    "find_axes",
+    "label_value",
+    "short_coords",
+]
 
 
 #: Refuse a cross product larger than this without an explicit override
@@ -239,14 +248,18 @@ def _cross(axes: tuple[Axis, ...]) -> Iterator[tuple[Any, ...]]:
             yield (value, *tail)
 
 
-def coordinate_label(coords: Mapping[str, Any], *, entry: str | None = None) -> str:
-    """The ``[k=8]`` / ``[target.layer=5]`` suffix for derived names (§3).
+def short_coords(
+    coords: Mapping[str, Any], *, entry: str | None = None
+) -> dict[str, Any]:
+    """Coordinates keyed by their **short** names — the names that appear in
+    labels, in saved tensor keys, and therefore in an ``entry`` selector
+    (:mod:`causalab.protocol.bundles`).
 
     Coordinates on the named entry itself drop the entry prefix
-    (``rot[k=8]``, not ``rot[featurizers.rot.k=8]``); transitive coordinates
-    keep ``<entry>.<field>``; the table name is always dropped. ``train``
-    axes read best bare (``seed=0``)."""
-    parts: list[str] = []
+    (``k``, not ``featurizers.rot.k``); transitive coordinates keep
+    ``<entry>.<field>``; the table name is always dropped. ``train`` axes
+    read best bare (``seed``)."""
+    out: dict[str, Any] = {}
     for axis_id, value in coords.items():
         segments = axis_id.split(".")
         if len(segments) >= 2 and segments[0] in (
@@ -263,11 +276,24 @@ def coordinate_label(coords: Mapping[str, Any], *, entry: str | None = None) -> 
             segments = segments[1:]
         if entry is not None and len(segments) >= 2 and segments[0] == entry:
             segments = segments[1:]
-        parts.append(f"{'.'.join(segments)}={_label_value(value)}")
+        out[".".join(segments)] = value
+    return out
+
+
+def coordinate_label(coords: Mapping[str, Any], *, entry: str | None = None) -> str:
+    """The ``[k=8]`` / ``[target.layer=5]`` suffix for derived names (§3),
+    over :func:`short_coords`."""
+    parts = [
+        f"{name}={label_value(value)}"
+        for name, value in short_coords(coords, entry=entry).items()
+    ]
     return f"[{','.join(parts)}]" if parts else ""
 
 
-def _label_value(value: Any) -> str:
+def label_value(value: Any) -> str:
+    """One coordinate value as it appears in a label — and therefore in a
+    saved tensor key, which :mod:`causalab.protocol.bundles` matches
+    against, so this rendering is part of the artifact contract."""
     if isinstance(value, Mapping):
         # a swept spec (e.g. a position): label by its single distinguishing pair
         pairs = ",".join(f"{k}:{v}" for k, v in value.items())

--- a/causalab/protocol/validate.py
+++ b/causalab/protocol/validate.py
@@ -650,6 +650,14 @@ def _check_save_binding(doc: Document, entry: SaveEntry, path: str) -> None:
             path=path,
         )
     is_metric = entry.value in doc.metrics
+    if entry.reduce is not None and is_metric:
+        raise ValidationError(
+            10,
+            f"save entry for metric {entry.value!r} carries 'reduce' — a metric "
+            "is already a reduction over its read; reduce applies to reads "
+            "(§2.12)",
+            path=path,
+        )
     expected_ext = ".parquet" if is_metric else ".safetensors"
     if not entry.file_path.endswith(expected_ext):
         raise ValidationError(
@@ -683,6 +691,13 @@ def _check_save_featurizer(
             10,
             f"featurizer {entry.value!r} is used at site(s) {sorted(used_sites)}, "
             f"not {entry.site!r} — the restated site is cross-checked (§2.12)",
+            path=path,
+        )
+    if entry.reduce is not None:
+        raise ValidationError(
+            10,
+            "a featurizer bundle carries fitted parameters, not gathered rows — "
+            "'reduce' applies to reads (§2.12)",
             path=path,
         )
     if not entry.file_path.endswith(".safetensors"):

--- a/causalab/protocol/workflow.py
+++ b/causalab/protocol/workflow.py
@@ -30,11 +30,27 @@ import re
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
+from causalab.protocol.bundles import (
+    entry_key,
+    entry_selection,
+    select_entry,
+    selector_slot,
+)
 from causalab.protocol.canonical import canonical_bytes
-from causalab.protocol.errors import ParseError, ProtocolError, suggest
+from causalab.protocol.errors import (
+    ParseError,
+    ProtocolError,
+    ValidationError,
+    suggest,
+)
 from causalab.protocol.loader import LoadedProtocol, apply_overrides, load, load_text
 from causalab.protocol.resolve import ArtifactStore, ResolutionEnv
-from causalab.protocol.sweep import DEFAULT_POINT_CAP
+from causalab.protocol.schema import FEATURIZER_SLOTS
+from causalab.protocol.sweep import (
+    DEFAULT_POINT_CAP,
+    coordinate_label,
+    short_coords,
+)
 
 __all__ = [
     "DeferredArtifacts",
@@ -734,6 +750,14 @@ def load_workflow(
                     "must name a file the step actually saves (§5.10)",
                     path=f"steps.{name}",
                 )
+            if isinstance(producer_step, ProtocolStep):
+                _check_entry_selection(
+                    consumer=inner[name],
+                    producer=inner[producer],
+                    run_path=run_path,
+                    rest=rest,
+                    step=name,
+                )
 
     for i, entry in enumerate(document.save):
         if entry.step not in steps:
@@ -777,6 +801,77 @@ def load_workflow(
         canonical=canonical,
         digest=digest,
     )
+
+
+def _bundle_entries(
+    producer: LoadedProtocol, file_path: str
+) -> dict[str, dict[str, Any]] | None:
+    """The tensor keys a producing document will write into ``file_path``,
+    with their coordinates — derivable at load because sweeps expand
+    deterministically (§3), which is what lets a wrong selection fail here
+    instead of after the producing step has run."""
+    entries: dict[str, dict[str, Any]] = {}
+    for save_entry in producer.document.save:
+        if save_entry.file_path != file_path:
+            continue
+        if save_entry.value in producer.document.metrics:
+            return None  # a metric table, not a tensor bundle
+        # a saved read is keyed by the read's name; a fitted featurizer by
+        # its kind's slots — either way the coordinates are labelled against
+        # the *declared* entity, which is the name a selector can write
+        if save_entry.value in producer.document.reads:
+            slots: tuple[str, ...] = (save_entry.value,)
+        else:
+            spec = producer.document.featurizers.get(save_entry.value)
+            kind = spec.kind if spec is not None and isinstance(spec.kind, str) else ""
+            slots = FEATURIZER_SLOTS.get(kind, ())
+        if not slots:
+            return None
+        for point in producer.expansion.points:
+            short = short_coords(point.coords, entry=save_entry.value)
+            label = coordinate_label(point.coords, entry=save_entry.value)
+            for slot in slots:
+                entries[entry_key(slot, label)] = {"slot": slot, "coords": short}
+    return entries or None
+
+
+def _check_entry_selection(
+    *,
+    consumer: LoadedProtocol,
+    producer: LoadedProtocol,
+    run_path: str,
+    rest: str,
+    step: str,
+) -> None:
+    """§5.10, second half: the entry a load selects must be one the producer
+    will write, for every point of the consuming document."""
+    entries = _bundle_entries(producer, rest)
+    if entries is None:
+        return
+    for expanded, point in zip(consumer.expansion.points, consumer.point_documents):
+        loads: list[tuple[str, str, Any]] = []
+        for fname, spec in point.featurizers.items():
+            if spec.file_path == run_path:
+                kind = spec.kind if isinstance(spec.kind, str) else "identity"
+                slots = FEATURIZER_SLOTS.get(kind, ())
+                if slots:
+                    loads.append((fname, slots[0], spec.entry))
+        for pname, pspec in point.params.items():
+            if pspec.file_path == run_path:
+                loads.append((pname, selector_slot(pspec.entry, "value"), pspec.entry))
+        for name, slot, authored in loads:
+            want, implicit = entry_selection(authored, expanded.coords, name)
+            try:
+                select_entry(
+                    entries.keys(),
+                    slot,
+                    want,
+                    what=f"step {step!r}: {name!r} loads {run_path!r}",
+                    coords_by_key=entries,
+                    implicit=implicit,
+                )
+            except ValidationError as err:
+                raise WorkflowError(10, str(err), path=f"steps.{step}") from err
 
 
 def _canonicalize(

--- a/docs/CODEBASE.md
+++ b/docs/CODEBASE.md
@@ -24,6 +24,7 @@ The normative spec is [`docs/intervention_protocol.md`](intervention_protocol.md
 | `loader.py` | strict load, `--set` overrides, the §5 validation checklist, column checks |
 | `canonical.py` | canonical form + digests (§7) |
 | `sweep.py` | axis expansion, point cap, coordinate labels (§3) |
+| `bundles.py` | addressing one entry inside a saved `.safetensors` bundle: key grammar, coordinate selection (§2.5, §2.6) |
 | `plan.py` | model graph → forward groups, content dedup (§4) |
 | `backend.py` | `Backend` ABC, `ExecutionRequest`/`RunResult`, capability routing (§8) |
 | `resolve.py` | `ResolutionEnv`: `FileDatasets` (JSON tables), `FileArtifacts`, `ArtifactIdentity` build/check |

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -50,7 +50,7 @@ Every pinned file follows the same rule: **regenerate via its script, review the
 
 ### Smoke
 
-Corpus documents (`tests/protocols/*_im.json`) run through the real CLI on `hf-internal-testing/tiny-random-LlamaForCausalLM` with `--set` overrides retargeting layers/model at tiny scale. Assertions are existence/shape/dtype only — tiny-random output content is garbage by design. The workflow capstone (`tests/neural/pytorch_hooks/test_workflow_run.py`) runs the whole weekdays pipeline shape the same way.
+Corpus documents (`tests/protocols/*_im.json`) run through the real CLI on `hf-internal-testing/tiny-random-LlamaForCausalLM` with `--set` overrides retargeting layers/model at tiny scale. Assertions are existence/shape/dtype only — tiny-random output content is garbage by design. The workflow capstone (`tests/neural/pytorch_hooks/test_workflow_run.py`) runs the whole weekdays pipeline shape the same way, and `test_bundle_entries_run.py` covers the two tensor handoffs between steps: a *swept* fit applied at one selected coordinate (the capstone deliberately collapses that sweep, which is how the gap went unseen) and a mean-ablation harvest reduced at save time.
 
 ### Golden
 

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -129,6 +129,22 @@ Component vocabulary (per-backend `SiteResolver` maps each to a tap):
 - **`file_path`** (optional): load a fitted artifact instead of computing.
   Its `ArtifactIdentity` (sec. 8) is checked; mismatch refuses. A loaded
   featurizer may not appear in `train.params`.
+- **`entry`** (optional, only with `file_path`): which entry of that bundle.
+  A swept document writes one file across all its points, keyed by
+  coordinate (`weight[k=8,seed=0]`, sec. 2.12), so "the fit at k=8, seed=0"
+  is `{"entry": {"k": 8, "seed": 0}}` — coordinate *names*, as they appear
+  in the key, not full axis ids.
+  - Omitted, the entry is implied by the **consuming point's own
+    coordinates**: axis identity is name identity (sec. 3), so a document
+    swept on `featurizers.rot.k` selects the fit at *its* `k` and the two
+    sweeps zip instead of crossing. Coordinates the producer never had are
+    ignored; a bundle with a single entry needs nothing.
+  - A selection that matches no entry, or more than one, is a **load
+    error** — never first-hit-wins. Inside a workflow it is caught before
+    any step runs, since a producing document's entry names follow from its
+    own expansion (workflow spec sec. 5.10).
+  - All of a bundle's slots for one entry come from the same point: an
+    SAE's `enc` and `dec` cannot be crossed between fits.
 
 ### 2.6 `params` (optional)
 
@@ -137,7 +153,13 @@ Free tensors owned by no featurizer (steering vectors, a free written value):
 | field | meaning |
 |---|---|
 | `file_path` | constant tensor, loaded |
+| `entry` | which entry of that bundle (sec. 2.5), plus the reserved `slot` key |
 | `shape`, `init` | trainable free tensor (must then appear in `train.params`) |
+
+- A loaded constant is read from the bundle's `value` tensor by convention.
+  A bundle *harvested from a read* is keyed by that read's name instead, so
+  `{"entry": {"slot": "acts"}}` names it. `slot` is a params-only key — a
+  featurizer's slots are fixed by its kind.
 
 ### 2.7 `reads`
 
@@ -284,7 +306,18 @@ everything that leaves the run. Three saveable kinds, two entry shapes:
   drift-protected documentation, never a second source of truth.
 - `file_path` is relative to the run's output directory. Tensors →
   `.safetensors`; per-example metric tables → `.parquet`. In swept documents
-  the path is unchanged; axis coordinates become columns / keyed entries.
+  the path is unchanged; axis coordinates become columns / keyed entries
+  (`weight[k=8,seed=0]`, one record per entry in the header's `entries`
+  table — sec. 8).
+- **`reduce`** (optional, reads only): save a statistic over the read's
+  gathered rows instead of the rows. Closed vocabulary, `mean` in v1:
+  `(…, width)` collapses to `(width,)`, the broadcast form a write operand
+  takes (sec. 2.8) — mean ablation is a harvest with `reduce: mean` feeding
+  a `params` constant. The reduction happens where the rows are gathered, so
+  the un-reduced harvest never reaches disk: an ablation grid over an 8B
+  model's layers is gigabytes of activations for kilobytes of means. A
+  metric already reduces its read, and a featurizer bundle holds fitted
+  parameters rather than rows; `reduce` on either is a load error.
 - Rules (all load errors): every metric saved (no objective/eval exception —
   the loss trajectory is always in the results) · every trained featurizer
   saved · untrained or `file_path`-loaded featurizers not saveable · writes
@@ -417,6 +450,15 @@ A backend implements these services:
 refuses): `produced_by` digest · model key + revision · tokenizer · site
 record · `k` · parametrization · dtype · trained-on data ref + digest ·
 backend · code commit.
+
+**Per entry, not per file.** A swept document writes one file from many
+points, so the file-level stamp carries only what every point agrees on;
+whatever differs (`k`, the point digest, a swept site) is stamped per tensor
+key in an `entries` table in the same header — `{key: {slot, coords, …identity}}`.
+That table is what makes an entry selectable (sec. 2.5) and provable: the
+check runs against the record of the entry a document actually selects. A
+bundle with no table is a single-point or hand-made artifact and is checked
+at file level, as before.
 
 **Capabilities.** `requires` is derived from the document; a backend declares
 what it supports; `choose_backend = first b where requires ⊆ b.capabilities`;

--- a/docs/workflow_protocol.md
+++ b/docs/workflow_protocol.md
@@ -160,7 +160,10 @@ One mechanism, inherited from the IM spec: **artifact references**.
   canonical form stamps every resolved value, so the record shows which
   store answered.
 - The same overlay applies to `file_path` loads (a featurizer bundle
-  fitted by an earlier step: `"fit/rot.safetensors"`).
+  fitted by an earlier step: `"fit/rot.safetensors"`). A step that swept
+  writes one bundle holding one entry per point, so the loading document
+  names which with `entry` (IM spec §2.5) — authored, or implied by its own
+  sweep coordinates.
 - These references **are** the derived dependency edges, together with
   `from` on select/plot steps and `after`. The step graph must be
   acyclic; its topological order is the schedule skeleton, and steps with
@@ -213,7 +216,12 @@ One mechanism, inherited from the IM spec: **artifact references**.
 10. An artifact ref that names a step must name a `select` step (only
     they emit values tables), and a run-tree `file_path` load must name a
     file its step actually saves — both checkable at load from the emit
-    table and the inner save manifests.
+    table and the inner save manifests. The load must also select an
+    **entry** the producer will write, for every point of the consuming
+    document: a producing document's entry names follow from its own
+    expansion, which is deterministic at load (IM spec §3), so a mis-aimed
+    tensor handoff fails before any step runs rather than after the
+    producing step has spent its compute.
 
 ## 6. Derived — never authored
 
@@ -283,8 +291,17 @@ split), as one workflow over the golden-corpus documents 07/08/09:
     "fit": {"type": "protocol", "document": "../methods/weekdays_das_sweep.json",
              "set": {"positions.best": {"artifact": "best", "key": "best_pos"},
                      "sites.target.layer": {"artifact": "best", "key": "best_layer"}}},
+    "best_fit": {
+      "type": "select", "from": "fit", "table": "iia.parquet",
+      "choose": "max",
+      "emit": {"best_k": "featurizers.rot.k", "best_seed": "train.seed"}
+    },
     "apply": {"type": "protocol", "document": "../methods/weekdays_das_apply.json",
-               "set": {"featurizers.rot.file_path": "fit/rot.safetensors"}},
+               "set": {"featurizers.rot.file_path": "fit/rot.safetensors",
+                       "featurizers.rot.k": {"artifact": "best_fit", "key": "best_k"},
+                       "featurizers.rot.entry": {
+                         "k": {"artifact": "best_fit", "key": "best_k"},
+                         "seed": {"artifact": "best_fit", "key": "best_seed"}}}},
     "scan_heatmap": {"type": "plot", "plot": "heatmap", "from": "locate",
                       "table": "iia.parquet", "x": "sites.target.layer",
                       "y": "positions.tap", "value": "value",
@@ -296,6 +313,7 @@ split), as one workflow over the golden-corpus documents 07/08/09:
   },
   "save": [
     {"step": "best", "value": "values.json", "file_path": "best_cell.json"},
+    {"step": "best_fit", "value": "values.json", "file_path": "best_fit.json"},
     {"step": "fit", "value": "iia.parquet", "file_path": "fit_iia.parquet"},
     {"step": "apply", "value": "iia.parquet", "file_path": "apply_iia.parquet"},
     {"step": "scan_heatmap", "value": "scan_iia.png", "file_path": "scan_iia.png"},
@@ -304,13 +322,16 @@ split), as one workflow over the golden-corpus documents 07/08/09:
 }
 ```
 
-Derived schedule: `locate` → `best` → `fit` → `apply`, with
+Derived schedule: `locate` → `best` → `fit` → `best_fit` → `apply`, with
 `scan_heatmap` free to run as soon as `locate` finishes and `iia_by_k`
 after `fit` — two levels of parallelism nobody authored. The `set`
 overrides on `fit` re-point the corpus document's artifact refs at the
 in-run `best` step (the authored 08 document names a prior standalone
-run's artifact path); `apply` loads the rotation the `fit` step saved,
-with its ArtifactIdentity checked at load exactly as in a standalone run.
+run's artifact path). `fit` sweeps k × seed, so its bundle holds nine
+rotations: `best_fit` names the winning cell the same way `best` named the
+winning site, and `apply` selects that entry — one fit applied, provably the
+one the numbers chose, with its ArtifactIdentity checked exactly as in a
+standalone run.
 
 ## 11. Open (for the gate review)
 

--- a/tests/neural/pytorch_hooks/_drive.py
+++ b/tests/neural/pytorch_hooks/_drive.py
@@ -17,6 +17,20 @@ from causalab.protocol.validate import validate_document
 from tests.protocol._docs import in_order
 
 
+def bundle_loader(files: dict[str, dict[str, Any]]) -> Any:
+    """A ``load_tensors`` over in-memory bundles: path -> {slot: tensor}.
+
+    Tests that hand-build bundles carry no ``entries`` table, which is the
+    same shape an external (hand-made) artifact has — selection then falls
+    back to the entry keys themselves."""
+    from causalab.neural.pytorch_hooks.loading import TensorBundle
+
+    def load(path: str) -> TensorBundle:
+        return TensorBundle(tensors=files[path], entry_coords={})
+
+    return load
+
+
 def executor_for(
     doc_raw: dict[str, Any],
     bundle: ModelBundle,

--- a/tests/neural/pytorch_hooks/test_bundle_entries_run.py
+++ b/tests/neural/pytorch_hooks/test_bundle_entries_run.py
@@ -1,0 +1,328 @@
+"""Tensor handoffs between steps, end to end on tiny-random through the CLI.
+
+Two shapes the protocol could not express before, each the acceptance case
+of one half of the seam:
+
+* **A swept fit, applied.** The fit step really sweeps (k × seed), so its
+  bundle holds four rotations; the workflow picks the winning cell and the
+  apply step selects *that* entry. The pre-existing pipeline test
+  (``test_workflow_run.py``) collapses the same sweep to one point with
+  ``set`` — which is exactly why it never saw this gap.
+* **Mean ablation.** A harvest step reduces a read to its corpus mean at
+  save time, and an ablation step swaps that constant in as a ``params``
+  operand. The un-reduced activations never reach disk.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import torch
+from safetensors.torch import load_file
+
+from causalab.protocol.cli import main
+from causalab.protocol.resolve import read_safetensors_metadata
+
+from tests.neural.pytorch_hooks.conftest import TINY_LLAMA
+from tests.protocol._env import FIXTURES
+
+pytestmark = pytest.mark.smoke
+
+REPO = Path(__file__).resolve().parents[3]
+METHODS = str(REPO / "causalab/configs/methods")
+
+TINY = {"model.key": TINY_LLAMA}
+
+
+def _run_workflow(base: Path, document: dict) -> Path:
+    """Write one workflow beside a copy of the artifact fixtures and run it
+    through the CLI, exactly as a user would."""
+    artifacts = base / "artifacts"
+    shutil.copytree(FIXTURES / "artifacts", artifacts, dirs_exist_ok=True)
+    wf_dir = base / "workflows"
+    wf_dir.mkdir()
+    path = wf_dir / "wf.json"
+    path.write_text(json.dumps(document, indent=2))
+    out = base / "run"
+    code = main(
+        [
+            "run",
+            str(path),
+            "--data-root",
+            str(FIXTURES / "data"),
+            "--artifacts-root",
+            str(artifacts),
+            "--out",
+            str(out),
+        ]
+    )
+    assert code == 0
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# a swept fit, applied at one selected coordinate
+# --------------------------------------------------------------------------- #
+
+
+def _swept_pipeline() -> dict:
+    return {
+        "version": "1",
+        "description": "fit k x seed at one cell, then apply the winning fit",
+        "steps": {
+            "fit": {
+                "type": "protocol",
+                "document": f"{METHODS}/weekdays_das_sweep.json",
+                "set": {
+                    **TINY,
+                    "sites.target.layer": 0,
+                    "positions.best": {"index": -1},
+                    "featurizers.rot.k": {"sweep": [2, 4]},
+                    "train.seed": {"sweep": [0, 1]},
+                    "train.steps": {"epochs": 1},
+                    "train.batch": {"pairs": 2},
+                },
+            },
+            "best_fit": {
+                "type": "select",
+                "from": "fit",
+                "table": "iia.parquet",
+                "choose": "max",
+                "emit": {"best_k": "featurizers.rot.k", "best_seed": "train.seed"},
+            },
+            "apply": {
+                "type": "protocol",
+                "document": f"{METHODS}/weekdays_das_apply.json",
+                "set": {
+                    **TINY,
+                    "sites.target.layer": 0,
+                    "featurizers.rot.file_path": "fit/rot.safetensors",
+                    "featurizers.rot.k": {"artifact": "best_fit", "key": "best_k"},
+                    "featurizers.rot.entry": {
+                        "k": {"artifact": "best_fit", "key": "best_k"},
+                        "seed": {"artifact": "best_fit", "key": "best_seed"},
+                    },
+                },
+            },
+        },
+        "save": [
+            {"step": "best_fit", "value": "values.json", "file_path": "best_fit.json"},
+            {"step": "apply", "value": "iia.parquet", "file_path": "apply_iia.parquet"},
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def swept_run(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    return _run_workflow(tmp_path_factory.mktemp("swept"), _swept_pipeline())
+
+
+def test_the_swept_fit_writes_one_entry_per_point(swept_run):
+    bundle = load_file(str(swept_run / "fit/rot.safetensors"))
+    assert sorted(bundle) == [
+        "weight[k=2,seed=0]",
+        "weight[k=2,seed=1]",
+        "weight[k=4,seed=0]",
+        "weight[k=4,seed=1]",
+    ]
+
+
+def test_the_entries_are_actually_different_fits(swept_run):
+    """Selecting one entry only means something if the entries differ. Two
+    seeds at one k must give different rotations (the init seed reaches the
+    subspace) and a different k a different shape."""
+    bundle = load_file(str(swept_run / "fit/rot.safetensors"))
+    seed0, seed1 = bundle["weight[k=2,seed=0]"], bundle["weight[k=2,seed=1]"]
+    assert seed0.shape == seed1.shape
+    assert not torch.allclose(seed0, seed1)
+    assert bundle["weight[k=4,seed=0]"].shape[1] == 4
+
+
+def test_every_entry_carries_its_own_provenance(swept_run):
+    """The stamp that used to be last-point-wins: each entry records the
+    point that produced it, and the file level keeps only what they share."""
+    stamped = read_safetensors_metadata(swept_run / "fit/rot.safetensors")
+    assert stamped is not None
+    entries = json.loads(stamped["entries"])
+    assert entries["weight[k=2,seed=1]"]["coords"] == {"k": 2, "seed": 1}
+    assert entries["weight[k=4,seed=0]"]["k"] == "4"
+    digests = {record["produced_by"] for record in entries.values()}
+    assert len(digests) == 4  # one provenance unit per point
+    assert "k" not in stamped  # k varies, so the file cannot claim one
+
+
+def test_apply_consumed_the_selected_entry(swept_run):
+    chosen = json.loads((swept_run / "best_fit.json").read_text())
+    assert chosen["best_k"] in (2, 4)
+    assert chosen["best_seed"] in (0, 1)
+    manifest = json.loads((swept_run / "workflow.json").read_text())
+    assert manifest["steps"]["apply"]["status"] == "completed"
+    iia = pd.read_parquet(swept_run / "apply/iia.parquet")
+    assert len(iia) == 2  # the weekdays/test fixture rows
+    assert iia["value"].dtype.kind == "f"
+
+
+def test_an_unselected_load_refuses_before_anything_runs(tmp_path):
+    """The gap this closes: without a selector the load used to validate
+    clean and die with a KeyError after the fit had already run."""
+    document = _swept_pipeline()
+    document["steps"]["apply"]["set"].pop("featurizers.rot.entry")
+    document["steps"]["apply"]["set"].pop("featurizers.rot.k")
+    wf_dir = tmp_path / "workflows"
+    wf_dir.mkdir()
+    (wf_dir / "wf.json").write_text(json.dumps(document))
+    code = main(
+        [
+            "validate",
+            str(wf_dir / "wf.json"),
+            "--data-root",
+            str(FIXTURES / "data"),
+            "--artifacts-root",
+            str(tmp_path),
+        ]
+    )
+    assert code != 0
+
+
+# --------------------------------------------------------------------------- #
+# mean ablation: reduce at save, swap as a constant
+# --------------------------------------------------------------------------- #
+
+
+def _harvest_doc(reduce: bool) -> dict:
+    entry = {
+        "value": "acts",
+        "model": "original",
+        "input": "base",
+        "file_path": "acts.safetensors",
+    }
+    if reduce:
+        entry["reduce"] = "mean"
+    return {
+        "version": "1",
+        "description": "harvest one site over the train split",
+        "model": {"key": TINY_LLAMA, "revision": "main"},
+        "data": {"base": {"dataset": "weekdays/train", "field": "input"}},
+        "positions": {"tap": {"index": -1}},
+        "sites": {"target": {"component": "block_output", "layer": 0}},
+        "reads": {
+            "acts": {
+                "site": "target",
+                "pos": "tap",
+                "model": "original",
+                "input": "base",
+            }
+        },
+        "save": [entry],
+    }
+
+
+def _ablate_doc() -> dict:
+    return {
+        "version": "1",
+        "description": "mean-ablate the site by swapping in the corpus mean",
+        "model": {"key": TINY_LLAMA, "revision": "main"},
+        "data": {"base": {"dataset": "weekdays/test", "field": "input"}},
+        "positions": {"tap": {"index": -1}},
+        "sites": {
+            "target": {"component": "block_output", "layer": 0},
+            "lm_head": {"component": "lm_head"},
+        },
+        "params": {
+            # the producer keyed the bundle by its read's name, not by the
+            # params convention 'value' — 'slot' is how a consumer says so
+            "mu": {
+                "file_path": "harvest/acts.safetensors",
+                "entry": {"slot": "acts"},
+            }
+        },
+        "reads": {
+            "logits": {
+                "site": "lm_head",
+                "pos": -1,
+                "model": "ablated",
+                "input": "base",
+            }
+        },
+        "writes": {
+            "ablate": {"site": "target", "pos": "tap", "do": {"swap": "mu"}},
+        },
+        "intervened_models": {"ablated": {"input": "base", "writes": ["ablate"]}},
+        "metrics": {
+            "ld": {
+                "kind": "logit_diff",
+                "of": "logits",
+                "a": "base_answer",
+                "b": "cf_answer",
+            }
+        },
+        "save": [
+            {
+                "value": "ld",
+                "model": "ablated",
+                "input": "base",
+                "file_path": "ld.parquet",
+            }
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def ablation_run(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    base = tmp_path_factory.mktemp("ablate")
+    docs = base / "docs"
+    docs.mkdir()
+    (docs / "harvest.json").write_text(json.dumps(_harvest_doc(reduce=True)))
+    (docs / "rows.json").write_text(json.dumps(_harvest_doc(reduce=False)))
+    (docs / "ablate.json").write_text(json.dumps(_ablate_doc()))
+    document = {
+        "version": "1",
+        "description": "harvest a corpus mean, then mean-ablate with it",
+        "steps": {
+            "harvest": {"type": "protocol", "document": "../docs/harvest.json"},
+            "rows": {"type": "protocol", "document": "../docs/rows.json"},
+            "ablate": {"type": "protocol", "document": "../docs/ablate.json"},
+        },
+        "save": [
+            {
+                "step": "harvest",
+                "value": "acts.safetensors",
+                "file_path": "mean.safetensors",
+            },
+            {
+                "step": "rows",
+                "value": "acts.safetensors",
+                "file_path": "rows.safetensors",
+            },
+            {"step": "ablate", "value": "ld.parquet", "file_path": "ld.parquet"},
+        ],
+    }
+    return _run_workflow(base, document)
+
+
+def test_a_reduced_read_saves_one_vector(ablation_run):
+    mean = load_file(str(ablation_run / "mean.safetensors"))["acts"]
+    rows = load_file(str(ablation_run / "rows.safetensors"))["acts"]
+    assert mean.ndim == 1
+    assert mean.shape[0] == rows.shape[-1]
+    assert rows.numel() > mean.numel()  # what never has to reach disk
+
+
+def test_the_reduction_is_the_mean_of_the_rows(ablation_run):
+    """Sanity check against the un-reduced save of the same read."""
+    mean = load_file(str(ablation_run / "mean.safetensors"))["acts"]
+    rows = load_file(str(ablation_run / "rows.safetensors"))["acts"]
+    expected = rows.to(torch.float32).reshape(-1, rows.shape[-1]).mean(dim=0)
+    assert torch.allclose(mean, expected, atol=1e-6)
+
+
+def test_the_ablation_consumed_the_harvested_mean(ablation_run):
+    ld = pd.read_parquet(ablation_run / "ld.parquet")
+    assert len(ld) == 2
+    assert ld["value"].notna().all()
+    manifest = json.loads((ablation_run / "workflow.json").read_text())
+    assert manifest["steps"]["ablate"]["status"] == "completed"

--- a/tests/neural/pytorch_hooks/test_featurizer_device.py
+++ b/tests/neural/pytorch_hooks/test_featurizer_device.py
@@ -32,6 +32,7 @@ from causalab.neural.pytorch_hooks.featurizers import (
     Subspace,
     build_stack,
 )
+from causalab.neural.pytorch_hooks.loading import TensorBundle
 from causalab.protocol.schema import FeaturizerSpec
 
 pytestmark = pytest.mark.unit
@@ -46,17 +47,20 @@ DEVICES = [
 ]
 
 
-def _load_tensors(_path: str) -> dict[str, torch.Tensor]:
+def _load_tensors(_path: str) -> TensorBundle:
     """Loaded bundles arrive from files on CPU, whatever the run's device."""
-    return {
-        "weight": torch.eye(WIDTH)[:, :K].contiguous(),
-        "mu": torch.zeros(WIDTH),
-        "sigma": torch.ones(WIDTH),
-        "enc": torch.zeros(WIDTH, 5),
-        "dec": torch.zeros(5, WIDTH),
-        "b_enc": torch.zeros(5),
-        "b_dec": torch.zeros(WIDTH),
-    }
+    return TensorBundle(
+        tensors={
+            "weight": torch.eye(WIDTH)[:, :K].contiguous(),
+            "mu": torch.zeros(WIDTH),
+            "sigma": torch.ones(WIDTH),
+            "enc": torch.zeros(WIDTH, 5),
+            "dec": torch.zeros(5, WIDTH),
+            "b_enc": torch.zeros(5),
+            "b_dec": torch.zeros(WIDTH),
+        },
+        entry_coords={},
+    )
 
 
 SPECS: dict[str, FeaturizerSpec] = {

--- a/tests/neural/pytorch_hooks/test_parity_goldens.py
+++ b/tests/neural/pytorch_hooks/test_parity_goldens.py
@@ -49,7 +49,11 @@ from causalab.neural.pytorch_hooks.loading import ModelBundle
 from causalab.protocol.registry import model_info_from_hf_config
 
 from tests._helpers.tiny import fresh_tiny_random_gpt2, fresh_tiny_random_llama
-from tests.neural.pytorch_hooks._drive import base_data_section, executor_for
+from tests.neural.pytorch_hooks._drive import (
+    base_data_section,
+    bundle_loader,
+    executor_for,
+)
 
 pytestmark = pytest.mark.numerical_unit
 
@@ -245,7 +249,7 @@ def _run_sub3_case(
         doc["reads"]["out"] = _read("dst", "original", featurizer="rot")
         doc["save"] = [_save("out", "original")]
         executor = executor_for(
-            doc, bundle, base_texts=[BASE_TEXT], load_tensors=tensors.__getitem__
+            doc, bundle, base_texts=[BASE_TEXT], load_tensors=bundle_loader(tensors)
         )
         return executor.read_value("out"), None
 
@@ -288,7 +292,7 @@ def _run_sub3_case(
     doc["writes"] = {"e": write}
     doc["intervened_models"] = {"patched": {"input": "base", "writes": ["e"]}}
     executor = executor_for(
-        doc, bundle, base_texts=[BASE_TEXT], load_tensors=tensors.__getitem__
+        doc, bundle, base_texts=[BASE_TEXT], load_tensors=bundle_loader(tensors)
     )
     if mode == "mask":
         # The gate stage operates in the rotation's k=3 feature space, so it

--- a/tests/protocol/corpus_digests.json
+++ b/tests/protocol/corpus_digests.json
@@ -119,9 +119,9 @@
     ]
   },
   "09_das_apply_im.json": {
-    "document": "53d1782d61b73e8f3b1873e56a64fd5da7627a837fe9fd3d7ab9fd163164d96b",
+    "document": "168fc49aae13e36d6ddc294e2fe52fbce17841c47c9c9d7a695b8f5c56fedd9e",
     "points": [
-      "53d1782d61b73e8f3b1873e56a64fd5da7627a837fe9fd3d7ab9fd163164d96b"
+      "168fc49aae13e36d6ddc294e2fe52fbce17841c47c9c9d7a695b8f5c56fedd9e"
     ]
   }
 }

--- a/tests/protocol/test_bundles.py
+++ b/tests/protocol/test_bundles.py
@@ -1,0 +1,144 @@
+"""Addressing one entry inside a tensor bundle (§2.5, §2.6).
+
+The producer keys entries off its *own* document (``weight[k=8,seed=0]``)
+while a consumer names a slot (``weight``); these are the rules that bridge
+the two without ever guessing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from causalab.protocol.bundles import (
+    entry_selection,
+    parse_entry_key,
+    select_entry,
+)
+from causalab.protocol.errors import ValidationError
+
+pytestmark = pytest.mark.unit
+
+SWEPT = [
+    "weight[k=2,seed=0]",
+    "weight[k=2,seed=1]",
+    "weight[k=4,seed=0]",
+    "weight[k=4,seed=1]",
+]
+
+
+class TestParseEntryKey:
+    def test_slot_and_coordinates(self):
+        assert parse_entry_key("weight[k=8,seed=0]") == (
+            "weight",
+            {"k": "8", "seed": "0"},
+        )
+
+    def test_bare_slot(self):
+        assert parse_entry_key("value") == ("value", {})
+
+    def test_structured_coordinate_is_opaque(self):
+        """A swept position renders as ``tap={index:-1}``; a flat split
+        cannot read that back, so the key stays opaque and the entry table
+        answers instead."""
+        key = "v[tap={index:-1}]"
+        assert parse_entry_key(key) == (key, {})
+
+
+class TestSelectEntry:
+    def test_single_entry_needs_no_selector(self):
+        assert select_entry(["weight"], "weight", None, what="w") == "weight"
+
+    def test_selects_by_coordinates(self):
+        assert (
+            select_entry(SWEPT, "weight", {"k": 4, "seed": 1}, what="w")
+            == "weight[k=4,seed=1]"
+        )
+
+    def test_int_and_string_coordinates_agree(self):
+        """The bundle key records ``k=4``; a document may author either."""
+        assert select_entry(SWEPT, "weight", {"k": "4", "seed": 1}, what="w") == (
+            select_entry(SWEPT, "weight", {"k": 4, "seed": 1}, what="w")
+        )
+
+    def test_ambiguous_selection_refuses(self):
+        with pytest.raises(ValidationError) as err:
+            select_entry(SWEPT, "weight", {"k": 4}, what="featurizer 'rot'")
+        assert "must be unique" in str(err.value)
+        assert "seed" in str(err.value)  # names what is still open
+
+    def test_no_selector_against_many_entries_refuses(self):
+        with pytest.raises(ValidationError) as err:
+            select_entry(SWEPT, "weight", None, what="featurizer 'rot'")
+        assert "selects none" in str(err.value)
+
+    def test_missing_coordinate_refuses(self):
+        with pytest.raises(ValidationError) as err:
+            select_entry(SWEPT, "weight", {"k": 99}, what="w")
+        assert "no 'weight' entry matches" in str(err.value)
+
+    def test_unknown_slot_refuses(self):
+        with pytest.raises(ValidationError) as err:
+            select_entry(SWEPT, "mu", None, what="w")
+        assert "holds no 'mu' entry" in str(err.value)
+
+    def test_widths_sidecar_is_not_a_candidate(self):
+        """A ragged read's ``.widths`` rides along with its parent entry."""
+        keys = ["v_mean", "v_mean.widths"]
+        assert select_entry(keys, "v_mean", None, what="w") == "v_mean"
+
+    def test_a_bundle_without_coordinates_answers_anything(self):
+        """An external, hand-made bundle records no coordinates: it cannot
+        answer a coordinate question, and cannot contradict one either."""
+        assert select_entry(["weight"], "weight", {"k": 8}, what="w") == "weight"
+
+    def test_entry_table_beats_the_key_text(self):
+        keys = ["v[tap={index:-1}]", "v[tap={index:-2}]"]
+        table = {
+            keys[0]: {"slot": "v", "coords": {"tap": {"index": -1}}},
+            keys[1]: {"slot": "v", "coords": {"tap": {"index": -2}}},
+        }
+        chosen = select_entry(
+            keys, "v", {"tap": {"index": -2}}, what="w", coords_by_key=table
+        )
+        assert chosen == keys[1]
+
+    def test_implicit_selection_drops_axes_the_producer_never_had(self):
+        """The consumer sweeps a layer the fit knew nothing about: that
+        coordinate is dropped rather than matching nothing."""
+        assert (
+            select_entry(
+                ["weight[k=2,seed=0]", "weight[k=4,seed=0]"],
+                "weight",
+                {"k": 4, "target.layer": 7},
+                what="w",
+                implicit=True,
+            )
+            == "weight[k=4,seed=0]"
+        )
+
+    def test_an_authored_selection_is_never_relaxed(self):
+        with pytest.raises(ValidationError):
+            select_entry(
+                ["weight[k=2,seed=0]"],
+                "weight",
+                {"k": 2, "target.layer": 7},
+                what="w",
+            )
+
+
+class TestEntrySelection:
+    def test_authored_entry_wins_and_is_explicit(self):
+        assert entry_selection({"k": 8}, {"featurizers.rot.k": 2}, "rot") == (
+            {"k": 8},
+            False,
+        )
+
+    def test_point_coordinates_stand_in_implicitly(self):
+        want, implicit = entry_selection(
+            None, {"featurizers.rot.k": 2, "train.seed": 1}, "rot"
+        )
+        assert want == {"k": 2, "seed": 1}
+        assert implicit is True
+
+    def test_an_unswept_consumer_implies_nothing(self):
+        assert entry_selection(None, {}, "rot") == (None, False)

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -266,6 +266,87 @@ def test_rule_10_untrained_featurizer_not_saveable():
     expect_rule(10, doc)
 
 
+def test_rule_10_reduce_on_a_metric_refused():
+    """§2.12: a metric is already a reduction over its read."""
+    doc = base_doc()
+    doc["save"][0]["reduce"] = "mean"
+    expect_rule(10, doc)
+
+
+def test_rule_10_reduce_on_a_featurizer_bundle_refused():
+    doc = base_doc()
+    doc["featurizers"] = {
+        "rot": {"kind": "subspace", "k": 4, "parametrization": "cayley"}
+    }
+    doc["reads"]["v_cf"]["featurizer"] = "rot"
+    doc["writes"]["patch"]["featurizer"] = "rot"
+    doc["train"] = {
+        "objective": [[1.0, "ld"]],
+        "params": ["rot"],
+        "optimizer": {"name": "adam", "lr": 0.001},
+        "steps": {"epochs": 1},
+        "batch": {"pairs": 2},
+    }
+    doc["save"].append(
+        {
+            "value": "rot",
+            "site": "tgt",
+            "file_path": "rot.safetensors",
+            "reduce": "mean",
+        }
+    )
+    expect_rule(10, doc)
+
+
+def test_a_reduced_read_is_a_valid_save():
+    doc = base_doc()
+    doc["save"].append(
+        {
+            "value": "v_cf",
+            "model": "original",
+            "input": "counterfactual",
+            "reduce": "mean",
+            "file_path": "mean.safetensors",
+        }
+    )
+    parse_and_validate(doc)
+
+
+def test_an_entry_selector_needs_a_file_path():
+    """'entry' selects *inside* a loaded bundle — there is nothing to
+    select in a featurizer that is fitted rather than loaded."""
+    doc = base_doc()
+    doc["featurizers"] = {
+        "rot": {
+            "kind": "subspace",
+            "k": 4,
+            "parametrization": "cayley",
+            "entry": {"k": 4},
+        }
+    }
+    doc["reads"]["v_cf"]["featurizer"] = "rot"
+    with pytest.raises(ParseError):
+        parse_and_validate(doc)
+
+
+def test_a_featurizer_may_not_rename_its_slots():
+    """A featurizer bundle's slots come from its kind; only a params
+    constant may name the tensor it wants."""
+    doc = base_doc()
+    doc["featurizers"] = {
+        "rot": {
+            "kind": "subspace",
+            "k": 4,
+            "parametrization": "cayley",
+            "file_path": "rot.safetensors",
+            "entry": {"slot": "acts"},
+        }
+    }
+    doc["reads"]["v_cf"]["featurizer"] = "rot"
+    with pytest.raises(ParseError):
+        parse_and_validate(doc)
+
+
 # rule 11 — sinks ---------------------------------------------------------------- #
 
 

--- a/tests/protocol/test_workflow.py
+++ b/tests/protocol/test_workflow.py
@@ -207,6 +207,7 @@ class TestWeekdaysWorkflow:
             "locate",
             "best",
             "fit",
+            "best_fit",
             "apply",
             "scan_heatmap",
             "iia_by_k",
@@ -215,7 +216,8 @@ class TestWeekdaysWorkflow:
             ("locate",),
             ("best", "scan_heatmap"),
             ("fit",),
-            ("apply", "iia_by_k"),
+            ("best_fit", "iia_by_k"),
+            ("apply",),
         )
 
     def test_digest_kinds_split_by_dependency(self, env):

--- a/tests/protocols/09_das_apply_im.json
+++ b/tests/protocols/09_das_apply_im.json
@@ -1,6 +1,6 @@
 {
   "version": "1",
-  "description": "Apply a previously fitted DAS rotation on the test split instead of re-computing it: the featurizer's file_path loads the artifact, and its ArtifactIdentity (model, site, k, parametrization, dtype) is checked on load - a mismatch refuses. No train section; a featurizer with file_path may not appear in train.params.",
+  "description": "Apply a previously fitted DAS rotation on the test split instead of re-computing it: the featurizer's file_path loads the artifact, and its ArtifactIdentity (model, site, k, parametrization, dtype) is checked on load - a mismatch refuses. 'entry' names which fit to apply: against this single-bundle artifact it is documentation, but the same document loaded against a swept fit's bundle (one entry per k x seed point) is how one rotation is picked out. No train section; a featurizer with file_path may not appear in train.params.",
   "model": {"key": "meta-llama/Llama-3.1-8B", "revision": "main"},
   "causal_model": {"key": "weekdays.causal_model"},
   "data": {
@@ -13,7 +13,8 @@
   },
   "featurizers": {
     "rot": {"kind": "subspace", "k": 8, "parametrization": "cayley",
-            "file_path": "artifacts/weekdays/llama31_8b/subspace/rot_k8.safetensors"}
+            "file_path": "artifacts/weekdays/llama31_8b/subspace/rot_k8.safetensors",
+            "entry": {"k": 8, "seed": 0}}
   },
   "reads": {
     "v_cf":  {"site": "target",  "pos": -1, "model": "original", "input": "counterfactual", "featurizer": "rot"},


### PR DESCRIPTION
Closes #26. Stacked on #21 (`can/pr20-token-form-and-device`) — review that first; the diff here is only the two commits above it.

## What this fixes

`.safetensors` files are already the tensor channel between steps: two load sites (`featurizers.<f>.file_path`, `params.<p>.file_path`), already a derived workflow dependency edge, already rule-10 validated, and `_coerce` already broadcasts a `(width,)` operand into a `[batch, n_pos, width]` slice. **A file just was not an address.** Three things were missing, and together they made *every* in-run handoff fail:

1. **Entry names.** The producer keys entries off its own document (`TensorFile.add` → `weight[k=8,seed=0]`); consumers hard-coded the slot (`tensors["weight"]`, `tensors["value"]`). Even an un-swept harvest → `params` handoff `KeyError`d.
2. **No reduce.** Nothing turned a per-example read into a corpus statistic, so mean ablation had nothing to point at.
3. **Per-entry provenance.** `bundle_file.metadata.update(...)` ran once per point, so the *last* point stamped `k`/`site` for the whole file.

## What changed

- **`entry` on a `file_path` load** (new `causalab/protocol/bundles.py`): selects one entry by coordinates. Omitted, the **consuming point's own coordinates** imply it — axis identity is name identity (§3), so a consumer swept on `featurizers.rot.k` *zips* to the producer's `k` instead of crossing it. No match, or several: load error, never first-hit-wins. `params` may also name the tensor with the reserved `slot` key, since a bundle harvested from a read is keyed by that read's name rather than by `value`.
- **Caught at load, inside a workflow.** A producing document's entry names follow from its own expansion, which is deterministic at load, so workflow rule 10 now checks the entry as well as the file. The old failure mode was a `KeyError` *after* the fit step had spent its GPU time.
- **Per-entry identity**, in an `entries` table in the safetensors header (`{key: {slot, coords, …identity}}`). The file level keeps only what every point agrees on; the check runs against the record of the entry a document actually selects, and the executing point re-checks `k`/`parametrization` when the selection was implicit. A bundle's slots for one entry are sliced by a shared suffix, so an SAE's `enc` and `dec` cannot be crossed between fits.
- **`reduce` on a saved read** — `mean` in v1, over the gathered rows, in fp32. It reduces where the rows are gathered, so the un-reduced harvest never reaches disk: for the mean-ablation layer grid on an 8B model that is ≈5.2 GB of activations (500 rows × 20 pos × 4096 × 4 B × 32) for ≈0.5 MB of means. Refused on metrics (already reductions) and on featurizer bundles (parameters, not rows).

Not changed, deliberately: no tensor operands, no tensor artifact refs. §2.8's "an operand is a read, a param, or a literal scalar — never a tensor" stands.

## One correction to the issue

#26 asks that `configs/workflows/weekdays_8b.json` run "unmodified". That criterion was wrong and I did not meet it. `fit` sweeps k × seed and `apply` has no train section, so **the document never said which of the nine fits to apply** — no selector can invent that. The workflow now names the winner with a `best_fit` select (the same shape as the existing `best` cell select) and `apply` selects that entry. It is a repair of an under-specified document, not a translation of a working one. Everything else in the acceptance list holds.

## Evidence

- `tests/neural/pytorch_hooks/test_bundle_entries_run.py` — a swept fit (k × seed, **not** collapsed) → `best_fit` → apply at the selected coordinate; and the mean-ablation shape: harvest with `reduce: mean` → `params` constant swap → scored ablation. The reduce is checked against an un-reduced save of the same read, and the "no selector" case is asserted to fail `validate`.
  The pre-existing pipeline test (`test_workflow_run.py:61-83`) `set`s `featurizers.rot.k: 2` and `train.seed: 0`, collapsing the sweep to one point — which is exactly why CI never saw this.
- `tests/protocol/test_bundles.py` — 18 unit tests over the selection rules (ambiguity, missing coordinate, ragged sidecar, entry table vs key text, implicit-vs-authored).
- `tests/protocol/test_validation_rules.py` — `reduce` misplacement, `entry` without `file_path`, `slot` on a featurizer.
- Full suite: **1477 passed**, 0 basedpyright errors, pre-commit clean. Only corpus 09's digest pin moves (it gained the `entry` field); every other pinned digest is byte-identical.

Docs updated in the same change: IM spec §2.5/§2.6/§2.12/§8, workflow spec §3/§5.10/§10, `CODEBASE.md`, `TESTS.md`.

Rebased onto the base's current head (through #28's seed threading): `build_stack`/`_build_stage`/`PointExecutor` now carry both the init `seed` and this branch's point `coords`. That rebase also made the swept-fit test sharper — with the seed actually reaching the subspace init, the four entries are four genuinely different rotations, so `test_the_entries_are_actually_different_fits` pins that selecting one entry means something. An earlier drive-by commit fixing the ROME golden's E741s was dropped: the base fixed the same five (`l` → `i`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

