### PR TITLE
ci: unpin the model on both Claude workflows, and print why a run failed

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,5 +46,25 @@ jobs:
 
             After conducting this review, read CLAUDE.md and conduct a second review pass with those additional considerations in mind.
 
+          # No --model: the action's default follows what the credential is
+          # entitled to. A pinned alias resolves locally and then fails on the
+          # first API call if the token cannot use that model — which is what
+          # this workflow did on every PR, indistinguishably from a bad token.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)" --model opus
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+
+      # The action reports `is_error: true` without the API error that caused
+      # it, so a failure here is otherwise unreadable. The execution log has
+      # the actual message.
+      - name: Surface the execution log on failure
+        if: failure()
+        run: |
+          log="${{ steps.claude-review.outputs.execution_file }}"
+          [ -f "$log" ] || log="${RUNNER_TEMP}/claude-execution-output.json"
+          if [ -f "$log" ]; then
+            echo "::group::claude-execution-output.json"
+            cat "$log"
+            echo "::endgroup::"
+          else
+            echo "no execution log at $log"
+          fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,5 +47,21 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-          claude_args: '--model opus'
+          # No --model here either: see claude-code-review.yml.
+
+      # The action reports `is_error: true` without the API error that caused
+      # it, so a failure here is otherwise unreadable. The execution log has
+      # the actual message.
+      - name: Surface the execution log on failure
+        if: failure()
+        run: |
+          log="${{ steps.claude.outputs.execution_file }}"
+          [ -f "$log" ] || log="${RUNNER_TEMP}/claude-execution-output.json"
+          if [ -f "$log" ]; then
+            echo "::group::claude-execution-output.json"
+            cat "$log"
+            echo "::endgroup::"
+          else
+            echo "no execution log at $log"
+          fi
 


### PR DESCRIPTION
Both Claude workflows in this repo are broken, and have been for as long as the run history shows. This unpins the model they share and makes the next failure readable.

## The symptom

`claude-code-review` has failed on **every non-draft PR** in the visible history — `can/dataset-seam`, `can/tensor-bundle-entries`, `can/protocol-all-positions`, `can/protocol-refactor` (2026-08-18 onward; everything earlier is `skipped`, i.e. draft PRs). Always the same shape:

```json
{"type": "result", "subtype": "success", "is_error": true,
 "duration_ms": 1960, "num_turns": 1, "total_cost_usd": 0}
```

One turn, ~2 s, no API error anywhere in the log. The tracking comment says only *"Claude encountered an error after 2s"*.

## Isolating it

I reproduced it from a second entry point: an `@claude` mention on a PR, which runs `claude.yml` **from `main`** — same token, different workflow, different prompt, no `track_progress`, no inline-comment tool. Identical signature (`num_turns: 1`, 2059 ms, `is_error: true`, [run](https://github.com/goodfire-ai/causalab/actions/runs/32469715455)).

Two different entry points failing identically rules out anything specific to the review workflow — its prompt, `track_progress`, the inline-comment MCP tool. What the two share is **the credential** and **`--model opus`**.

## The change

1. **Drop the `--model opus` pin** from both workflows. The alias resolves locally — the init line reports `"model": "claude-opus-5"` — and then fails on the first API request if the credential is not entitled to that model, which in this log is indistinguishable from a bad token. Without the pin, the action's default follows what the credential can actually use.
2. **Print `claude-execution-output.json` on failure.** The action declares an `execution_file` output and nothing read it, which is why the actual API error never reached the log. This is the part I'd keep regardless of what the cause turns out to be.

## Two caveats worth reading before merging

- **This PR's own checks prove nothing.** The action refuses to run when a PR's workflow file differs from the default branch's copy, and **self-skips as a passing check** ("Action skipped due to workflow validation error… your workflow will begin working once you merge your PR"). So `claude-review` will go green on this PR without executing. That is also why I could not test the fix before proposing it — a workflow change can only take effect on `main`.
- **If it still fails after merge, the remaining suspect is the token.** `CLAUDE_CODE_OAUTH_TOKEN` was last set 2026-06-11; rotating it means `claude setup-token` and updating the secret, which only its owner can do. The diagnostic step added here will name the cause instead of leaving it a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
