### PR TITLE
Workflow: a `transform` step type over a versioned op registry

### DIFF
--- a/causalab/neural/pytorch_hooks/backend.py
+++ b/causalab/neural/pytorch_hooks/backend.py
@@ -142,12 +142,24 @@ class PytorchHooksBackend(Backend):
                     entry.value, metric_values[entry.value], coords, point_digest
                 )
             elif entry.value in doc.reads:
+                # the site goes on the entry too: a harvested activation is
+                # bound to where it was read, and a consumer (a transform op
+                # fitting a basis on it, then a document loading that basis)
+                # has no other way to prove the two agree
+                read_site = _site_identity(doc, str(doc.reads[entry.value].site))
                 tensor_files.setdefault(entry.file_path, TensorFile()).add(
                     entry.value,
                     executor.read_value(entry.value),
                     coords,
                     reduce=entry.reduce,
-                    identity={"produced_by": point_digest},
+                    identity={
+                        "produced_by": point_digest,
+                        **(
+                            {"site": json.dumps(read_site, sort_keys=True)}
+                            if read_site
+                            else {}
+                        ),
+                    },
                 )
             else:  # a trained featurizer bundle
                 stage = trained_stages.get(entry.value)
@@ -187,26 +199,32 @@ def _summary_stat(values: list[Any]) -> Any:
     return f"{len(values)} rows"
 
 
+def _site_identity(doc: Document, site_name: str | None) -> dict[str, Any] | None:
+    """One site as the ArtifactIdentity records it — the non-null address
+    fields only, the shape ``loader.py`` builds its expectation in."""
+    if site_name is None or site_name not in doc.sites:
+        return None
+    record = doc.sites[site_name]
+    return {
+        key: value
+        for key, value in {
+            "component": record.component,
+            "layer": record.layer,
+            "head": record.head,
+            "expert": record.expert,
+            "stream": record.stream,
+        }.items()
+        if value is not None
+    }
+
+
 def _featurizer_identity(
     doc: Document, name: str, site_name: str | None, point_digest: str
 ) -> dict[str, str]:
     from causalab.protocol.resolve import build_artifact_identity
 
     spec = doc.featurizers[name]
-    site: Mapping[str, Any] | None = None
-    if site_name is not None:
-        record = doc.sites[site_name]
-        site = {
-            key: value
-            for key, value in {
-                "component": record.component,
-                "layer": record.layer,
-                "head": record.head,
-                "expert": record.expert,
-                "stream": record.stream,
-            }.items()
-            if value is not None
-        }
+    site = _site_identity(doc, site_name)
     base = doc.data["base"]
     trained_on = base.dataset if not isinstance(base, tuple) else base[0].dataset
     return build_artifact_identity(

--- a/causalab/protocol/workflow.py
+++ b/causalab/protocol/workflow.py
@@ -28,7 +28,7 @@ import dataclasses
 import hashlib
 import re
 from pathlib import Path
-from typing import Any, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence
 
 from causalab.protocol.bundles import (
     entry_key,
@@ -57,6 +57,8 @@ __all__ = [
     "LoadedWorkflow",
     "PLOT_KINDS",
     "STEP_TYPES",
+    "TransformInput",
+    "TransformStep",
     "WorkflowError",
     "WorkflowDocument",
     "is_workflow",
@@ -64,7 +66,7 @@ __all__ = [
     "parse_workflow",
 ]
 
-STEP_TYPES: tuple[str, ...] = ("protocol", "select", "plot")
+STEP_TYPES: tuple[str, ...] = ("protocol", "transform", "select", "plot")
 PLOT_KINDS: tuple[str, ...] = ("heatmap", "lines")
 CHOOSE_KINDS: tuple[str, ...] = ("max", "min")
 
@@ -101,6 +103,34 @@ class ProtocolStep:
 
 
 @dataclasses.dataclass(frozen=True)
+class TransformInput:
+    """One slot of a transform step's ``inputs``: an earlier step's output.
+
+    ``slot``/``entry`` address one entry inside a swept producer's tensor
+    bundle (IM spec §2.5). They are *authored only* — a transform step has no sweep
+    coordinates of its own, so the implicit coordinate matching a protocol
+    step gets does not apply here."""
+
+    step: str
+    value: str
+    slot: str | None = None
+    entry: Mapping[str, Any] | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class TransformStep:
+    type: str
+    op: str
+    inputs: Mapping[str, TransformInput]
+    outputs: Mapping[str, str]
+    #: materialized at parse against the op's schema, so the defaults are in
+    #: the canonical form and therefore in the digest (§7)
+    params: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+    after: tuple[str, ...] = ()
+    description: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
 class SelectStep:
     type: str
     from_: str
@@ -127,7 +157,7 @@ class PlotStep:
     description: str | None = None
 
 
-Step = ProtocolStep | SelectStep | PlotStep
+Step = ProtocolStep | TransformStep | SelectStep | PlotStep
 
 
 @dataclasses.dataclass(frozen=True)
@@ -161,6 +191,9 @@ class LoadedWorkflow:
     inner_digests: Mapping[str, str]
     canonical: Mapping[str, Any]
     digest: str
+    #: ``{transform step: digest of its canonical entry}`` — the provenance
+    #: unit a tensor that step writes is stamped with (§2.4)
+    transform_digests: Mapping[str, str] = dataclasses.field(default_factory=dict)
 
 
 def is_workflow(raw: Mapping[str, Any]) -> bool:
@@ -267,6 +300,13 @@ def _parse_step(name: str, raw: Any, path: str) -> Step:
             after=_after(raw, path),
             description=raw.get("description"),
         )
+    if step_type == "transform":
+        return _parse_transform_step(raw, path, common)
+    # every branch above returns, so this is the plot parser — spelled out
+    # rather than left as a fall-through, so a fifth step type added to
+    # STEP_TYPES without a branch fails loudly instead of parsing as a
+    # malformed plot
+    assert step_type == "plot", step_type
     _check_keys(
         raw,
         (*common, "plot", "from", "table", "x", "y", "series", "value", "file_path"),
@@ -304,9 +344,158 @@ def _parse_step(name: str, raw: Any, path: str) -> Step:
     )
 
 
+def _parse_transform_step(
+    raw: Mapping[str, Any], path: str, common: Sequence[str]
+) -> TransformStep:
+    """A ``transform`` step, checked against its op's record (§2.4).
+
+    The registry is imported *inside* this function on purpose. This package
+    is the backend-free document layer, so it keeps no module-level edge to a
+    package that executes numerics — the discipline ``cli.py`` follows for the
+    reference backend. The registry itself is torch-free, so ``validate`` and
+    ``digest`` still cost nothing but stdlib.
+    """
+    from causalab.transform.registry import lookup
+    from causalab.transform.schema import Table, TransformError, validate_params
+
+    _check_keys(raw, (*common, "op", "inputs", "params", "outputs"), path)
+    _need(raw, ("op", "inputs", "outputs"), path)
+    try:
+        op = lookup(raw["op"])
+    except TransformError as err:
+        raise WorkflowError(1, err.message, path=f"{path}.op") from err
+
+    inputs_raw = raw["inputs"]
+    if not isinstance(inputs_raw, Mapping):
+        raise WorkflowError(
+            1,
+            "'inputs' maps each of the op's input slots to an earlier step's output",
+            path=f"{path}.inputs",
+        )
+    for slot in inputs_raw:
+        if slot not in op.inputs:
+            raise WorkflowError(
+                1,
+                f"op {op.id} has no input slot {str(slot)!r}"
+                f"{suggest(str(slot), tuple(op.inputs))}",
+                path=f"{path}.inputs",
+            )
+    absent = [slot for slot in op.inputs if slot not in inputs_raw]
+    if absent:
+        raise WorkflowError(
+            1, f"op {op.id} needs input slot(s) {absent}", path=f"{path}.inputs"
+        )
+    inputs: dict[str, TransformInput] = {}
+    for slot, in_decl in op.inputs.items():
+        ref = inputs_raw[slot]
+        ref_path = f"{path}.inputs.{slot}"
+        if not isinstance(ref, Mapping):
+            raise WorkflowError(
+                1, "an input names {'step': …, 'value': …}", path=ref_path
+            )
+        _check_keys(ref, ("step", "value", "slot", "entry"), ref_path)
+        _need(ref, ("step", "value"), ref_path)
+        entry = ref.get("entry")
+        if entry is not None and (
+            not isinstance(entry, Mapping) or not all(isinstance(k, str) for k in entry)
+        ):
+            raise WorkflowError(
+                1,
+                "'entry' selects one bundle entry by coordinate (IM spec §2.5)",
+                path=ref_path,
+            )
+        bundle_slot = ref.get("slot")
+        if bundle_slot is not None and not isinstance(bundle_slot, str):
+            raise WorkflowError(
+                1, "'slot' is the producer's name for the tensor", path=ref_path
+            )
+        if isinstance(in_decl, Table) and (
+            bundle_slot is not None or entry is not None
+        ):
+            raise WorkflowError(
+                1,
+                f"input slot {slot!r} is a table — 'slot'/'entry' address a "
+                "tensor bundle",
+                path=ref_path,
+            )
+        value = _str_field(ref, "value", ref_path)
+        if not value.endswith(in_decl.suffix):
+            raise WorkflowError(
+                8,
+                f"input slot {slot!r} reads a {in_decl.suffix} output, got {value!r}",
+                path=ref_path,
+            )
+        inputs[slot] = TransformInput(
+            step=_str_field(ref, "step", ref_path),
+            value=value,
+            slot=bundle_slot,
+            entry=dict(entry) if entry is not None else None,
+        )
+
+    outputs_raw = raw["outputs"]
+    if not isinstance(outputs_raw, Mapping):
+        raise WorkflowError(
+            1,
+            "'outputs' maps each of the op's output slots to a file path",
+            path=f"{path}.outputs",
+        )
+    for slot in outputs_raw:
+        if slot not in op.outputs:
+            raise WorkflowError(
+                1,
+                f"op {op.id} declares no output slot {str(slot)!r}"
+                f"{suggest(str(slot), tuple(op.outputs))}",
+                path=f"{path}.outputs",
+            )
+    absent = [slot for slot in op.outputs if slot not in outputs_raw]
+    if absent:
+        raise WorkflowError(
+            1,
+            f"op {op.id} writes output slot(s) {absent} — every declared slot "
+            "needs a file path, so the record says what the step produces",
+            path=f"{path}.outputs",
+        )
+    outputs: dict[str, str] = {}
+    claimed: dict[str, str] = {}
+    for slot, out_decl in op.outputs.items():
+        out_path = f"{path}.outputs.{slot}"
+        file_path = _str_field(outputs_raw, slot, out_path)
+        if not file_path.endswith(out_decl.suffix):
+            raise WorkflowError(
+                8,
+                f"output slot {slot!r} writes a {out_decl.suffix} file, got "
+                f"{file_path!r}",
+                path=out_path,
+            )
+        _check_contained_path(file_path, 8, out_path)
+        if file_path in claimed:
+            raise WorkflowError(
+                3,
+                f"output slots {claimed[file_path]!r} and {slot!r} both write "
+                f"{file_path!r}",
+                path=out_path,
+            )
+        claimed[file_path] = slot
+        outputs[slot] = file_path
+
+    try:
+        params = validate_params(op.params, raw.get("params"), path=f"{path}.params")
+    except TransformError as err:
+        raise WorkflowError(1, err.message, path=err.path) from err
+    return TransformStep(
+        type="transform",
+        op=op.id,
+        inputs=inputs,
+        outputs=outputs,
+        params=params,
+        after=_after(raw, path),
+        description=raw.get("description"),
+    )
+
+
 def _check_contained_path(value: str, rule: int, path: str) -> None:
     """A workflow-owned file path stays inside its root: relative, no
-    parent escapes (§2.4 "within the step's output dir", §2.5 "under the
+    parent escapes (§2.5 "within the step's output dir", §2.6 "under the
     workflow's output root")."""
     parts = Path(value).parts
     if Path(value).is_absolute() or ".." in parts:
@@ -519,11 +708,11 @@ def load_workflow(
                 raise WorkflowError(
                     4, f"'from' names unknown step {step.from_!r}", path=f"steps.{name}"
                 )
-            if not isinstance(steps[step.from_], ProtocolStep):
+            if not isinstance(steps[step.from_], (ProtocolStep, TransformStep)):
                 raise WorkflowError(
                     4,
-                    f"'from' must name a protocol step; {step.from_!r} is a "
-                    f"{steps[step.from_].type} step",
+                    f"'from' must name a protocol or transform step; "
+                    f"{step.from_!r} is a {steps[step.from_].type} step",
                     path=f"steps.{name}",
                 )
             deps[name].add(step.from_)
@@ -540,6 +729,19 @@ def load_workflow(
                 f"a plot file_path ends in .png/.pdf, got {step.file_path!r}",
                 path=f"steps.{name}",
             )
+        if isinstance(step, TransformStep):
+            # a transform step's `inputs` ARE its dependency edges (§3) — the
+            # same rule artifact refs and run-tree loads follow, spelled once
+            # per slot instead of discovered by walking a nested document
+            for slot, ref in step.inputs.items():
+                if ref.step not in steps:
+                    raise WorkflowError(
+                        4,
+                        f"input {slot!r} names unknown step {ref.step!r}",
+                        path=f"steps.{name}.inputs.{slot}",
+                    )
+                deps[name].add(ref.step)
+                data_deps[name].add(ref.step)
         if isinstance(step, ProtocolStep):
             doc_path = (workflow_dir / step.document).resolve()
             if not doc_path.is_file():
@@ -612,6 +814,26 @@ def load_workflow(
     representatives: dict[tuple[str, str], Any] = {}
 
     def compute_representatives(select_name: str, select: SelectStep) -> None:
+        producer_step = steps[select.from_]
+        if isinstance(producer_step, TransformStep):
+            # a transform table's columns are declared, not swept, so the
+            # stand-in is a type-appropriate zero. Representatives only exist
+            # to type-check a consuming document at load; the real values
+            # arrive at run time (module docstring).
+            declared = _transform_table_columns(
+                producer_step, select.table, path=f"steps.{select_name}.table"
+            )
+            for key, column in select.emit.items():
+                if column not in declared:
+                    raise WorkflowError(
+                        7,
+                        f"emit column {column!r} is not a column of "
+                        f"{select.from_!r}'s {select.table!r} "
+                        f"({sorted(declared)})",
+                        path=f"steps.{select_name}.emit",
+                    )
+                representatives[(select_name, key)] = _COLUMN_ZERO[declared[column]]
+            return
         producer = inner.get(select.from_)
         if producer is None:
             return  # the producer failed earlier; its error already raised
@@ -677,6 +899,26 @@ def load_workflow(
     def check_columns(
         name: str, from_: str, table: str, columns: Sequence[str]
     ) -> None:
+        producing = steps[from_]
+        if isinstance(producing, TransformStep):
+            # a transform producer has no sweep axes; what it *does* have is a
+            # declared column list per table output, so rule 7 keeps its
+            # load-time bite against that instead (§2.4). Note there is no
+            # implicit 'value' column here: a transform table is whatever its
+            # op declares, so a select must name the column it ranks.
+            declared = _transform_table_columns(
+                producing, table, path=f"steps.{name}.table"
+            )
+            for column in columns:
+                if column not in declared:
+                    raise WorkflowError(
+                        7,
+                        f"column {column!r} is not a column of {from_!r}'s "
+                        f"{table!r} ({sorted(declared)}) — a transform op "
+                        "declares the columns of every table it writes (§2.4)",
+                        path=f"steps.{name}",
+                    )
+            return
         producer = inner[from_]
         outputs = {entry.file_path for entry in producer.document.save}
         if table not in outputs:
@@ -705,8 +947,10 @@ def load_workflow(
                 c for c in (step.y, step.series) if c is not None
             ]
             check_columns(name, step.from_, step.table, columns)
+            if isinstance(steps[step.from_], TransformStep):
+                continue  # a transform producer has no axes to leave uncovered
             # a figure must account for every axis of what it renders — an
-            # uncovered axis would collapse into duplicate cells (§2.4)
+            # uncovered axis would collapse into duplicate cells (§2.5)
             axis_ids = {axis.id for axis in inner[step.from_].expansion.axes}
             covered = (
                 {step.x}
@@ -728,6 +972,8 @@ def load_workflow(
         step = steps[name]
         if isinstance(step, ProtocolStep):
             return {entry.file_path for entry in inner[name].document.save}
+        if isinstance(step, TransformStep):
+            return set(step.outputs.values())
         if isinstance(step, SelectStep):
             return {"values.json"}
         return {step.file_path}
@@ -738,6 +984,13 @@ def load_workflow(
             producer_step = steps[producer]
             if isinstance(producer_step, ProtocolStep):
                 produced = {e.file_path for e in inner[producer].document.save}
+            elif isinstance(producer_step, TransformStep):
+                # rule 10, run-tree half: a protocol step may load a tensor a
+                # transform step wrote — the fitted-artifact direction the
+                # manifold pipelines need. The bundle is stamped with an
+                # ArtifactIdentity at write time, so the loading document's
+                # IM spec §2.5 identity check is a real check, not a waived one.
+                produced = set(producer_step.outputs.values())
             elif isinstance(producer_step, SelectStep):
                 produced = {"values.json"}
             else:
@@ -758,6 +1011,13 @@ def load_workflow(
                     rest=rest,
                     step=name,
                 )
+
+    # ---- rules 4 + 10 for transform inputs (§2.4, §3) ----------------------- #
+    for name, step in steps.items():
+        if isinstance(step, TransformStep):
+            _check_transform_inputs(
+                name, step, steps=steps, inner=inner, outputs_of=outputs_of
+            )
 
     for i, entry in enumerate(document.save):
         if entry.step not in steps:
@@ -788,6 +1048,15 @@ def load_workflow(
     # ---- canonical form + digest (§7) --------------------------------------- #
     canonical = _canonicalize(document, inner_digests, inner_digest_kind)
     digest = hashlib.sha256(canonical_bytes(canonical)).hexdigest()
+    # a transform step's provenance unit: the digest of its own canonical
+    # entry, which is a pure function of op@version + inputs + params +
+    # outputs. It is what a tensor it writes is stamped `produced_by`, the
+    # analogue of a protocol point's digest.
+    transform_digests = {
+        name: hashlib.sha256(canonical_bytes(canonical["steps"][name])).hexdigest()
+        for name, step in steps.items()
+        if isinstance(step, TransformStep)
+    }
 
     return LoadedWorkflow(
         document=document,
@@ -800,6 +1069,46 @@ def load_workflow(
         inner_digests=inner_digests,
         canonical=canonical,
         digest=digest,
+        transform_digests=transform_digests,
+    )
+
+
+#: Load-time stand-in per declared column dtype, for the representative a
+#: select step over a transform-produced table substitutes into a consuming
+#: document. Only the *type* is load-bearing — the real value arrives at run
+#: time (module docstring).
+_COLUMN_ZERO: Mapping[str, Any] = {
+    "int64": 0,
+    "float64": 0.0,
+    "bool": False,
+    "string": "",
+}
+
+
+def _transform_table_columns(
+    step: TransformStep, table: str, *, path: str
+) -> dict[str, str]:
+    """The declared columns of the table a transform step writes as ``table``."""
+    from causalab.transform.registry import lookup
+    from causalab.transform.schema import Table
+
+    op = lookup(step.op)
+    for slot, file_path in step.outputs.items():
+        if file_path != table:
+            continue
+        decl = op.outputs[slot]
+        if not isinstance(decl, Table):
+            raise WorkflowError(
+                4,
+                f"{table!r} is {op.id}'s {slot!r} slot, a tensor bundle — only "
+                "tables are ranked and plotted (§2.3, §2.5)",
+                path=path,
+            )
+        return dict(decl.columns or {})
+    raise WorkflowError(
+        4,
+        f"the step writes no {table!r} (has {sorted(step.outputs.values())})",
+        path=path,
     )
 
 
@@ -833,6 +1142,72 @@ def _bundle_entries(
             for slot in slots:
                 entries[entry_key(slot, label)] = {"slot": slot, "coords": short}
     return entries or None
+
+
+def _sole_bundle_slot(entries: Mapping[str, Mapping[str, Any]]) -> str | None:
+    """The one slot a bundle holds, or ``None`` when it holds several."""
+    slots = {str(entry.get("slot")) for entry in entries.values()}
+    return slots.pop() if len(slots) == 1 else None
+
+
+def _check_transform_inputs(
+    name: str,
+    step: TransformStep,
+    *,
+    steps: Mapping[str, Step],
+    inner: Mapping[str, LoadedProtocol],
+    outputs_of: Callable[[str], set[str]],
+) -> None:
+    """Every transform input names an output its producer really writes, and
+    selects an entry that producer will really hold (§5.4, §5.10).
+
+    The entry half is checkable for the same reason it is for a protocol
+    consumer: a producing document's sweep expands deterministically at load,
+    so a mis-aimed tensor handoff fails before the producing step spends its
+    compute rather than after."""
+    from causalab.transform.registry import lookup
+    from causalab.transform.schema import Tensor
+
+    op = lookup(step.op)
+    for slot, ref in step.inputs.items():
+        produced = outputs_of(ref.step)
+        if ref.value not in produced:
+            raise WorkflowError(
+                4,
+                f"input {slot!r} reads {ref.step}/{ref.value}, but "
+                f"{ref.step!r} produces no {ref.value!r} (has {sorted(produced)})",
+                path=f"steps.{name}.inputs.{slot}",
+            )
+        producer = steps[ref.step]
+        if not isinstance(op.inputs[slot], Tensor) or not isinstance(
+            producer, ProtocolStep
+        ):
+            continue
+        entries = _bundle_entries(inner[ref.step], ref.value)
+        if entries is None:
+            continue
+        bundle_slot = ref.slot or _sole_bundle_slot(entries)
+        if bundle_slot is None:
+            held = sorted({str(e.get("slot")) for e in entries.values()})
+            raise WorkflowError(
+                10,
+                f"input {slot!r} reads a bundle holding several slots ({held}) "
+                "— name one with 'slot'",
+                path=f"steps.{name}.inputs.{slot}",
+            )
+        try:
+            select_entry(
+                entries.keys(),
+                bundle_slot,
+                ref.entry,
+                what=f"step {name!r}: input {slot!r} reads {ref.step}/{ref.value}",
+                coords_by_key=entries,
+                implicit=False,
+            )
+        except ValidationError as err:
+            raise WorkflowError(
+                10, str(err), path=f"steps.{name}.inputs.{slot}"
+            ) from err
 
 
 def _check_entry_selection(
@@ -874,6 +1249,17 @@ def _check_entry_selection(
                 raise WorkflowError(10, str(err), path=f"steps.{step}") from err
 
 
+def _canon_transform_input(ref: TransformInput) -> dict[str, Any]:
+    """One ``inputs`` entry in canonical form: the optional bundle selectors
+    appear only when authored, so a step that needs neither adds no key."""
+    entry: dict[str, Any] = {"step": ref.step, "value": ref.value}
+    if ref.slot is not None:
+        entry["slot"] = ref.slot
+    if ref.entry:
+        entry["entry"] = dict(ref.entry)
+    return entry
+
+
 def _canonicalize(
     document: WorkflowDocument,
     inner_digests: Mapping[str, str],
@@ -894,6 +1280,23 @@ def _canonicalize(
                 entry["max_points"] = step.max_points
             entry["document_digest"] = inner_digests[name]
             entry["digest_kind"] = inner_digest_kind[name]
+        elif isinstance(step, TransformStep):
+            entry.update(
+                {
+                    # name@version: the version IS the numerics contract, so a
+                    # behavioural change ships as a new op and old documents
+                    # keep digesting as written. The op's *implementation*
+                    # never enters the form, the rule that keeps backends out
+                    # of protocol digests.
+                    "op": step.op,
+                    "inputs": {
+                        slot: _canon_transform_input(ref)
+                        for slot, ref in step.inputs.items()
+                    },
+                    "params": dict(step.params),  # defaults already materialized
+                    "outputs": dict(step.outputs),
+                }
+            )
         elif isinstance(step, SelectStep):
             entry.update(
                 {

--- a/causalab/transform/__init__.py
+++ b/causalab/transform/__init__.py
@@ -1,0 +1,43 @@
+"""Deterministic, versioned transforms over a workflow's saved artifacts.
+
+The fourth workflow step type (docs/workflow_protocol.md §2.4) runs an ``op``
+from the registry here: a pure function of its declared inputs and parameters,
+turning a table or a tensor into another table or tensor. Fitting a basis,
+aggregating per-head statistics, running a paired t-test — analyses that touch
+no model, and that before this lived outside the record as post-hoc notebook
+work.
+
+Nothing in this package imports torch at module level: the op *records* — name,
+version, parameter schema, input and output slots, and the columns of every
+table an op writes — are what the pure CLI verbs read to refuse a bad document,
+and they must stay cheap. The numerics live inside the op function bodies.
+"""
+
+from __future__ import annotations
+
+from causalab.transform.registry import TransformOp, lookup, op_ids, register
+from causalab.transform.schema import (
+    Bool,
+    Float,
+    Int,
+    Str,
+    Table,
+    Tensor,
+    TransformError,
+    validate_params,
+)
+
+__all__ = [
+    "Bool",
+    "Float",
+    "Int",
+    "Str",
+    "Table",
+    "Tensor",
+    "TransformError",
+    "TransformOp",
+    "lookup",
+    "op_ids",
+    "register",
+    "validate_params",
+]

--- a/causalab/transform/io.py
+++ b/causalab/transform/io.py
@@ -1,0 +1,247 @@
+"""Reading a transform step's inputs and writing its outputs.
+
+The runner owns this seam, not the ops: an op is a pure
+``(inputs, params) -> {slot: value}`` function, so paths, file formats and
+provenance stamping all live here. Both formats are the ones the rest of the
+stack already uses — ``.parquet`` for tables, a ``.safetensors`` bundle with an
+``entries`` table and an ArtifactIdentity for tensors — because a transform op
+is **not** a new tensor-passing channel; it reuses the one #29 built.
+
+Heavy imports (pandas, safetensors, torch) are function-local: this module is
+importable, and its declarations readable, without them.
+
+Provenance of a transform-written bundle
+----------------------------------------
+``check_artifact_identity`` refuses a bundle carrying no identity, so a tensor
+a later *protocol* step loads has to be stamped. Three sources, in order:
+
+1. **inherited** from the tensor inputs, keeping only the fields they all
+   agree on (the ``record_common`` rule, ``pytorch_hooks/outputs.py``) — a fit
+   over activations from model X at site S really is bound to X and S;
+2. **from params**, for the fields the op's own parameters define rather than
+   inherit (``identity_from_params``, e.g. a fitted basis's rank ``k``);
+3. **stamped here**: ``produced_by`` (the step's digest — its provenance unit),
+   ``backend`` and ``dtype``.
+
+``commit`` is deliberately *not* stamped. The code identity of a transform
+output is its op's **version**, which is in the document and therefore in the
+digest; a git sha would say less and drift more.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from causalab.protocol.bundles import entry_key, select_entry
+from causalab.protocol.resolve import (
+    ARTIFACT_IDENTITY_KEYS,
+    build_artifact_identity,
+    read_safetensors_metadata,
+)
+from causalab.transform.schema import Table, TransformError
+
+__all__ = [
+    "inherited_identity",
+    "read_table",
+    "read_tensor",
+    "write_table",
+    "write_tensor",
+]
+
+#: torch dtype → the protocol's ``precision`` spelling (``protocol/schema.py``
+#: ``PRECISION_DTYPES``), so a stamped ``dtype`` is comparable with what a
+#: consuming featurizer spec declares.
+_DTYPE_NAMES = {
+    "torch.float32": "fp32",
+    "torch.bfloat16": "bf16",
+    "torch.float16": "fp16",
+}
+
+
+# --------------------------------------------------------------------------- #
+# tables
+# --------------------------------------------------------------------------- #
+
+
+def read_table(path: Path) -> Any:
+    """One ``.parquet`` table as a DataFrame."""
+    import pandas as pd
+
+    if not path.is_file():
+        raise TransformError(f"input table {str(path)!r} does not exist")
+    return pd.read_parquet(path)
+
+
+def write_table(frame: Any, path: Path, decl: Table, *, what: str) -> None:
+    """Write a table output, checked against the op's declared columns.
+
+    The declaration is the contract a downstream ``select``/``plot`` step was
+    validated against at load, so an op that returns something else is refused
+    here rather than producing a table whose columns silently disagree with
+    the document that was checked."""
+    import pandas as pd
+
+    if not isinstance(frame, pd.DataFrame):
+        raise TransformError(f"{what}: expected a table, got {type(frame).__name__}")
+    columns = dict(decl.columns or {})
+    missing = [name for name in columns if name not in frame.columns]
+    if missing:
+        raise TransformError(
+            f"{what}: the op declares columns {sorted(columns)} but returned "
+            f"{sorted(map(str, frame.columns))} — missing {missing}"
+        )
+    extra = [str(name) for name in frame.columns if name not in columns]
+    if extra:
+        raise TransformError(
+            f"{what}: the op returned undeclared columns {sorted(extra)} — a "
+            "table's columns are part of its record (§2.4)"
+        )
+    ordered = frame[list(columns)]
+    for name, dtype in columns.items():
+        ordered = ordered.astype({name: "string" if dtype == "string" else dtype})
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ordered.to_parquet(path, index=False)
+
+
+# --------------------------------------------------------------------------- #
+# tensors
+# --------------------------------------------------------------------------- #
+
+
+def _entry_table(metadata: Mapping[str, Any] | None) -> dict[str, dict[str, Any]]:
+    if not metadata:
+        return {}
+    raw = metadata.get("entries")
+    if not isinstance(raw, str):
+        return {}
+    try:
+        table = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return table if isinstance(table, dict) else {}
+
+
+def _identity_of(metadata: Mapping[str, Any] | None, key: str) -> dict[str, Any]:
+    """The identity of one bundle entry: the file-level stamp, overridden by
+    whatever the ``entries`` table records for that key (the per-entry fields
+    a swept producer could not stamp file-wide)."""
+    if not metadata:
+        return {}
+    identity = {
+        field: value
+        for field, value in metadata.items()
+        if field in ARTIFACT_IDENTITY_KEYS
+    }
+    entry = _entry_table(metadata).get(key, {})
+    identity.update(
+        {
+            field: value
+            for field, value in entry.items()
+            if field in ARTIFACT_IDENTITY_KEYS
+        }
+    )
+    return identity
+
+
+def read_tensor(
+    path: Path,
+    *,
+    slot: str | None,
+    entry: Mapping[str, Any] | None,
+    what: str,
+) -> tuple[Any, dict[str, Any]]:
+    """One tensor out of a ``.safetensors`` bundle, plus its identity.
+
+    Selection reuses :func:`causalab.protocol.bundles.select_entry`, so a
+    single-entry bundle needs no selector and an ambiguous one refuses with a
+    listing instead of picking first. ``implicit`` is always ``False``: a
+    transform step has no sweep coordinates of its own, so there is nothing to
+    match implicitly — a swept producer must be addressed by an authored
+    ``entry``."""
+    from safetensors.torch import load_file
+
+    if not path.is_file():
+        raise TransformError(f"{what}: input tensor {str(path)!r} does not exist")
+    metadata = read_safetensors_metadata(path)
+    tensors = load_file(str(path))
+    entries = _entry_table(metadata)
+    key = select_entry(
+        tensors.keys(),
+        slot if slot is not None else _sole_slot(tensors.keys(), entries, what),
+        entry,
+        what=what,
+        coords_by_key=entries or None,
+        implicit=False,
+    )
+    return tensors[key], _identity_of(metadata, key)
+
+
+def _sole_slot(keys: Any, entries: Mapping[str, Mapping[str, Any]], what: str) -> str:
+    """The slot name when the document did not say which.
+
+    A bundle written by one un-swept producer holds one slot, which is then
+    unambiguous; anything else has to be named, because guessing is exactly
+    the failure ``select_entry`` exists to prevent."""
+    from causalab.protocol.bundles import RAGGED_SUFFIX, parse_entry_key
+
+    slots = set()
+    for key in keys:
+        if str(key).endswith(RAGGED_SUFFIX):
+            continue
+        stored = entries.get(str(key), {})
+        slots.add(str(stored.get("slot", parse_entry_key(str(key))[0])))
+    if len(slots) == 1:
+        return slots.pop()
+    raise TransformError(
+        f"{what}: the bundle holds slots {sorted(slots)} — name one with "
+        "'slot' in the input's entry selector"
+    )
+
+
+def inherited_identity(sources: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """The identity fields every tensor input agrees on.
+
+    Same rule as ``TensorFile.record_common``: a field the sources disagree
+    about says nothing true about the output, so it is dropped rather than
+    letting one input speak for the result."""
+    if not sources:
+        return {}
+    common = {
+        field: value
+        for field, value in sources[0].items()
+        if field in ARTIFACT_IDENTITY_KEYS
+    }
+    for other in sources[1:]:
+        for field in list(common):
+            if str(common[field]) != str(other.get(field)):
+                del common[field]
+    return common
+
+
+def write_tensor(
+    tensor: Any,
+    path: Path,
+    *,
+    slot: str,
+    identity: Mapping[str, Any],
+    what: str,
+) -> None:
+    """Write one tensor as a single-entry bundle, stamped so a protocol step
+    may load it (module docstring)."""
+    import torch
+    from safetensors.torch import save_file
+
+    if not isinstance(tensor, torch.Tensor):
+        raise TransformError(f"{what}: expected a tensor, got {type(tensor).__name__}")
+    value = tensor.detach().to("cpu").contiguous()
+    key = entry_key(slot, "")
+    stamped = dict(identity)
+    stamped.setdefault("dtype", _DTYPE_NAMES.get(str(value.dtype), str(value.dtype)))
+    metadata = build_artifact_identity(**stamped)
+    metadata["entries"] = json.dumps(
+        {key: {"slot": slot, "coords": {}}}, sort_keys=True
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    save_file({key: value}, str(path), metadata=metadata)

--- a/causalab/transform/ops/__init__.py
+++ b/causalab/transform/ops/__init__.py
@@ -1,0 +1,13 @@
+"""The registered transform ops.
+
+Importing this package runs each op module's ``@register`` decorator, which is
+what populates the registry — so every new op must be imported here or it does
+not exist as far as a document is concerned. None of these imports pulls in
+torch: an op's numerics live inside its function body.
+"""
+
+from __future__ import annotations
+
+from causalab.transform.ops import fit_pca, head_stats, paired_ttest
+
+__all__ = ["fit_pca", "head_stats", "paired_ttest"]

--- a/causalab/transform/ops/fit_pca.py
+++ b/causalab/transform/ops/fit_pca.py
@@ -1,0 +1,95 @@
+"""``fit_pca@1`` — a principal basis over a saved read.
+
+Deterministic without a seed: a *full* SVD has no randomness to pin (unlike
+sklearn's randomized solver), and the one genuine ambiguity — the sign of each
+component, which SVD leaves free — is fixed here rather than left to the
+backend's mood. That is the registry's admission criterion met by
+construction, which is why this op declares no ``seed`` parameter: a seed that
+changes nothing would be a lie in the record.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from causalab.transform.registry import register
+from causalab.transform.schema import Int, Table, Tensor, TransformError
+
+__all__ = ["fit_pca"]
+
+
+@register(
+    name="fit_pca",
+    version=1,
+    inputs={
+        "acts": Tensor(
+            description="a saved read; leading dimensions are flattened, so "
+            "[examples, positions, d] and [rows, d] both mean rows of d"
+        )
+    },
+    outputs={
+        "weight": Tensor(
+            description="the principal basis as (d, k) — the orientation and "
+            "the slot name of the 'pca' featurizer's weight "
+            "(FEATURIZER_SLOTS, canonical.py's [width, k] shape rule), so the "
+            "bundle loads straight into a downstream protocol step"
+        ),
+        "spectrum": Table(
+            columns={
+                "pc": "int64",
+                "explained_variance": "float64",
+                "explained_variance_ratio": "float64",
+            },
+            description="one row per retained component, in descending order",
+        ),
+    },
+    params={"k": Int(min=1, description="number of components to retain")},
+    identity_from_params={"k": "k"},
+    description="Principal component basis of a saved read, by full SVD.",
+)
+def fit_pca(*, inputs: Mapping[str, Any], params: Mapping[str, Any]) -> dict[str, Any]:
+    import pandas as pd
+    import torch
+
+    acts = inputs["acts"]
+    if acts.ndim < 2:
+        raise TransformError(
+            f"fit_pca@1: 'acts' needs at least 2 dimensions, got shape "
+            f"{tuple(acts.shape)}"
+        )
+    # float64 throughout: the fit is the numerically delicate part, and a
+    # float32 SVD of a near-degenerate covariance is not reproducible across
+    # devices at the bit level, which the registry requires.
+    rows = acts.reshape(-1, acts.shape[-1]).to(torch.float64)
+    n, d = int(rows.shape[0]), int(rows.shape[1])
+    k = int(params["k"])
+    if k > min(n, d):
+        raise TransformError(
+            f"fit_pca@1: k={k} exceeds the rank available from {n} rows of {d} "
+            "dimensions"
+        )
+    if n < 2:
+        raise TransformError("fit_pca@1: a variance needs at least 2 rows")
+    centered = rows - rows.mean(dim=0, keepdim=True)
+    _, singular, vh = torch.linalg.svd(centered, full_matrices=False)
+    components = vh[:k].clone()
+    # sign convention: SVD fixes each component only up to a sign, so pin it —
+    # the entry of largest magnitude is made positive. Without this the same
+    # input can produce two bases that are both "correct" and not equal.
+    leading = components.abs().argmax(dim=1)
+    signs = torch.sign(components.gather(1, leading.unsqueeze(1))).squeeze(1)
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    components = components * signs.unsqueeze(1)
+    variance = (singular**2) / (n - 1)
+    total = variance.sum()
+    ratio = variance / total if total > 0 else torch.zeros_like(variance)
+    spectrum = pd.DataFrame(
+        {
+            "pc": list(range(k)),
+            "explained_variance": [float(v) for v in variance[:k]],
+            "explained_variance_ratio": [float(v) for v in ratio[:k]],
+        }
+    )
+    # (d, k), not (k, d): a featurizer's weight maps d -> k, and matching that
+    # convention here is what lets a protocol step load this bundle unchanged
+    return {"weight": components.T.contiguous().to(torch.float32), "spectrum": spectrum}

--- a/causalab/transform/ops/head_stats.py
+++ b/causalab/transform/ops/head_stats.py
@@ -1,0 +1,71 @@
+"""``head_stats@1`` — a per-(layer, head) summary of a metric table.
+
+The table→table direction of the IO contract. Deterministic: a sorted
+group-by over committed bytes, with a *population* standard deviation so a
+one-row cell yields ``0.0`` rather than a NaN that would then travel silently
+into a plot.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from causalab.transform.registry import register
+from causalab.transform.schema import Str, Table, TransformError
+
+__all__ = ["head_stats"]
+
+
+@register(
+    name="head_stats",
+    version=1,
+    inputs={
+        "table": Table(
+            description="a metric table; its sweep-coordinate columns are "
+            "whatever the producing document stamped, so they are not declared"
+        )
+    },
+    outputs={
+        "stats": Table(
+            columns={
+                "layer": "int64",
+                "head": "int64",
+                "n": "int64",
+                "mean": "float64",
+                "std": "float64",
+            },
+            description="one row per (layer, head) cell, layer-then-head sorted",
+        )
+    },
+    params={
+        "layer_column": Str(
+            default="sites.target.layer", description="the swept layer axis"
+        ),
+        "head_column": Str(
+            default="sites.target.head", description="the swept head axis"
+        ),
+        "value_column": Str(default="value", description="the column summarized"),
+    },
+    description="Mean and spread of a metric over each (layer, head) cell.",
+)
+def head_stats(
+    *, inputs: Mapping[str, Any], params: Mapping[str, Any]
+) -> dict[str, Any]:
+    frame = inputs["table"]
+    layer_column = str(params["layer_column"])
+    head_column = str(params["head_column"])
+    value_column = str(params["value_column"])
+    for column in (layer_column, head_column, value_column):
+        if column not in frame.columns:
+            raise TransformError(
+                f"head_stats@1: the input table has no column {column!r} "
+                f"(has {sorted(map(str, frame.columns))})"
+            )
+    grouped = frame.groupby([layer_column, head_column], sort=True)[value_column]
+    # ddof=0 on purpose: a cell with one row has no sample spread, and 0.0 is
+    # the honest answer for "how far apart are these", where NaN would poison
+    # every downstream mean.
+    stats = grouped.agg(n="count", mean="mean", std=lambda s: s.std(ddof=0))
+    stats = stats.reset_index()
+    stats = stats.rename(columns={layer_column: "layer", head_column: "head"})
+    return {"stats": stats[["layer", "head", "n", "mean", "std"]]}

--- a/causalab/transform/ops/paired_ttest.py
+++ b/causalab/transform/ops/paired_ttest.py
@@ -1,0 +1,95 @@
+"""``paired_ttest@1`` — a paired t-test between two metric tables.
+
+Proves the remaining two corners of the IO contract: **multiple input slots**,
+and a table output that is a single row of statistics rather than a grid.
+
+Pairing is by an explicit key column (``example`` in the metric tables the
+backend writes), and both sides are averaged within a key first — a swept
+document writes one row per (example, point), so a bare join would otherwise
+multiply rows and inflate the sample size.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from causalab.transform.registry import register
+from causalab.transform.schema import Str, Table, TransformError
+
+__all__ = ["paired_ttest"]
+
+
+@register(
+    name="paired_ttest",
+    version=1,
+    inputs={
+        "a": Table(description="the first arm"),
+        "b": Table(description="the second arm, paired with the first"),
+    },
+    outputs={
+        "stats": Table(
+            columns={
+                "n_pairs": "int64",
+                "df": "int64",
+                "mean_difference": "float64",
+                "t_statistic": "float64",
+                "p_value": "float64",
+            },
+            description="one row: the two-sided paired t-test of a - b",
+        )
+    },
+    params={
+        "value_column": Str(default="value", description="the compared column"),
+        "pair_column": Str(default="example", description="the pairing key"),
+    },
+    description="Two-sided paired t-test of the difference between two tables.",
+)
+def paired_ttest(
+    *, inputs: Mapping[str, Any], params: Mapping[str, Any]
+) -> dict[str, Any]:
+    import pandas as pd
+    from scipy import stats as scipy_stats
+
+    value_column = str(params["value_column"])
+    pair_column = str(params["pair_column"])
+    sides = {}
+    for slot in ("a", "b"):
+        frame = inputs[slot]
+        for column in (pair_column, value_column):
+            if column not in frame.columns:
+                raise TransformError(
+                    f"paired_ttest@1: input {slot!r} has no column {column!r} "
+                    f"(has {sorted(map(str, frame.columns))})"
+                )
+        sides[slot] = (
+            frame.groupby(pair_column, sort=True)[value_column].mean().rename(slot)
+        )
+    joined = pd.concat([sides["a"], sides["b"]], axis=1, join="inner").sort_index()
+    n = int(len(joined))
+    if n < 2:
+        raise TransformError(
+            f"paired_ttest@1: {n} pair(s) shared between the two tables — a "
+            "paired t-test needs at least 2"
+        )
+    difference = joined["a"] - joined["b"]
+    mean = float(difference.mean())
+    spread = float(difference.std(ddof=1))
+    df = n - 1
+    if spread == 0.0:
+        # every pair moved by exactly the same amount: the test is degenerate,
+        # and reporting inf/0.0 is more honest than a NaN or a fudged epsilon.
+        t_statistic = 0.0 if mean == 0.0 else float("inf") * (1.0 if mean > 0 else -1.0)
+        p_value = 1.0 if mean == 0.0 else 0.0
+    else:
+        t_statistic = mean / (spread / (n**0.5))
+        p_value = float(2.0 * scipy_stats.t.sf(abs(t_statistic), df))
+    stats = pd.DataFrame(
+        {
+            "n_pairs": [n],
+            "df": [df],
+            "mean_difference": [mean],
+            "t_statistic": [float(t_statistic)],
+            "p_value": [p_value],
+        }
+    )
+    return {"stats": stats}

--- a/causalab/transform/registry.py
+++ b/causalab/transform/registry.py
@@ -1,0 +1,211 @@
+"""The closed-but-growable registry of transform ops (workflow spec §2.4).
+
+A ``transform`` step names its op as ``name@version``. Both halves are part of
+the record: two runs of the same document must agree numerically, so pinning
+``fit_pca@1`` means a behavioural change ships as ``fit_pca@2`` and documents
+written against the old one keep digesting — and running — as written. The
+op's *implementation* is never in the digest, the same rule that keeps backends
+out of protocol digests.
+
+**Determinism is the admission criterion.** An op must be a pure function of
+its declared inputs and params; anything stochastic takes an explicit ``seed``
+parameter and must be bit-stable across devices. An op that cannot meet that
+does not belong here, and that refusal is the point of a closed set — the
+registry grows by pull request, never by document.
+
+The registry is **torch-free**: op modules keep their numerics inside the
+function body (``import torch`` at call time, the idiom the runner already uses
+for pandas and matplotlib), so importing this module to *validate* a document
+costs nothing but stdlib. ``tests/test_architecture_layering.py`` enforces it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from typing import Any, Callable, Mapping
+
+from causalab.protocol.errors import suggest
+from causalab.protocol.resolve import ARTIFACT_IDENTITY_KEYS
+from causalab.transform.schema import (
+    COLUMN_DTYPES,
+    Param,
+    Slot,
+    Table,
+    TransformError,
+)
+
+__all__ = ["TransformOp", "lookup", "op_ids", "register"]
+
+_OP_NAME = re.compile(r"^[a-z][a-z0-9_]*$")
+
+#: The callable an op registers: ``(inputs, params) -> {slot: value}``. Values
+#: are in-memory objects (a DataFrame for a table slot, a tensor for a tensor
+#: slot); the *runner* owns paths, file formats and identity stamping, so an op
+#: stays a pure function and its unit test needs no filesystem.
+#: Typed as returning ``object`` rather than the mapping it owes: an op body is
+#: ordinary Python, so the runner *checks* the shape it got instead of trusting
+#: an annotation to have been true.
+OpCallable = Callable[..., object]
+
+
+@dataclasses.dataclass(frozen=True)
+class TransformOp:
+    """One registered op: everything the loader needs, plus the body."""
+
+    name: str
+    version: int
+    params: Mapping[str, Param]
+    inputs: Mapping[str, Slot]
+    outputs: Mapping[str, Slot]
+    fn: OpCallable
+    #: ``{identity field: parameter name}`` — identity a tensor output gets
+    #: from its own params rather than by inheritance from a tensor input
+    #: (``fit_pca@1`` sets the featurizer rank ``k`` this way).
+    identity_from_params: Mapping[str, str] = dataclasses.field(default_factory=dict)
+    description: str | None = None
+
+    @property
+    def id(self) -> str:
+        return f"{self.name}@{self.version}"
+
+
+_REGISTRY: dict[str, TransformOp] = {}
+
+
+def _check_record(op: TransformOp) -> None:
+    """Refuse a malformed record at import time — a registry entry is part of
+    the protocol's surface, so a bad one is a bug in this repository, not a
+    user error."""
+    if not _OP_NAME.match(op.name):
+        raise AssertionError(f"op name {op.name!r} is not a lower_snake identifier")
+    if op.version < 1:
+        raise AssertionError(f"op {op.name!r} has a non-positive version")
+    if not op.outputs:
+        raise AssertionError(f"op {op.id} declares no outputs")
+    for slot, decl in op.outputs.items():
+        if not isinstance(decl, Table):
+            continue
+        if decl.columns is None:
+            raise AssertionError(
+                f"op {op.id} output {slot!r} is a table with no declared columns — "
+                "a consuming select/plot step's column references are checked "
+                "against that declaration at load"
+            )
+        for column, dtype in decl.columns.items():
+            if dtype not in COLUMN_DTYPES:
+                raise AssertionError(
+                    f"op {op.id} output {slot!r} column {column!r} has unknown "
+                    f"dtype {dtype!r} (one of {list(COLUMN_DTYPES)})"
+                )
+    for field, param in op.identity_from_params.items():
+        if field not in ARTIFACT_IDENTITY_KEYS:
+            raise AssertionError(
+                f"op {op.id} maps unknown ArtifactIdentity field {field!r}"
+            )
+        if param not in op.params:
+            raise AssertionError(
+                f"op {op.id} maps identity {field!r} from undeclared parameter "
+                f"{param!r}"
+            )
+
+
+def register(
+    *,
+    name: str,
+    version: int,
+    inputs: Mapping[str, Slot],
+    outputs: Mapping[str, Slot],
+    params: Mapping[str, Param] | None = None,
+    identity_from_params: Mapping[str, str] | None = None,
+    description: str | None = None,
+) -> Callable[[OpCallable], OpCallable]:
+    """Register one op under ``name@version``.
+
+    Returns the function unchanged, so an op's unit test can call it directly
+    without going through the registry."""
+
+    def decorate(fn: OpCallable) -> OpCallable:
+        op = TransformOp(
+            name=name,
+            version=version,
+            params=dict(params or {}),
+            inputs=dict(inputs),
+            outputs=dict(outputs),
+            fn=fn,
+            identity_from_params=dict(identity_from_params or {}),
+            description=description
+            or (fn.__doc__ or "").strip().split("\n")[0]
+            or None,
+        )
+        _check_record(op)
+        if op.id in _REGISTRY:
+            raise AssertionError(f"op {op.id} is registered twice")
+        _REGISTRY[op.id] = op
+        return fn
+
+    return decorate
+
+
+def _ensure_ops_imported() -> None:
+    """Populate the registry. Importing the op modules runs their decorators;
+    it does **not** import torch, which stays inside the function bodies.
+
+    By module path rather than by name: the import is for its side effect, and
+    nothing here uses the module object."""
+    import importlib
+
+    importlib.import_module("causalab.transform.ops")
+
+
+def op_ids() -> tuple[str, ...]:
+    """Every registered ``name@version``, sorted."""
+    _ensure_ops_imported()
+    return tuple(sorted(_REGISTRY))
+
+
+def lookup(op_id: Any, *, path: str | None = None) -> TransformOp:
+    """The op a document names, or a refusal with suggestions.
+
+    An unknown *version of a known op* gets its own message: the usual
+    did-you-mean over the whole id would suggest ``fit_pca@1`` for
+    ``fit_pca@2`` without saying why, and "this op has versions 1" is the
+    thing the author actually needs to read."""
+    _ensure_ops_imported()
+    if not isinstance(op_id, str):
+        raise TransformError(
+            f"'op' is a string 'name@version', got {op_id!r}", path=path
+        )
+    name, sep, version_text = op_id.partition("@")
+    if not sep or not version_text:
+        raise TransformError(
+            f"op {op_id!r} is not spelled 'name@version' — the version is part "
+            "of the record, so a document pins the numerics it was written "
+            f"against{suggest(op_id, op_ids())}",
+            path=path,
+        )
+    known_versions = sorted(op.version for op in _REGISTRY.values() if op.name == name)
+    if not known_versions:
+        raise TransformError(
+            f"unknown op {name!r}{suggest(name, sorted({op.name for op in _REGISTRY.values()}))}",
+            path=path,
+        )
+    if not version_text.isdigit():
+        raise TransformError(
+            f"op version {version_text!r} is not an integer (op {name!r} has "
+            f"{_versions_text(known_versions)})",
+            path=path,
+        )
+    op = _REGISTRY.get(f"{name}@{int(version_text)}")
+    if op is None:
+        raise TransformError(
+            f"op {name!r} has no version {int(version_text)} — it has "
+            f"{_versions_text(known_versions)}",
+            path=path,
+        )
+    return op
+
+
+def _versions_text(versions: list[int]) -> str:
+    joined = ", ".join(str(v) for v in versions)
+    return f"version{'s' if len(versions) > 1 else ''} {joined}"

--- a/causalab/transform/schema.py
+++ b/causalab/transform/schema.py
@@ -1,0 +1,219 @@
+"""Slot and parameter vocabulary for transform ops (workflow spec §2.4).
+
+Torch-free by construction. A :class:`~causalab.transform.registry.TransformOp`
+record describes an op's *shape* — its parameters, its input and output slots,
+and the columns of every table it writes — and this module is that vocabulary.
+Keeping it free of numerics is what lets ``causalab validate`` / ``digest`` /
+``explain`` refuse a bad document on a machine with no torch, before a single
+step runs (docs/CODEBASE.md §1, "``protocol/`` is torch-free").
+
+Two slot kinds, mirroring the two things a workflow step can already produce:
+a :class:`Table` (a ``.parquet`` metric table) and a :class:`Tensor` (a
+``.safetensors`` bundle). An **output** table must declare its columns — that
+declaration is what a downstream ``select``/``plot`` step's column references
+are checked against at load, the same load-time bite rule 7 has for a protocol
+producer's sweep axes. An **input** table may leave them unconstrained.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Mapping, Sequence
+
+from causalab.protocol.errors import ProtocolError, suggest
+
+__all__ = [
+    "COLUMN_DTYPES",
+    "Bool",
+    "Float",
+    "Int",
+    "Param",
+    "Slot",
+    "Str",
+    "Table",
+    "Tensor",
+    "TransformError",
+    "validate_params",
+]
+
+
+class TransformError(ProtocolError):
+    """An op record was violated: an unknown op, a bad parameter, a slot the
+    op does not declare. Code ``T1``.
+
+    The workflow loader re-raises this as a ``WorkflowError(1, …)`` so the
+    document-level contract stays the §5 checklist; the runner lets it
+    propagate, where it is a run-time refusal."""
+
+    def __init__(self, message: str, *, path: str | None = None) -> None:
+        #: the bare text, so the workflow loader can re-raise it under its own
+        #: rule code instead of nesting ``[T1]`` inside ``[W1]``
+        self.message = message
+        super().__init__("T1", message, path=path)
+
+
+#: Closed set of column dtypes a table slot may declare. Deliberately narrow:
+#: these are the types that survive a parquet round-trip and a strict re-parse
+#: by a consuming document (``protocol/workflow.py`` `_decode_cell`).
+COLUMN_DTYPES: tuple[str, ...] = ("int64", "float64", "bool", "string")
+
+
+# --------------------------------------------------------------------------- #
+# slots
+# --------------------------------------------------------------------------- #
+
+
+@dataclasses.dataclass(frozen=True)
+class Table:
+    """A ``.parquet`` table slot.
+
+    ``columns`` maps column name to a :data:`COLUMN_DTYPES` entry. It is
+    required on an output slot and optional on an input slot — an op that
+    consumes a metric table cannot know which sweep-coordinate columns the
+    producing document stamped, so constraining them would be a lie."""
+
+    columns: Mapping[str, str] | None = None
+    description: str | None = None
+
+    #: the file extension a document must give this slot (rule 8)
+    suffix: str = ".parquet"
+
+
+@dataclasses.dataclass(frozen=True)
+class Tensor:
+    """A ``.safetensors`` bundle slot holding one tensor."""
+
+    description: str | None = None
+
+    suffix: str = ".safetensors"
+
+
+Slot = Table | Tensor
+
+
+# --------------------------------------------------------------------------- #
+# parameters
+# --------------------------------------------------------------------------- #
+
+
+@dataclasses.dataclass(frozen=True)
+class Int:
+    default: int | None = None
+    min: int | None = None
+    max: int | None = None
+    description: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Float:
+    default: float | None = None
+    min: float | None = None
+    max: float | None = None
+    description: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Str:
+    default: str | None = None
+    choices: tuple[str, ...] | None = None
+    description: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class Bool:
+    default: bool | None = None
+    description: str | None = None
+
+
+Param = Int | Float | Str | Bool
+
+
+def _type_name(spec: Param) -> str:
+    return {Int: "an integer", Float: "a number", Str: "a string", Bool: "a boolean"}[
+        type(spec)
+    ]
+
+
+def _coerce(name: str, spec: Param, value: Any, path: str) -> Any:
+    """One authored parameter value, type-checked and normalized.
+
+    ``bool`` is rejected for the numeric kinds on purpose: it is an ``int``
+    subclass in Python, so ``{"k": true}`` would silently mean ``k = 1``."""
+    if isinstance(spec, Bool):
+        if not isinstance(value, bool):
+            raise TransformError(
+                f"parameter {name!r} is a boolean, got {value!r}", path=path
+            )
+        return value
+    if isinstance(value, bool):
+        raise TransformError(
+            f"parameter {name!r} is {_type_name(spec)}, got the boolean {value!r}",
+            path=path,
+        )
+    if isinstance(spec, Int):
+        if not isinstance(value, int):
+            raise TransformError(
+                f"parameter {name!r} is an integer, got {value!r}", path=path
+            )
+        return _bounded(name, value, spec.min, spec.max, path)
+    if isinstance(spec, Float):
+        if not isinstance(value, (int, float)):
+            raise TransformError(
+                f"parameter {name!r} is a number, got {value!r}", path=path
+            )
+        return float(_bounded(name, float(value), spec.min, spec.max, path))
+    if not isinstance(value, str):
+        raise TransformError(
+            f"parameter {name!r} is a string, got {value!r}", path=path
+        )
+    if spec.choices is not None and value not in spec.choices:
+        raise TransformError(
+            f"parameter {name!r} rejects {value!r}{suggest(value, spec.choices)}",
+            path=path,
+        )
+    return value
+
+
+def _bounded(name: str, value: Any, low: Any, high: Any, path: str) -> Any:
+    if low is not None and value < low:
+        raise TransformError(
+            f"parameter {name!r} is below its minimum {low}", path=path
+        )
+    if high is not None and value > high:
+        raise TransformError(
+            f"parameter {name!r} is above its maximum {high}", path=path
+        )
+    return value
+
+
+def validate_params(
+    schema: Mapping[str, Param], authored: Any, *, path: str
+) -> dict[str, Any]:
+    """Check an authored ``params`` table against an op's schema and return
+    it with every default **materialized**.
+
+    Materializing here is what puts the defaults into the canonical form and
+    therefore the digest (§7) — the same treatment ``_canon_train`` gives
+    optimizer defaults, and the reason a later change to a default is a
+    visible loader migration rather than a silent renumbering."""
+    if authored is None:
+        authored = {}
+    if not isinstance(authored, Mapping) or not all(
+        isinstance(key, str) for key in authored
+    ):
+        raise TransformError("'params' maps parameter names to values", path=path)
+    known: Sequence[str] = tuple(schema)
+    for key in authored:
+        if key not in schema:
+            raise TransformError(
+                f"unknown parameter {key!r}{suggest(key, known)}", path=path
+            )
+    out: dict[str, Any] = {}
+    for name, spec in schema.items():
+        if name in authored:
+            out[name] = _coerce(name, spec, authored[name], f"{path}.{name}")
+            continue
+        if spec.default is None:
+            raise TransformError(f"missing required parameter {name!r}", path=path)
+        out[name] = spec.default
+    return out

--- a/causalab/workflow/runner.py
+++ b/causalab/workflow/runner.py
@@ -29,6 +29,7 @@ from causalab.protocol.workflow import (
     PlotStep,
     ProtocolStep,
     SelectStep,
+    TransformStep,
 )
 
 __all__ = ["OverlayArtifacts", "WorkflowRunResult", "run_workflow"]
@@ -108,6 +109,13 @@ def run_workflow(
     )
     step_manifest: dict[str, Any] = {}
     run_axes: dict[str, tuple[Any, ...]] = {}
+    # a transform step's table is consumed as written: its op already decided
+    # what a row is, and it carries no sweep coordinates to group by (§2.4)
+    as_written = frozenset(
+        name
+        for name, step in loaded.document.steps.items()
+        if isinstance(step, TransformStep)
+    )
 
     for name in loaded.order:
         step = loaded.document.steps[name]
@@ -117,11 +125,17 @@ def run_workflow(
             entry = _run_protocol_step(
                 name, step, loaded, run_env, step_dir, backends, run_axes
             )
+        elif isinstance(step, TransformStep):
+            entry = _run_transform_step(name, step, loaded, output_dir, step_dir)
         elif isinstance(step, SelectStep):
-            entry = _run_select_step(name, step, output_dir, step_dir, run_axes)
+            entry = _run_select_step(
+                name, step, output_dir, step_dir, run_axes, as_written
+            )
         else:
             assert isinstance(step, PlotStep)
-            entry = _run_plot_step(name, step, output_dir, step_dir, run_axes)
+            entry = _run_plot_step(
+                name, step, output_dir, step_dir, run_axes, as_written
+            )
         step_manifest[name] = entry
 
     published: dict[str, Path] = {}
@@ -194,6 +208,95 @@ def _run_protocol_step(
 
 
 # --------------------------------------------------------------------------- #
+# transform steps
+# --------------------------------------------------------------------------- #
+
+
+def _run_transform_step(
+    name: str,
+    step: TransformStep,
+    loaded: LoadedWorkflow,
+    output_dir: Path,
+    step_dir: Path,
+) -> dict[str, Any]:
+    """Run one registered op over earlier steps' outputs (§2.4).
+
+    The op body and its numerics are imported here, not at module scope: this
+    package drives backends but links against none, and a workflow with no
+    transform step must not pay for torch.
+
+    Inputs are read straight out of the run tree rather than through the
+    artifact overlay: unlike a protocol step's document, which may name either
+    an in-run step or the external artifacts root, a transform input *always*
+    names a step — rule 4 checked it at load."""
+    from causalab.transform import io as transform_io
+    from causalab.transform.registry import lookup
+    from causalab.transform.schema import Table, TransformError
+
+    op = lookup(step.op)
+    inputs: dict[str, Any] = {}
+    inherited: list[Mapping[str, Any]] = []
+    for slot, ref in step.inputs.items():
+        source = output_dir / ref.step / ref.value
+        what = f"step {name!r}: input {slot!r} ({ref.step}/{ref.value})"
+        if isinstance(op.inputs[slot], Table):
+            inputs[slot] = transform_io.read_table(source)
+            continue
+        tensor, identity = transform_io.read_tensor(
+            source, slot=ref.slot, entry=ref.entry, what=what
+        )
+        inputs[slot] = tensor
+        inherited.append(identity)
+
+    # typed as `object`: the record says an op returns {slot: value}, but an op
+    # body is ordinary Python, so the shape is checked rather than assumed
+    returned: object = op.fn(inputs=inputs, params=dict(step.params))
+    if not isinstance(returned, Mapping):
+        raise TransformError(
+            f"step {name!r}: op {op.id} returned {type(returned).__name__}, not "
+            "a {slot: value} mapping"
+        )
+    produced: Mapping[str, Any] = returned
+    undeclared = sorted(set(produced) - set(op.outputs))
+    absent = sorted(set(op.outputs) - set(produced))
+    if undeclared or absent:
+        raise TransformError(
+            f"step {name!r}: op {op.id} must return exactly its declared slots "
+            f"{sorted(op.outputs)}"
+            + (f"; it added {undeclared}" if undeclared else "")
+            + (f"; it omitted {absent}" if absent else "")
+        )
+
+    identity = transform_io.inherited_identity(inherited)
+    identity.update(
+        {field: step.params[param] for field, param in op.identity_from_params.items()}
+    )
+    identity["produced_by"] = loaded.transform_digests[name]
+    identity["backend"] = "transform"
+
+    for slot, file_path in step.outputs.items():
+        target = step_dir / file_path
+        what = f"step {name!r}: output {slot!r} ({file_path})"
+        decl = op.outputs[slot]
+        if isinstance(decl, Table):
+            transform_io.write_table(produced[slot], target, decl, what=what)
+        else:
+            transform_io.write_tensor(
+                produced[slot], target, slot=slot, identity=identity, what=what
+            )
+    return {
+        "type": "transform",
+        "status": "completed",
+        "op": op.id,
+        "digest": loaded.transform_digests[name],  # the provenance unit (§2.4)
+        "inputs": {
+            slot: f"{ref.step}/{ref.value}" for slot, ref in step.inputs.items()
+        },
+        "files": sorted(step.outputs.values()),
+    }
+
+
+# --------------------------------------------------------------------------- #
 # select steps
 # --------------------------------------------------------------------------- #
 
@@ -204,14 +307,21 @@ def _aggregated(
     table: str,
     value_column: str,
     run_axes: Mapping[str, tuple[Any, ...]],
+    as_written: frozenset[str] = frozenset(),
 ) -> "Any":
     """The mean-over-examples table, one row per sweep-coordinate group
-    (§2.3): columns = the producing document's axis ids + the value."""
+    (§2.3): columns = the producing document's axis ids + the value.
+
+    A **transform** producer is exempt: its op already decided what a row
+    means, and its table carries no sweep coordinates, so re-aggregating here
+    would silently collapse the rows the document was validated against."""
     import pandas as pd
 
     frame = pd.read_parquet(output_dir / from_step / table)
     if value_column not in frame.columns:
         raise ProtocolError("P2", f"{from_step}/{table} has no column {value_column!r}")
+    if from_step in as_written:
+        return frame
     coord_columns = [
         axis.id for axis in run_axes.get(from_step, ()) if axis.id in frame.columns
     ]
@@ -239,8 +349,11 @@ def _run_select_step(
     output_dir: Path,
     step_dir: Path,
     run_axes: Mapping[str, tuple[Any, ...]],
+    as_written: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
-    table = _aggregated(output_dir, step.from_, step.table, step.value, run_axes)
+    table = _aggregated(
+        output_dir, step.from_, step.table, step.value, run_axes, as_written
+    )
     chosen_index = (
         table[step.value].idxmax()
         if step.choose == "max"
@@ -280,13 +393,16 @@ def _run_plot_step(
     output_dir: Path,
     step_dir: Path,
     run_axes: Mapping[str, tuple[Any, ...]],
+    as_written: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     import matplotlib
 
     matplotlib.use("Agg")
     import matplotlib.pyplot as plt
 
-    table = _aggregated(output_dir, step.from_, step.table, step.value, run_axes)
+    table = _aggregated(
+        output_dir, step.from_, step.table, step.value, run_axes, as_written
+    )
     figure, axes = plt.subplots(figsize=(7, 5), constrained_layout=True)
     if step.plot == "heatmap":
         assert step.y is not None  # parse guarantees it

--- a/docs/CODEBASE.md
+++ b/docs/CODEBASE.md
@@ -8,11 +8,12 @@
 | `tasks/` | task definitions (causal models + counterfactual generators) + `serialize.py`, which writes them out as dataset tables |
 | `protocol/` | the backend-free document layer |
 | `neural/pytorch_hooks/` | the reference execution backend |
+| `transform/` | the registry of deterministic, versioned ops a workflow `transform` step runs |
 | `workflow/` | the workflow runner |
 | `io/` | disk I/O + shared plotting primitives |
 | `configs/` | method presets and workflow documents (JSON, not code) |
 
-**Dependency flow:** `tasks/` and `causal/` are independent. `protocol/` is torch-free and links against no execution engine — the CLI imports the reference backend lazily. `neural/pytorch_hooks/` implements `protocol.backend.Backend`. `workflow/` depends on `protocol/` and drives whichever backends it is handed. `io/` depends only on `neural/`, `tasks/`, `causal/`.
+**Dependency flow:** `tasks/` and `causal/` are independent. `protocol/` is torch-free and links against no execution engine — the CLI imports the reference backend lazily. `neural/pytorch_hooks/` implements `protocol.backend.Backend`. `transform/` depends only on `protocol/` and is torch-free at module level: its op *records* are what load-time validation reads, so an op's numerics are imported inside its function body. `workflow/` depends on `protocol/`, drives whichever backends it is handed, and reaches `transform/` lazily when it runs a transform step; the workflow loader likewise reaches the op registry through a function-local import, so `protocol/` keeps no module-level edge to anything that executes. `io/` depends only on `neural/`, `tasks/`, `causal/`. `tests/test_architecture_layering.py` enforces the static half of all this; `tests/transform/test_load_is_torch_free.py` the behavioural half.
 
 ## 2. The protocol layer (`causalab/protocol/`)
 
@@ -55,7 +56,18 @@ Known limits (tracked in the intervention-protocol epic): one device per run (no
 
 ## 4. The workflow runner (`causalab/workflow/`)
 
-Executes workflow documents: topological step order from derived references, per-step output dirs under the run tree, an artifact overlay so later steps resolve earlier steps' products, select/plot steps, save publication, and a `workflow.json` manifest. The runner knows only the step graph — device/dtype live in the backends it is handed, and job dispatch is site tooling outside the repo (spec §8, "Execution scale").
+Executes workflow documents: topological step order from derived references, per-step output dirs under the run tree, an artifact overlay so later steps resolve earlier steps' products, transform/select/plot steps, save publication, and a `workflow.json` manifest. The runner knows only the step graph — device/dtype live in the backends it is handed, and job dispatch is site tooling outside the repo (spec §8, "Execution scale").
+
+**Transform ops (`causalab/transform/`)** are what a `transform` step runs (workflow spec §2.4):
+
+| module | owns |
+|---|---|
+| `schema.py` | the slot kinds (`Table` with declared columns, `Tensor`) and the parameter primitives, plus `TransformError` |
+| `registry.py` | the `TransformOp` record, the `@register` decorator, and `lookup("name@version")` with suggestions |
+| `io.py` | reading inputs and writing outputs — parquet tables, `.safetensors` bundles, and the identity a tensor output is stamped with |
+| `ops/` | the registered ops, one module each, numerics imported inside the function body |
+
+An op is a pure `(inputs, params) -> {slot: value}` function; the runner owns paths, formats and provenance so an op's unit test needs no filesystem. Adding one means adding a record, a body and an oracle test — a document can never introduce an op, which is what keeps a workflow run a pure function of the document.
 
 ## 5. Datasets are build products
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -41,6 +41,7 @@ Every pinned file follows the same rule: **regenerate via its script, review the
 | Pin | Script | What a diff means |
 |---|---|---|
 | `tests/protocol/corpus_digests.json` | `tests/protocol/update_corpus_digests.py` | the canonical form changed — spec §7 treats it as a loader migration |
+| `tests/protocol/workflow_digests.json` | `tests/protocol/update_workflow_digests.py` | a shipped workflow's canonical form changed (workflow spec §7). It is also what makes "adding a step type changed no existing document" a check rather than a claim |
 | `tests/golden/golden_digests.json` | `tests/golden/update_golden_digests.py` | a golden document or its fixture dataset changed (dataset content digests are part of the canonical form) |
 | `tests/golden/drift/drift_goldens.json` | `tests/golden/drift/update_drift_goldens.py` (GPU) | the stack's real-model numerics moved |
 | `tests/tasks/<task>/pinned_samples.json` | `scripts/update_task_pins.py` | task prompt/causal-model semantics changed |
@@ -51,7 +52,9 @@ Every pinned file follows the same rule: **regenerate via its script, review the
 
 ### Smoke
 
-Corpus documents (`tests/protocols/*_im.json`) run through the real CLI on `hf-internal-testing/tiny-random-LlamaForCausalLM` with `--set` overrides retargeting layers/model at tiny scale. Assertions are existence/shape/dtype only — tiny-random output content is garbage by design. The workflow capstone (`tests/neural/pytorch_hooks/test_workflow_run.py`) runs the whole weekdays pipeline shape the same way, and `test_bundle_entries_run.py` covers the two tensor handoffs between steps: a *swept* fit applied at one selected coordinate (the capstone deliberately collapses that sweep, which is how the gap went unseen) and a mean-ablation harvest reduced at save time.
+Corpus documents (`tests/protocols/*_im.json`) run through the real CLI on `hf-internal-testing/tiny-random-LlamaForCausalLM` with `--set` overrides retargeting layers/model at tiny scale. Assertions are existence/shape/dtype only — tiny-random output content is garbage by design. The workflow capstone (`tests/neural/pytorch_hooks/test_workflow_run.py`) runs the whole weekdays pipeline shape the same way, and `test_bundle_entries_run.py` covers the two tensor handoffs between steps: a *swept* fit applied at one selected coordinate (the capstone deliberately collapses that sweep, which is how the gap went unseen) and a mean-ablation harvest reduced at save time. `test_transform_run.py` is the `transform`-step capstone, covering both of its directions in one pipeline: protocol → transform → select/plot, and protocol → transform → protocol (a fitted basis re-entering a model-touching run, with its ArtifactIdentity checked).
+
+Transform ops themselves are unit-tested under `tests/transform/`: each op against a hand-computed oracle plus a determinism assertion (`numerical_unit`), the registry's refusals and record invariants (`unit`), and — in a subprocess, since `tests/conftest.py` imports torch at session scope — that a real `causalab validate` of a transform workflow never imports torch.
 
 ### Golden
 

--- a/docs/workflow_protocol.md
+++ b/docs/workflow_protocol.md
@@ -18,9 +18,11 @@ IM spec" below); it never touches a neural network itself.
   parallelism, and `explain` reports the derived schedule.
 - **Everything declared must reach a sink.** A step nothing consumes and
   nothing saves is a load error, exactly as in the IM spec.
-- **Closed vocabularies.** Step kinds, reductions, and plots are closed
-  sets. Anything they cannot express is post-hoc analysis outside the
-  record — the same trade the IM spec makes for metrics.
+- **Closed vocabularies.** Step kinds, reductions, plots, and the
+  transform ops are closed sets. Anything they cannot express is post-hoc
+  analysis outside the record — the same trade the IM spec makes for
+  metrics. Closed is not frozen: the op registry grows by pull request
+  (§11), never by document.
 - **Format**: strict JSON (unknown keys = error); YAML accepted at the
   authoring surface. **v1 scope**: a finite acyclic step graph — no
   loops, no conditionals, no nested workflows, one workflow per run.
@@ -46,7 +48,7 @@ Sections in this order (order enforced; `save` last):
 ### 2.1 `steps` — common fields
 
 Every step is an object with a `type` from the closed set
-`protocol · select · plot`, plus:
+`protocol · transform · select · plot`, plus:
 
 | field | meaning |
 |---|---|
@@ -103,12 +105,76 @@ notebook.
   aggregated by **mean** over examples — v1's one aggregation. `choose`
   then picks the best group; `emit` reads that group's coordinate (or
   value) columns.
+- **A `transform` producer is the exception: its table is ranked as
+  written.** A transform step carries no sweep coordinates, and its op
+  already decided what a row is, so there is nothing to group by and
+  re-aggregating would collapse the very rows the document was validated
+  against. The columns `value` and `emit` may name are exactly the ones
+  the op declares (§2.4) — there is no implicit `value` column, so a
+  select over a transform table names the column it ranks.
 - Output: `<run>/<step>/values.json` — an artifact **values table** in
   exactly the shape the IM spec's artifact-valued fields read
   (`{"artifact": "<step>", "key": "<emit key>"}`; the store resolves a
   step name to its `values.json`).
 
-### 2.4 `plot` steps — closed figure vocabulary
+### 2.4 `transform` steps — a registered, versioned, deterministic op
+
+The other half of what an analysis does: turn a table or a tensor into
+another one, deterministically, *inside* the record. Fitting a basis,
+aggregating per-head statistics, running a paired t-test — none of these
+touch a model, and before this step type each one was post-hoc analysis
+over saved files, which is exactly what makes a pipeline inexpressible as
+a document.
+
+```json
+"fit": {
+  "type": "transform", "op": "fit_pca@1",
+  "inputs": {"acts": {"step": "harvest", "value": "acts.safetensors"}},
+  "params": {"k": 8},
+  "outputs": {"weight": "basis.safetensors", "spectrum": "spectrum.parquet"}
+}
+```
+
+| field | meaning |
+|---|---|
+| `op` | ✓ — `name@version` from the registry (`causalab/transform/`); an unknown name, or an unknown version of a known name, is a load error with suggestions |
+| `inputs` | ✓ — `{slot: {step, value}}`, one entry per input slot the op declares; each **is** a derived dependency edge (§3). `slot`/`entry` additionally address one entry of a swept producer's bundle (IM spec §2.5) |
+| `params` | – the op's declared parameters, checked against its schema at load; defaults are materialized into the canonical form |
+| `outputs` | ✓ — `{slot: file_path}` under the step dir, one per output slot the op declares. A missing slot, an extra slot, or a path whose extension contradicts the slot's kind is a load error |
+
+- **The op vocabulary is closed, and versioned.** `name@version` is the
+  numerics contract: two runs of the same document must agree, so a
+  behavioural change ships as `fit_pca@2` and documents written against
+  `@1` keep digesting — and running — as written. The version is part of
+  the canonical form; the op's *implementation* never is, the same rule
+  that keeps backends out of protocol digests.
+- **Determinism is the registry's admission criterion.** An op must be a
+  pure function of its declared inputs and params. Anything stochastic
+  takes an explicit `seed` param and must be bit-stable across devices;
+  an op that cannot meet that does not belong in the registry, and that
+  refusal is the point of a closed set. (`fit_pca@1` declares no seed
+  because a full SVD has no randomness to pin — only a sign convention,
+  which it fixes.)
+- **An op declares the columns of every table it writes.** That is what a
+  consuming `select`/`plot` step's column references are checked against
+  at load (§5.7), since a transform step has no sweep axes to check
+  against instead.
+- **A transform step is not a new tensor channel.** Its tensor outputs are
+  ordinary `.safetensors` bundles in the run tree, read back through the
+  same `file_path` overlay and `entry` selector every other handoff uses
+  (§3) — including by a later *protocol* step, which is how a fitted
+  artifact re-enters a model-touching run.
+- **Provenance.** A tensor a transform step writes is stamped with an
+  ArtifactIdentity, so the §5.10 check a consuming document performs is a
+  real one: the fields its tensor inputs agree on are **inherited** (a fit
+  over activations from model X at site S is bound to X and S), the op may
+  declare fields its params define (a basis's rank `k`), and the step
+  stamps `produced_by` with the digest of its own canonical entry — its
+  provenance unit, the analogue of a protocol point's digest. An op with
+  no tensor input has nothing to inherit, so its tensor output cannot be
+  consumed as a featurizer bundle; that is a limit, not an oversight.
+
+### 2.5 `plot` steps — closed figure vocabulary
 
 ```json
 "scan": {"type": "plot", "plot": "heatmap", "from": "locate",
@@ -130,7 +196,7 @@ notebook.
   metric-vs-axis curves (`lines`). Every other figure is post-hoc
   analysis over the saved tables — deliberately outside the record.
 
-### 2.5 `save`
+### 2.6 `save`
 
 Mandatory, non-empty, the last section — the complete manifest of what
 leaves the workflow run, in the IM spec's binding-restated style:
@@ -164,9 +230,13 @@ One mechanism, inherited from the IM spec: **artifact references**.
   writes one bundle holding one entry per point, so the loading document
   names which with `entry` (IM spec §2.5) — authored, or implied by its own
   sweep coordinates.
+- A `transform` step's `inputs` are the third spelling of the same idea:
+  each entry names a prior step's output directly, so the table of inputs
+  **is** the step's dependency edges — nothing is discovered by walking a
+  nested document, because a transform step has none.
 - These references **are** the derived dependency edges, together with
-  `from` on select/plot steps and `after`. The step graph must be
-  acyclic; its topological order is the schedule skeleton, and steps with
+  `from` on select/plot steps, `inputs` on transform steps, and `after`.
+  The step graph must be acyclic; its topological order is the schedule skeleton, and steps with
   no path between them may run in parallel — the runner's choice, never
   authored.
 
@@ -192,31 +262,45 @@ One mechanism, inherited from the IM spec: **artifact references**.
 
 ## 5. Validation — load-error checklist
 
-1. Strict keys everywhere; closed enums (`type`, `choose`, `plot`) reject
-   with suggestions; derived fields may not be authored.
+1. Strict keys everywhere; closed enums (`type`, `choose`, `plot`, and a
+   transform step's `op`) reject with suggestions; derived fields may not
+   be authored. A transform step's `inputs`/`outputs` must name exactly
+   the slots its op declares — no missing slot, no extra one — and its
+   `params` must satisfy the op's parameter schema.
 2. Section order per §1; `save` last, non-empty.
 3. Step names unique and filesystem-safe; `save` file_paths unique,
    contained (relative, no parent escapes), and colliding with neither a
    step directory nor the reserved `workflow.json`.
-4. Every reference resolves: `from`/`after` name declared steps; every
-   `document` file exists and **loads as a valid intervention protocol**
-   (with the step's `set` applied); a save entry's `step`/`value` name an
-   actual output.
-5. The derived step graph (artifact refs + `from` + `after`) is acyclic.
+4. Every reference resolves: `from`/`after` name declared steps (`from`
+   names a `protocol` or a `transform` step — the two that produce
+   tables); every `document` file exists and **loads as a valid
+   intervention protocol** (with the step's `set` applied); a transform
+   `inputs` entry names an output its producer really writes; a save
+   entry's `step`/`value` name an actual output.
+5. The derived step graph (artifact refs + `from` + `inputs` + `after`)
+   is acyclic.
 6. Sink rule: every step is consumed by a later step or by `save`.
 7. `select`/`plot` column references (`x`, `y`, `series`, the ranked
    `value` column, `emit` values) must be sweep-coordinate columns (or
    `value`) of the referenced table's producing document — checkable at
    load from the inner document's axes; a plot must cover *every* axis of
    its producer (an uncovered axis would collapse into duplicate cells).
+   Over a **transform** producer the same rule reads against the op's
+   *declared* columns (§2.4) instead of sweep axes, with no implicit
+   `value`; axis coverage is vacuous, since there are no axes.
 8. `select.table`/`plot.table` name `.parquet` outputs; plot `file_path`
-   ends in `.png`/`.pdf`.
+   ends in `.png`/`.pdf`; a transform `outputs` path matches its slot's
+   kind (`.parquet` for a table, `.safetensors` for a tensor) and stays
+   inside the step dir.
 9. A protocol step's `set` paths must exist in the target document (an
    override that would create structure is a typo).
 10. An artifact ref that names a step must name a `select` step (only
-    they emit values tables), and a run-tree `file_path` load must name a
-    file its step actually saves — both checkable at load from the emit
-    table and the inner save manifests. The load must also select an
+    they emit values tables) — a transform step's outputs are *files*,
+    reached by the run-tree overlay, not a values table. A run-tree
+    `file_path` load must name a file its step actually saves, whether
+    that step is a `protocol` or a `transform` one — both checkable at
+    load from the emit table, the inner save manifests, and a transform
+    step's declared outputs. The load must also select an
     **entry** the producer will write, for every point of the consuming
     document: a producing document's entry names follow from its own
     expansion, which is deterministic at load (IM spec §3), so a mis-aimed
@@ -228,15 +312,19 @@ One mechanism, inherited from the IM spec: **artifact references**.
 | property | derivation |
 |---|---|
 | step dependencies, schedule, parallelism | the reference graph (§3) |
-| group-by columns of `select`/`plot` | the producing document's sweep axes |
+| group-by columns of `select`/`plot` | the producing document's sweep axes — none for a transform producer, whose table is used as written (§2.3) |
+| the columns of a transform step's table | its op's declared record (§2.4) |
+| a transform step's digest, and the identity it stamps | its canonical entry, plus what its tensor inputs agree on (§2.4) |
 | inner-document digests | the IM spec's canonicalization |
 | the run manifest | stamped at execution |
 
 ## 7. Canonical form and digests
 
 - The canonical form materializes every default (`value: "value"`, the
-  mean aggregation), sorts `after` lists, and **stamps each protocol
-  step with its document's digest**, computed with `set` applied: for a
+  mean aggregation, a transform op's parameter defaults), sorts `after`
+  lists, records a transform step's `op` as `name@version`, and **stamps
+  each protocol step with its document's digest**, computed with `set`
+  applied: for a
   document with no in-run references this is the IM spec §7 campaign
   digest; a document that references step outputs (its values exist only
   at run time) stamps the digest of its overridden authored form, and
@@ -343,6 +431,19 @@ standalone run.
 - **Plot vocabulary**: deliberately two kinds. The old analyses' bespoke
   figures (manifolds, pullback visualizations) are post-hoc consumers of
   saved tables/tensors, not workflow steps — confirm this boundary.
+- **Growing the op registry.** A new op, or a new version of one, is a
+  pull request against `causalab/transform/ops/`: a record (name, version,
+  parameter schema, input and output slots, declared table columns), a
+  body whose numerics are imported inside the function, and a unit test
+  against a hand-computed oracle plus a determinism assertion. A document
+  can never introduce one — that is what makes "the same document runs
+  the same way" checkable. The seed set is `fit_pca@1`, `head_stats@1`
+  and `paired_ttest@1`, chosen to exercise both directions of the IO
+  contract and multi-input slots rather than to cover the analyses.
+- **Ops with no consumer yet stay out.** The manifold family
+  (`fit_spline`, `geodesic_path`, `hellinger_pca`, `path_scores`) arrives
+  with the workflows that consume it, rather than pinning an API before
+  its caller exists.
 - **Multi-tenant steps**: a step per backend (fit on Megatron, apply on
   serving) needs per-step backend pinning — deferred until a second
   backend exists; the field would be one optional `backend` per protocol

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
     # (both were transitive before — via hydra-core/omegaconf and datasets)
     "pyyaml>=6.0",
     "pyarrow>=15.0",
+    # transform ops: the t-distribution CDF `paired_ttest@1` needs. Transitive
+    # before (via scikit-learn), but an op's dependency belongs in the record
+    # of what this package requires, not in another library's install tree.
+    "scipy>=1.10",
 ]
 
 [tool.pytest.ini_options]
@@ -86,6 +90,7 @@ dev = [
     "basedpyright",
     "scikit-learn-stubs",
     "pandas-stubs",
+    "scipy-stubs",
     "ipdb>=0.13.13",
     "hypothesis>=6.0",
 ]

--- a/tests/neural/pytorch_hooks/test_transform_run.py
+++ b/tests/neural/pytorch_hooks/test_transform_run.py
@@ -1,0 +1,224 @@
+"""A ``transform`` step end to end on tiny-random, through the real CLI.
+
+Two directions in one pipeline, because they are the two halves of the
+claim that a transform op is a first-class step and not a new mechanism:
+
+* **protocol → transform → select/plot** — a harvested activation bundle is
+  fitted by ``fit_pca@1``; the spectrum table it writes is then ranked by a
+  ``select`` step and drawn by a ``plot`` step, against the columns the op
+  *declared* (there are no sweep axes to group by).
+* **protocol → transform → protocol** — the fitted basis is loaded back by a
+  later protocol step as a ``pca`` featurizer through the ordinary run-tree
+  ``file_path`` overlay, with its ArtifactIdentity checked. That is the
+  handoff the manifold pipelines are built on, and the reason the transform
+  layer stamps identity rather than writing a bare tensor.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from safetensors.torch import load_file
+
+from causalab.protocol.cli import main
+from causalab.protocol.resolve import read_safetensors_metadata
+
+from tests.neural.pytorch_hooks.conftest import TINY_LLAMA
+from tests.protocol._env import FIXTURES
+
+pytestmark = pytest.mark.smoke
+
+REPO = Path(__file__).resolve().parents[3]
+METHODS = str(REPO / "causalab/configs/methods")  # absolute: the workflow is in tmp
+
+#: A pure-read document that loads the fitted basis as a ``pca`` featurizer.
+#: Its ``file_path`` names the transform step's run tree, which is what makes
+#: the edge a derived dependency (§3) — nothing about it is transform-specific.
+PROJECT_DOC = {
+    "version": "1",
+    "description": "read L0 through the fitted PCA basis",
+    "model": {"key": TINY_LLAMA, "revision": "main"},
+    "data": {"base": {"dataset": "weekdays/train", "field": "input"}},
+    "positions": {"answer_tok": {"index": -1}},
+    "sites": {"L0": {"component": "block_output", "layer": 0}},
+    "featurizers": {
+        "basis": {"kind": "pca", "k": 2, "file_path": "fit/weight.safetensors"}
+    },
+    "reads": {
+        "coords": {
+            "site": "L0",
+            "pos": "answer_tok",
+            "model": "original",
+            "input": "base",
+            "featurizer": "basis",
+        }
+    },
+    "save": [
+        {
+            "value": "coords",
+            "model": "original",
+            "input": "base",
+            "file_path": "coords.safetensors",
+        }
+    ],
+}
+
+
+def _workflow(project_doc: Path) -> dict:
+    tiny = {"model.key": TINY_LLAMA}
+    return {
+        "version": "1",
+        "description": "harvest -> fit_pca -> (select, plot) and back into a protocol step",
+        "steps": {
+            "harvest": {
+                "type": "protocol",
+                "document": f"{METHODS}/harvest.json",
+                "set": {**tiny, "sites.L8.layer": 0, "sites.L24.layer": 1},
+            },
+            "fit": {
+                "type": "transform",
+                "op": "fit_pca@1",
+                "inputs": {
+                    "acts": {"step": "harvest", "value": "acts_L8_ans.safetensors"}
+                },
+                "params": {"k": 2},
+                "outputs": {
+                    "weight": "weight.safetensors",
+                    "spectrum": "spectrum.parquet",
+                },
+            },
+            "top_pc": {
+                "type": "select",
+                "from": "fit",
+                "table": "spectrum.parquet",
+                "choose": "max",
+                "value": "explained_variance_ratio",
+                "emit": {"best_pc": "pc"},
+            },
+            "scree": {
+                "type": "plot",
+                "plot": "lines",
+                "from": "fit",
+                "table": "spectrum.parquet",
+                "x": "pc",
+                "value": "explained_variance_ratio",
+                "file_path": "scree.png",
+            },
+            "project": {"type": "protocol", "document": str(project_doc)},
+        },
+        "save": [
+            {
+                "step": "fit",
+                "value": "spectrum.parquet",
+                "file_path": "spectrum.parquet",
+            },
+            {
+                "step": "fit",
+                "value": "weight.safetensors",
+                "file_path": "basis.safetensors",
+            },
+            {"step": "top_pc", "value": "values.json", "file_path": "top_pc.json"},
+            {"step": "scree", "value": "scree.png", "file_path": "scree.png"},
+            {
+                "step": "project",
+                "value": "coords.safetensors",
+                "file_path": "coords.safetensors",
+            },
+        ],
+    }
+
+
+@pytest.fixture(scope="module")
+def transform_run(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """One full CLI run of the pipeline; the assertions below share it."""
+    root = tmp_path_factory.mktemp("transform-wf")
+    artifacts = root / "artifacts"
+    shutil.copytree(FIXTURES / "artifacts", artifacts, dirs_exist_ok=True)
+    project_doc = root / "project.json"
+    project_doc.write_text(json.dumps(PROJECT_DOC, indent=2))
+    wf_path = root / "wf.json"
+    wf_path.write_text(json.dumps(_workflow(project_doc), indent=2))
+    out = root / "run"
+    code = main(
+        [
+            "run",
+            str(wf_path),
+            "--data-root",
+            str(FIXTURES / "data"),
+            "--artifacts-root",
+            str(artifacts),
+            "--out",
+            str(out),
+        ]
+    )
+    assert code == 0
+    return out
+
+
+def test_transform_step_writes_its_declared_outputs(transform_run: Path) -> None:
+    assert (transform_run / "fit" / "weight.safetensors").is_file()
+    assert (transform_run / "fit" / "spectrum.parquet").is_file()
+    weight = load_file(str(transform_run / "fit" / "weight.safetensors"))["weight"]
+    # (d, k): the featurizer convention, so a protocol step can load it as-is
+    assert weight.shape == (16, 2)
+
+
+def test_spectrum_table_matches_the_declared_columns(transform_run: Path) -> None:
+    spectrum = pd.read_parquet(transform_run / "fit" / "spectrum.parquet")
+    assert list(spectrum.columns) == [
+        "pc",
+        "explained_variance",
+        "explained_variance_ratio",
+    ]
+    assert len(spectrum) == 2  # k = 2
+    assert spectrum["explained_variance_ratio"].is_monotonic_decreasing
+
+
+def test_select_ranks_the_transform_table_as_written(transform_run: Path) -> None:
+    """The rows are the op's, not a re-aggregation: the winning pc is 0, the
+    leading component, which a collapse-to-one-row mean could not name."""
+    values = json.loads((transform_run / "top_pc" / "values.json").read_text())
+    assert values == {"best_pc": 0}
+
+
+def test_fitted_basis_carries_a_checkable_identity(transform_run: Path) -> None:
+    metadata = read_safetensors_metadata(transform_run / "fit" / "weight.safetensors")
+    assert metadata is not None
+    # inherited from the harvested activations, so the basis is provably a fit
+    # on this model at the site the read came from
+    assert metadata["model_key"] == TINY_LLAMA
+    assert json.loads(metadata["site"]) == {"component": "block_output", "layer": 0}
+    # from the op's params, and from the step itself
+    assert metadata["k"] == "2"
+    assert metadata["dtype"] == "fp32"
+    assert metadata["backend"] == "transform"
+    assert len(metadata["produced_by"]) == 64
+
+
+def test_protocol_step_consumes_the_fitted_basis(transform_run: Path) -> None:
+    """The transform → protocol direction: the identity check on the loaded
+    featurizer is a real one, and the read comes back in the 2-d feature
+    space the basis defines."""
+    coords = load_file(str(transform_run / "project" / "coords.safetensors"))["coords"]
+    assert coords.shape == (4, 1, 2)  # 4 examples x 1 position x k
+
+
+def test_manifest_records_the_transform_step(transform_run: Path) -> None:
+    manifest = json.loads((transform_run / "workflow.json").read_text())
+    fit = manifest["steps"]["fit"]
+    assert fit["type"] == "transform"
+    assert fit["op"] == "fit_pca@1"
+    assert fit["status"] == "completed"
+    assert len(fit["digest"]) == 64
+    assert fit["files"] == ["spectrum.parquet", "weight.safetensors"]
+    assert sorted(manifest["published"]) == [
+        "basis.safetensors",
+        "coords.safetensors",
+        "scree.png",
+        "spectrum.parquet",
+        "top_pc.json",
+    ]

--- a/tests/protocol/test_workflow.py
+++ b/tests/protocol/test_workflow.py
@@ -434,3 +434,311 @@ def test_deferred_doc_with_external_featurizer_loads(env, tmp_path):
     )
     loaded = load_workflow(raw, env, workflow_dir=tmp_path)
     assert loaded.inner_digest_kind["apply"] == "authored"
+
+
+# --------------------------------------------------------------------------- #
+# transform steps (§2.4)
+# --------------------------------------------------------------------------- #
+
+
+def transform_workflow(tmp_path: Path) -> dict[str, Any]:
+    """A minimal harvest → fit_pca → plot workflow."""
+    methods = tmp_path / "methods"
+    methods.mkdir(exist_ok=True)
+    shutil.copyfile(
+        REPO / "causalab/configs/methods/harvest.json", methods / "harvest.json"
+    )
+    return {
+        "version": "1",
+        "steps": {
+            "harvest": {"type": "protocol", "document": "methods/harvest.json"},
+            "fit": {
+                "type": "transform",
+                "op": "fit_pca@1",
+                "inputs": {
+                    "acts": {"step": "harvest", "value": "acts_L8_ans.safetensors"}
+                },
+                "params": {"k": 2},
+                "outputs": {
+                    "weight": "weight.safetensors",
+                    "spectrum": "spectrum.parquet",
+                },
+            },
+            "scree": {
+                "type": "plot",
+                "plot": "lines",
+                "from": "fit",
+                "table": "spectrum.parquet",
+                "x": "pc",
+                "value": "explained_variance_ratio",
+                "file_path": "scree.png",
+            },
+        },
+        "save": [{"step": "scree", "value": "scree.png", "file_path": "scree.png"}],
+    }
+
+
+class TestTransformParse:
+    def test_it_loads_and_schedules_after_its_input(self, env, tmp_path):
+        """`inputs` ARE the dependency edges — nobody authored this order."""
+        loaded = load_workflow(transform_workflow(tmp_path), env, workflow_dir=tmp_path)
+        assert loaded.order == ("harvest", "fit", "scree")
+        assert loaded.dependencies["fit"] == ("harvest",)
+
+    def test_rule_1_unknown_op_suggests(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["op"] = "fit_pcaa@1"
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "fit_pca" in str(err)
+
+    def test_rule_1_unknown_version_of_a_known_op(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["op"] = "fit_pca@9"
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "has no version 9" in str(err)
+
+    def test_rule_1_a_missing_output_slot(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        del raw["steps"]["fit"]["outputs"]["spectrum"]
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "spectrum" in str(err)
+
+    def test_rule_1_an_undeclared_output_slot(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["outputs"]["loadings"] = "loadings.parquet"
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "no output slot 'loadings'" in str(err)
+
+    def test_rule_1_an_undeclared_input_slot(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["inputs"]["extra"] = {
+            "step": "harvest",
+            "value": "x.safetensors",
+        }
+        expect_rule(1, raw, env, tmp_path)
+
+    def test_rule_1_a_bad_param_type(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["params"]["k"] = "2"
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "integer" in str(err)
+
+    def test_rule_1_a_missing_required_param(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["params"] = {}
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "missing required parameter 'k'" in str(err)
+
+    def test_rule_1_an_unknown_param_suggests(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["params"]["kk"] = 2
+        err = expect_rule(1, raw, env, tmp_path)
+        assert "unknown parameter 'kk'" in str(err)
+
+    def test_rule_8_an_output_slot_keeps_its_file_kind(self, env, tmp_path):
+        """A tensor slot cannot be written as a .parquet — the record says
+        which format the slot is, so a typo is a load error, not a surprise
+        at read time."""
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["outputs"]["weight"] = "weight.parquet"
+        expect_rule(8, raw, env, tmp_path)
+
+    def test_rule_4_an_input_naming_an_unknown_step(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["inputs"]["acts"]["step"] = "nowhere"
+        expect_rule(4, raw, env, tmp_path)
+
+    def test_rule_4_an_input_the_producer_does_not_save(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["inputs"]["acts"]["value"] = "acts_L99.safetensors"
+        err = expect_rule(4, raw, env, tmp_path)
+        assert "produces no 'acts_L99.safetensors'" in str(err)
+
+
+class TestTransformAsAProducer:
+    def test_rule_7_columns_are_checked_against_the_declaration(self, env, tmp_path):
+        """A transform producer has no sweep axes; its op's declared columns
+        are what rule 7 checks instead."""
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["scree"]["x"] = "component"
+        err = expect_rule(7, raw, env, tmp_path)
+        assert "explained_variance_ratio" in str(err)  # what it does have
+
+    def test_rule_7_there_is_no_implicit_value_column(self, env, tmp_path):
+        """`value` defaults to 'value' for a protocol producer's metric table;
+        a transform table is only what its op declares, so the default must be
+        refused rather than silently failing at run time."""
+        raw = transform_workflow(tmp_path)
+        del raw["steps"]["scree"]["value"]
+        err = expect_rule(7, raw, env, tmp_path)
+        assert "'value'" in str(err)
+
+    def test_a_select_step_may_rank_a_transform_table(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["top"] = {
+            "type": "select",
+            "from": "fit",
+            "table": "spectrum.parquet",
+            "choose": "max",
+            "value": "explained_variance_ratio",
+            "emit": {"best_pc": "pc"},
+        }
+        raw["save"].append(
+            {"step": "top", "value": "values.json", "file_path": "top.json"}
+        )
+        loaded = load_workflow(raw, env, workflow_dir=tmp_path)
+        assert loaded.dependencies["top"] == ("fit",)
+
+    def test_rule_4_a_tensor_slot_cannot_be_ranked(self, env, tmp_path):
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["scree"]["table"] = "weight.safetensors"
+        expect_rule(8, raw, env, tmp_path)  # .parquet is required first
+
+    def test_a_protocol_step_may_load_a_transform_tensor(self, env, tmp_path):
+        """Rule 10's run-tree half: the fitted-artifact direction #37 needs."""
+        raw = transform_workflow(tmp_path)
+        project = {
+            "version": "1",
+            "model": {"key": "meta-llama/Llama-3.1-8B", "revision": "main"},
+            "data": {"base": {"dataset": "weekdays/train", "field": "input"}},
+            "positions": {"tap": {"index": -1}},
+            "sites": {"L0": {"component": "block_output", "layer": 0}},
+            "featurizers": {
+                "basis": {"kind": "pca", "k": 2, "file_path": "fit/weight.safetensors"}
+            },
+            "reads": {
+                "coords": {
+                    "site": "L0",
+                    "pos": "tap",
+                    "model": "original",
+                    "input": "base",
+                    "featurizer": "basis",
+                }
+            },
+            "save": [
+                {
+                    "value": "coords",
+                    "model": "original",
+                    "input": "base",
+                    "file_path": "coords.safetensors",
+                }
+            ],
+        }
+        (tmp_path / "methods/project.json").write_text(json.dumps(project))
+        raw["steps"]["project"] = {
+            "type": "protocol",
+            "document": "methods/project.json",
+        }
+        raw["save"].append(
+            {
+                "step": "project",
+                "value": "coords.safetensors",
+                "file_path": "coords.safetensors",
+            }
+        )
+        loaded = load_workflow(raw, env, workflow_dir=tmp_path)
+        assert "fit" in loaded.dependencies["project"]
+
+    def test_rule_10_a_protocol_step_cannot_load_what_a_transform_never_writes(
+        self, env, tmp_path
+    ):
+        raw = transform_workflow(tmp_path)
+        project = {
+            "version": "1",
+            "model": {"key": "meta-llama/Llama-3.1-8B", "revision": "main"},
+            "data": {"base": {"dataset": "weekdays/train", "field": "input"}},
+            "positions": {"tap": {"index": -1}},
+            "sites": {"L0": {"component": "block_output", "layer": 0}},
+            "featurizers": {
+                "basis": {"kind": "pca", "k": 2, "file_path": "fit/basis.safetensors"}
+            },
+            "reads": {
+                "coords": {
+                    "site": "L0",
+                    "pos": "tap",
+                    "model": "original",
+                    "input": "base",
+                    "featurizer": "basis",
+                }
+            },
+            "save": [
+                {
+                    "value": "coords",
+                    "model": "original",
+                    "input": "base",
+                    "file_path": "coords.safetensors",
+                }
+            ],
+        }
+        (tmp_path / "methods/project.json").write_text(json.dumps(project))
+        raw["steps"]["project"] = {
+            "type": "protocol",
+            "document": "methods/project.json",
+        }
+        raw["save"].append(
+            {
+                "step": "project",
+                "value": "coords.safetensors",
+                "file_path": "coords.safetensors",
+            }
+        )
+        err = expect_rule(10, raw, env, tmp_path)
+        assert "saves no 'basis.safetensors'" in str(err)
+
+
+class TestTransformCanonicalForm:
+    def test_the_op_version_and_params_enter_the_form(self, env, tmp_path):
+        loaded = load_workflow(transform_workflow(tmp_path), env, workflow_dir=tmp_path)
+        entry = loaded.canonical["steps"]["fit"]
+        assert entry["op"] == "fit_pca@1"
+        assert entry["params"] == {"k": 2}
+        assert entry["outputs"] == {
+            "weight": "weight.safetensors",
+            "spectrum": "spectrum.parquet",
+        }
+        assert entry["inputs"] == {
+            "acts": {"step": "harvest", "value": "acts_L8_ans.safetensors"}
+        }
+
+    def test_optional_selectors_add_no_key_when_unauthored(self, env, tmp_path):
+        loaded = load_workflow(transform_workflow(tmp_path), env, workflow_dir=tmp_path)
+        acts = loaded.canonical["steps"]["fit"]["inputs"]["acts"]
+        assert "slot" not in acts and "entry" not in acts
+
+    def test_a_param_change_moves_the_digest(self, env, tmp_path):
+        original = load_workflow(
+            transform_workflow(tmp_path), env, workflow_dir=tmp_path
+        )
+        raw = transform_workflow(tmp_path)
+        raw["steps"]["fit"]["params"]["k"] = 3
+        edited = load_workflow(raw, env, workflow_dir=tmp_path)
+        assert edited.digest != original.digest
+
+    def test_each_transform_step_gets_a_provenance_digest(self, env, tmp_path):
+        loaded = load_workflow(transform_workflow(tmp_path), env, workflow_dir=tmp_path)
+        assert len(loaded.transform_digests["fit"]) == 64
+        assert set(loaded.transform_digests) == {"fit"}
+
+
+# --------------------------------------------------------------------------- #
+# shipped-workflow digest pins
+# --------------------------------------------------------------------------- #
+
+WORKFLOW_DIR = REPO / "causalab/configs/workflows"
+WORKFLOW_PINS = Path(__file__).parent / "workflow_digests.json"
+
+
+class TestShippedWorkflowDigests:
+    """`workflow_digests.json`, regenerated by update_workflow_digests.py.
+
+    A diff is a loader migration (§7), never a silent re-pin — and it is what
+    makes "a new step type changed no existing document" a check rather than
+    a claim."""
+
+    def test_every_shipped_workflow_is_pinned(self):
+        pins = json.loads(WORKFLOW_PINS.read_text())
+        assert sorted(pins) == sorted(p.name for p in WORKFLOW_DIR.glob("*.json"))
+
+    def test_digests_match_their_pins(self, env):
+        for name, digest in json.loads(WORKFLOW_PINS.read_text()).items():
+            assert load_workflow(WORKFLOW_DIR / name, env).digest == digest, name

--- a/tests/protocol/update_workflow_digests.py
+++ b/tests/protocol/update_workflow_digests.py
@@ -1,0 +1,44 @@
+"""Regenerate tests/protocol/workflow_digests.json — the shipped-workflow pins.
+
+Run with ``uv run python tests/protocol/update_workflow_digests.py`` from the
+repo root, then review the diff. Same discipline as the corpus pins: a changed
+workflow digest means the workflow canonical form changed (workflow spec §7),
+which is a loader migration, never a silent re-pin.
+
+The pin exists so that "adding a step type changed no existing document" is a
+test rather than a claim: a new step type that leaked a key into the canonical
+form of documents that do not use it would move these digests.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from protocol._env import FIXTURES, build_env, write_rot_fixture  # noqa: E402
+
+from causalab.protocol.workflow import load_workflow  # noqa: E402
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[2] / "causalab/configs/workflows"
+
+
+def main() -> None:
+    tmp = Path(tempfile.mkdtemp())
+    shutil.copytree(FIXTURES / "artifacts", tmp, dirs_exist_ok=True)
+    write_rot_fixture(tmp)
+    env = build_env(tmp)
+    pins: dict[str, str] = {}
+    for path in sorted(WORKFLOW_DIR.glob("*.json")):
+        pins[path.name] = load_workflow(path, env).digest
+    out = Path(__file__).parent / "workflow_digests.json"
+    out.write_text(json.dumps(pins, indent=2) + "\n")
+    print(f"wrote {out} ({len(pins)} workflows)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/protocol/workflow_digests.json
+++ b/tests/protocol/workflow_digests.json
@@ -1,0 +1,3 @@
+{
+  "weekdays_8b.json": "ccf7893c03f199562b7688f864e43317233981b594d97dda0754cdccb5c13ea7"
+}

--- a/tests/test_architecture_layering.py
+++ b/tests/test_architecture_layering.py
@@ -1,12 +1,23 @@
-"""Guard test for docs/CODEBASE.md invariant 3.
+"""Static guards for the layering docs/CODEBASE.md §1 states.
 
-`io/` is the lowest application layer above third-party libs: it may depend only
-on `neural/`, `tasks/`, `causal/`, and third-party libs. It must NOT import from
-`methods/`, `analyses/`, or `runner/`. Both `methods/` and `analyses/` consume
-`io/`, so an upward edge from `io/` creates a circular dependency.
+Three invariants, all checked by parsing the source — no model load, no GPU:
 
-This test parses every module under `causalab/io/` and fails if any of them
-imports from a forbidden higher layer. It's static (no GPU, no model load).
+1. **`io/` has no upward imports.** It is the lowest application layer above
+   third-party libs, and the layers above it consume it, so an upward edge
+   would be a cycle.
+2. **`transform/` is torch-free at module level.** The op *records* are what
+   the pure CLI verbs read to refuse a bad document, so importing the registry
+   must not drag in numerics. Ops keep their heavy imports inside the function
+   body — the idiom the runner already uses for pandas and matplotlib.
+3. **`protocol/` keeps no module-level edge to `transform/`.** The document
+   layer links against nothing that executes; the workflow loader reaches the
+   registry through a function-local import, as `cli.py` does for the backend.
+
+Invariant 2 is a *static* check. Its behavioural counterpart — that a real
+``causalab validate`` of a transform workflow leaves torch out of
+``sys.modules`` — lives in ``tests/transform/test_load_is_torch_free.py``,
+because ``tests/conftest.py`` imports torch at session scope and an in-process
+check could never see the difference.
 """
 
 from __future__ import annotations
@@ -17,56 +28,89 @@ from pathlib import Path
 import pytest
 
 import causalab.io
+import causalab.protocol
+import causalab.transform
 
-# Static structural guard — pure AST inspection, no model load (see module docstring).
+# Static structural guard — pure AST inspection, no model load (see docstring).
 pytestmark = pytest.mark.unit
 
-# Higher layers that io/ must never import from (invariant 3).
-FORBIDDEN_PREFIXES = (
-    "causalab.methods",
-    "causalab.analyses",
-    "causalab.runner",
-)
+#: Layers `io/` must never import from. The pre-refactor entries
+#: (`causalab.methods`, `causalab.analyses`, `causalab.runner`) named packages
+#: that no longer exist, so the guard had stopped guarding anything.
+FORBIDDEN_PREFIXES = ("causalab.transform", "causalab.workflow")
+
+#: Numerics no module under `causalab/transform/` may import at module level.
+HEAVY_MODULES = ("torch", "numpy", "pandas", "scipy", "sklearn", "safetensors")
 
 IO_DIR = Path(causalab.io.__file__).parent
+TRANSFORM_DIR = Path(causalab.transform.__file__).parent
+PROTOCOL_DIR = Path(causalab.protocol.__file__).parent
 
 
-def _forbidden_imports(path: Path) -> list[tuple[int, str]]:
-    """Return (lineno, module) for every absolute import into a forbidden layer."""
+def _module_level_imports(path: Path) -> list[tuple[int, str]]:
+    """Every absolute import executed at *module* scope.
+
+    Imports nested inside a function body are deliberately not reported:
+    deferring a heavy import into the call is exactly the discipline these
+    guards exist to permit."""
     tree = ast.parse(path.read_text(), filename=str(path))
-    violations: list[tuple[int, str]] = []
+    nested: set[int] = set()
     for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for inner in ast.walk(node):
+                nested.add(id(inner))
+    found: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if id(node) in nested:
+            continue
         if isinstance(node, ast.ImportFrom):
-            # level > 0 is a relative import (within io/) — always allowed.
             if node.level == 0 and node.module is not None:
-                module = node.module
-            else:
-                continue
+                found.append((node.lineno, node.module))
         elif isinstance(node, ast.Import):
-            # `import a, b` — check each alias.
-            for alias in node.names:
-                if any(
-                    alias.name == p or alias.name.startswith(p + ".")
-                    for p in FORBIDDEN_PREFIXES
-                ):
-                    violations.append((node.lineno, alias.name))
-            continue
-        else:
-            continue
-        if any(module == p or module.startswith(p + ".") for p in FORBIDDEN_PREFIXES):
-            violations.append((node.lineno, module))
-    return violations
+            found.extend((node.lineno, alias.name) for alias in node.names)
+    return found
+
+
+def _matches(module: str, prefixes: tuple[str, ...]) -> bool:
+    return any(module == p or module.startswith(p + ".") for p in prefixes)
+
+
+def _offenders(root: Path, prefixes: tuple[str, ...]) -> list[str]:
+    return [
+        f"{path.relative_to(root.parent.parent)}:{lineno} imports {module}"
+        for path in sorted(root.rglob("*.py"))
+        for lineno, module in _module_level_imports(path)
+        if _matches(module, prefixes)
+    ]
 
 
 def test_io_has_no_upward_imports():
-    """No file under causalab/io/ may import from methods/, analyses/, or runner/."""
-    offenders: list[str] = []
-    for py_file in sorted(IO_DIR.rglob("*.py")):
-        for lineno, module in _forbidden_imports(py_file):
-            rel = py_file.relative_to(IO_DIR.parent.parent)
-            offenders.append(f"{rel}:{lineno} imports {module}")
-
+    offenders = _offenders(IO_DIR, FORBIDDEN_PREFIXES)
     assert not offenders, (
-        "docs/CODEBASE.md invariant 3 violated — io/ must not import from "
-        "methods/, analyses/, or runner/:\n  " + "\n  ".join(offenders)
+        "docs/CODEBASE.md invariant 3 violated — io/ must not import from a "
+        "higher layer:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_transform_is_torch_free_at_module_level():
+    """An op's numerics belong inside its function body.
+
+    Without this, one stray top-level ``import torch`` in a new op would make
+    ``causalab validate`` pay for the whole numerics stack — silently, since
+    every test process has torch loaded already."""
+    offenders = _offenders(TRANSFORM_DIR, HEAVY_MODULES)
+    assert not offenders, (
+        "causalab/transform/ must stay importable without numerics — move the "
+        "import inside the function that needs it:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_protocol_does_not_link_against_transform_at_module_level():
+    """``protocol/`` is the backend-free document layer. It *reads* op records
+    at load, but through a function-local import, so ``import causalab.protocol``
+    still pulls in nothing that executes."""
+    offenders = _offenders(PROTOCOL_DIR, ("causalab.transform",))
+    assert not offenders, (
+        "protocol/ must not import causalab.transform at module level:\n  "
+        + "\n  ".join(offenders)
     )

--- a/tests/transform/test_fit_pca.py
+++ b/tests/transform/test_fit_pca.py
@@ -1,0 +1,83 @@
+"""``fit_pca@1`` against a hand-computed oracle.
+
+The fixture is a cross in the xy-plane of R^3, centred at the origin:
+points (±2, 0, 0) and (0, ±1, 0). With n = 4 and ddof = 1 the variances are
+x: (4 + 4)/3 = 8/3, y: (1 + 1)/3 = 2/3, z: 0 — so the ratios are exactly
+0.8 and 0.2, and the components are the x and y axes.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from causalab.transform.ops.fit_pca import fit_pca
+from causalab.transform.schema import TransformError
+
+pytestmark = pytest.mark.numerical_unit
+
+CROSS = torch.tensor(
+    [[2.0, 0.0, 0.0], [-2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, -1.0, 0.0]]
+)
+
+
+def test_components_and_spectrum_match_the_oracle() -> None:
+    out = fit_pca(inputs={"acts": CROSS}, params={"k": 2})
+    weight, spectrum = out["weight"], out["spectrum"]
+    assert weight.shape == (3, 2)  # (d, k)
+    assert torch.allclose(weight[:, 0], torch.tensor([1.0, 0.0, 0.0]), atol=1e-6)
+    assert torch.allclose(weight[:, 1], torch.tensor([0.0, 1.0, 0.0]), atol=1e-6)
+    assert spectrum["pc"].tolist() == [0, 1]
+    assert spectrum["explained_variance"].tolist() == pytest.approx([8 / 3, 2 / 3])
+    assert spectrum["explained_variance_ratio"].tolist() == pytest.approx([0.8, 0.2])
+
+
+def test_leading_dimensions_are_flattened() -> None:
+    """[examples, positions, d] and [rows, d] must mean the same fit."""
+    flat = fit_pca(inputs={"acts": CROSS}, params={"k": 2})
+    nested = fit_pca(inputs={"acts": CROSS.reshape(2, 2, 3)}, params={"k": 2})
+    assert torch.equal(flat["weight"], nested["weight"])
+
+
+def test_the_sign_convention_is_pinned() -> None:
+    """SVD fixes a component only up to a sign. Negating the input must not
+    negate the basis, or two equally 'correct' fits would disagree."""
+    positive = fit_pca(inputs={"acts": CROSS}, params={"k": 2})["weight"]
+    negated = fit_pca(inputs={"acts": -CROSS}, params={"k": 2})["weight"]
+    assert torch.equal(positive, negated)
+    # and the pinned sign is "largest-magnitude entry positive"
+    for column in range(positive.shape[1]):
+        component = positive[:, column]
+        assert component[component.abs().argmax()] > 0
+
+
+def test_the_fit_is_deterministic() -> None:
+    """Bit-identical, twice in one process — the registry's admission
+    criterion, and why this op declares no seed."""
+    first = fit_pca(inputs={"acts": CROSS}, params={"k": 2})
+    second = fit_pca(inputs={"acts": CROSS}, params={"k": 2})
+    assert torch.equal(first["weight"], second["weight"])
+    assert first["spectrum"].equals(second["spectrum"])
+
+
+def test_k_beyond_the_available_rank_is_refused() -> None:
+    with pytest.raises(TransformError) as err:
+        fit_pca(inputs={"acts": CROSS}, params={"k": 5})
+    assert "exceeds the rank available" in str(err.value)
+
+
+def test_a_one_dimensional_input_is_refused() -> None:
+    with pytest.raises(TransformError):
+        fit_pca(inputs={"acts": torch.zeros(4)}, params={"k": 1})
+
+
+def test_a_single_row_has_no_variance_to_fit() -> None:
+    with pytest.raises(TransformError):
+        fit_pca(inputs={"acts": torch.zeros(1, 3)}, params={"k": 1})
+
+
+def test_a_degenerate_input_reports_zero_ratios_rather_than_nan() -> None:
+    """All-identical rows have zero total variance; 0/0 would be NaN, which
+    would then travel silently into a plot."""
+    out = fit_pca(inputs={"acts": torch.ones(4, 3)}, params={"k": 2})
+    assert out["spectrum"]["explained_variance_ratio"].tolist() == [0.0, 0.0]

--- a/tests/transform/test_head_stats.py
+++ b/tests/transform/test_head_stats.py
@@ -1,0 +1,58 @@
+"""``head_stats@1`` against a hand-computed oracle."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from causalab.transform.ops.head_stats import head_stats
+from causalab.transform.schema import TransformError
+
+pytestmark = pytest.mark.numerical_unit
+
+TABLE = pd.DataFrame(
+    {
+        "sites.target.layer": [0, 0, 1, 1, 1],
+        "sites.target.head": [0, 0, 0, 1, 1],
+        "value": [1.0, 3.0, 5.0, 2.0, 4.0],
+    }
+)
+DEFAULTS = {
+    "layer_column": "sites.target.layer",
+    "head_column": "sites.target.head",
+    "value_column": "value",
+}
+
+
+def test_cells_match_the_oracle() -> None:
+    """(0,0): {1,3} -> mean 2, population std 1. (1,0): {5} -> 5, 0.
+    (1,1): {2,4} -> mean 3, population std 1."""
+    stats = head_stats(inputs={"table": TABLE}, params=DEFAULTS)["stats"]
+    assert list(stats.columns) == ["layer", "head", "n", "mean", "std"]
+    assert stats.to_dict("records") == [
+        {"layer": 0, "head": 0, "n": 2, "mean": 2.0, "std": 1.0},
+        {"layer": 1, "head": 0, "n": 1, "mean": 5.0, "std": 0.0},
+        {"layer": 1, "head": 1, "n": 2, "mean": 3.0, "std": 1.0},
+    ]
+
+
+def test_a_single_row_cell_has_zero_spread_not_nan() -> None:
+    """ddof=0 on purpose: NaN here would poison every downstream mean."""
+    stats = head_stats(inputs={"table": TABLE}, params=DEFAULTS)["stats"]
+    lonely = stats[(stats["layer"] == 1) & (stats["head"] == 0)]
+    assert lonely["std"].iloc[0] == 0.0
+
+
+def test_rows_are_sorted_so_the_output_is_deterministic() -> None:
+    shuffled = TABLE.iloc[[4, 0, 3, 1, 2]].reset_index(drop=True)
+    first = head_stats(inputs={"table": TABLE}, params=DEFAULTS)["stats"]
+    second = head_stats(inputs={"table": shuffled}, params=DEFAULTS)["stats"]
+    assert first.equals(second)
+
+
+def test_a_missing_column_names_what_the_table_has() -> None:
+    params = {**DEFAULTS, "head_column": "sites.target.expert"}
+    with pytest.raises(TransformError) as err:
+        head_stats(inputs={"table": TABLE}, params=params)
+    assert "sites.target.expert" in str(err.value)
+    assert "sites.target.head" in str(err.value)  # what it does have

--- a/tests/transform/test_load_is_torch_free.py
+++ b/tests/transform/test_load_is_torch_free.py
@@ -1,0 +1,102 @@
+"""``causalab validate`` of a transform workflow must not import torch.
+
+This is the property the whole record-versus-body split exists for: a document
+naming an unknown op, a bad parameter or a missing output slot is refused on a
+laptop with no accelerator, before a single step runs. The registry holds the
+op *records*; the numerics live inside the op function bodies.
+
+It has to run in a **subprocess**: ``tests/conftest.py`` imports torch at
+session scope, so an in-process ``"torch" not in sys.modules`` check would be
+false regardless of whether the loader behaved. The subprocess precedent is
+``tests/neural/pytorch_hooks/test_end_to_end_iia.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.protocol._env import FIXTURES
+
+pytestmark = pytest.mark.unit
+
+REPO = Path(__file__).resolve().parents[2]
+METHODS = REPO / "causalab/configs/methods"
+
+_PROBE = """
+import json, sys
+from causalab.protocol.cli import main
+
+code = main(["validate", sys.argv[1], "--data-root", sys.argv[2],
+             "--artifacts-root", sys.argv[3]])
+print(json.dumps({"code": code, "torch": "torch" in sys.modules,
+                  "ops": "causalab.transform.registry" in sys.modules}))
+"""
+
+
+def _workflow() -> dict:
+    return {
+        "version": "1",
+        "steps": {
+            "harvest": {"type": "protocol", "document": str(METHODS / "harvest.json")},
+            "fit": {
+                "type": "transform",
+                "op": "fit_pca@1",
+                "inputs": {
+                    "acts": {"step": "harvest", "value": "acts_L8_ans.safetensors"}
+                },
+                "params": {"k": 2},
+                "outputs": {
+                    "weight": "weight.safetensors",
+                    "spectrum": "spectrum.parquet",
+                },
+            },
+            "scree": {
+                "type": "plot",
+                "plot": "lines",
+                "from": "fit",
+                "table": "spectrum.parquet",
+                "x": "pc",
+                "value": "explained_variance_ratio",
+                "file_path": "scree.png",
+            },
+        },
+        "save": [{"step": "scree", "value": "scree.png", "file_path": "scree.png"}],
+    }
+
+
+def _validate(tmp_path: Path, workflow: dict) -> dict:
+    artifacts = tmp_path / "artifacts"
+    shutil.copytree(FIXTURES / "artifacts", artifacts, dirs_exist_ok=True)
+    wf = tmp_path / "wf.json"
+    wf.write_text(json.dumps(workflow))
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE, str(wf), str(FIXTURES / "data"), str(artifacts)],
+        capture_output=True,
+        text=True,
+        cwd=REPO,
+    )
+    assert result.returncode == 0, result.stderr
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
+def test_validate_reads_op_records_without_importing_torch(tmp_path: Path) -> None:
+    report = _validate(tmp_path, _workflow())
+    assert report["code"] == 0
+    assert report["ops"], "the registry was never consulted — the test proves nothing"
+    assert not report["torch"], "validating a transform workflow imported torch"
+
+
+def test_a_bad_op_is_refused_without_importing_torch(tmp_path: Path) -> None:
+    """The refusal, not just the acceptance, has to be cheap: that is what
+    lets an author check a document before booking an accelerator."""
+    workflow = _workflow()
+    workflow["steps"]["fit"]["params"]["k"] = "two"
+    report = _validate(tmp_path, workflow)
+    assert report["code"] != 0
+    assert not report["torch"]

--- a/tests/transform/test_paired_ttest.py
+++ b/tests/transform/test_paired_ttest.py
@@ -1,0 +1,91 @@
+"""``paired_ttest@1`` against a hand-computed oracle.
+
+Differences 0.5, 1.0, 0.5, 1.0 → mean 0.75, sample sd sqrt(0.25/3) = 0.288675,
+so t = 0.75 / (0.288675 / 2) = 5.196152 on 3 degrees of freedom.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from causalab.transform.ops.paired_ttest import paired_ttest
+from causalab.transform.schema import TransformError
+
+pytestmark = pytest.mark.numerical_unit
+
+A = pd.DataFrame({"example": [0, 1, 2, 3], "value": [1.0, 2.0, 3.0, 4.0]})
+B = pd.DataFrame({"example": [0, 1, 2, 3], "value": [0.5, 1.0, 2.5, 3.0]})
+DEFAULTS = {"value_column": "value", "pair_column": "example"}
+
+
+def test_statistics_match_the_oracle() -> None:
+    stats = paired_ttest(inputs={"a": A, "b": B}, params=DEFAULTS)["stats"]
+    assert list(stats.columns) == [
+        "n_pairs",
+        "df",
+        "mean_difference",
+        "t_statistic",
+        "p_value",
+    ]
+    row = stats.iloc[0]
+    assert row["n_pairs"] == 4 and row["df"] == 3
+    assert row["mean_difference"] == pytest.approx(0.75)
+    assert row["t_statistic"] == pytest.approx(5.196152, abs=1e-6)
+    assert row["p_value"] == pytest.approx(0.013847, abs=1e-6)
+
+
+def test_the_test_is_two_sided() -> None:
+    """Swapping the arms flips the statistic's sign and leaves p alone."""
+    forward = paired_ttest(inputs={"a": A, "b": B}, params=DEFAULTS)["stats"].iloc[0]
+    reverse = paired_ttest(inputs={"a": B, "b": A}, params=DEFAULTS)["stats"].iloc[0]
+    assert reverse["t_statistic"] == pytest.approx(-forward["t_statistic"])
+    assert reverse["p_value"] == pytest.approx(forward["p_value"])
+
+
+def test_rows_are_averaged_within_a_pair_before_the_test() -> None:
+    """A swept document writes one row per (example, point); a bare join would
+    multiply rows and inflate n."""
+    doubled = pd.concat([A, A], ignore_index=True)
+    once = paired_ttest(inputs={"a": A, "b": B}, params=DEFAULTS)["stats"].iloc[0]
+    twice = paired_ttest(inputs={"a": doubled, "b": B}, params=DEFAULTS)["stats"].iloc[
+        0
+    ]
+    assert twice["n_pairs"] == once["n_pairs"] == 4
+    assert twice["t_statistic"] == pytest.approx(once["t_statistic"])
+
+
+def test_only_shared_pairs_are_compared() -> None:
+    partial = pd.DataFrame({"example": [0, 1], "value": [0.5, 1.0]})
+    stats = paired_ttest(inputs={"a": A, "b": partial}, params=DEFAULTS)["stats"]
+    assert stats.iloc[0]["n_pairs"] == 2
+
+
+def test_a_constant_difference_is_reported_rather_than_fudged() -> None:
+    """Zero spread makes the statistic degenerate; inf/0.0 is honest, an
+    epsilon in the denominator would not be."""
+    shifted = A.assign(value=A["value"] + 1.0)
+    stats = paired_ttest(inputs={"a": shifted, "b": A}, params=DEFAULTS)["stats"]
+    assert stats.iloc[0]["t_statistic"] == float("inf")
+    assert stats.iloc[0]["p_value"] == 0.0
+
+
+def test_identical_arms_are_not_significant() -> None:
+    stats = paired_ttest(inputs={"a": A, "b": A}, params=DEFAULTS)["stats"]
+    assert stats.iloc[0]["t_statistic"] == 0.0
+    assert stats.iloc[0]["p_value"] == 1.0
+
+
+def test_too_few_pairs_is_refused() -> None:
+    one = pd.DataFrame({"example": [0], "value": [1.0]})
+    with pytest.raises(TransformError) as err:
+        paired_ttest(inputs={"a": one, "b": one}, params=DEFAULTS)
+    assert "at least 2" in str(err.value)
+
+
+def test_a_missing_column_names_the_offending_side() -> None:
+    with pytest.raises(TransformError) as err:
+        paired_ttest(
+            inputs={"a": A, "b": B.rename(columns={"value": "score"})}, params=DEFAULTS
+        )
+    assert "input 'b'" in str(err.value)

--- a/tests/transform/test_registry.py
+++ b/tests/transform/test_registry.py
@@ -1,0 +1,166 @@
+"""The op registry's refusals, and the invariants every record must hold.
+
+The registry is a closed vocabulary like the metric kinds and the plot
+kinds, so it is held to the same standard: an unknown value is refused at
+load with a suggestion, and the *record* is checked as strictly as the
+document that names it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from causalab.transform.registry import lookup, op_ids
+from causalab.transform.schema import (
+    COLUMN_DTYPES,
+    Bool,
+    Float,
+    Int,
+    Str,
+    Table,
+    Tensor,
+    TransformError,
+    validate_params,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestLookup:
+    def test_every_seed_op_is_registered(self) -> None:
+        assert op_ids() == ("fit_pca@1", "head_stats@1", "paired_ttest@1")
+
+    def test_a_known_op_resolves(self) -> None:
+        op = lookup("fit_pca@1")
+        assert op.name == "fit_pca" and op.version == 1
+        assert op.id == "fit_pca@1"
+
+    def test_unknown_op_suggests(self) -> None:
+        with pytest.raises(TransformError) as err:
+            lookup("fit_pcaa@1")
+        assert "unknown op 'fit_pcaa'" in str(err.value)
+        assert "fit_pca" in str(err.value)  # the suggestion
+
+    def test_unknown_version_of_a_known_op_says_which_exist(self) -> None:
+        """A did-you-mean over the whole id would answer 'fit_pca@1' without
+        saying why; the version list is what the author needs."""
+        with pytest.raises(TransformError) as err:
+            lookup("fit_pca@7")
+        assert "has no version 7" in str(err.value)
+        assert "version 1" in str(err.value)
+
+    def test_an_unversioned_op_is_refused(self) -> None:
+        with pytest.raises(TransformError) as err:
+            lookup("fit_pca")
+        assert "name@version" in str(err.value)
+
+    def test_a_non_numeric_version_is_refused(self) -> None:
+        with pytest.raises(TransformError) as err:
+            lookup("fit_pca@one")
+        assert "not an integer" in str(err.value)
+
+
+class TestRecords:
+    """Invariants that make a record safe to validate a document against."""
+
+    @pytest.mark.parametrize("op_id", op_ids())
+    def test_output_tables_declare_typed_columns(self, op_id: str) -> None:
+        for slot, decl in lookup(op_id).outputs.items():
+            if isinstance(decl, Table):
+                assert decl.columns, f"{op_id}:{slot} declares no columns"
+                for column, dtype in decl.columns.items():
+                    assert dtype in COLUMN_DTYPES, f"{op_id}:{slot}.{column}"
+
+    @pytest.mark.parametrize("op_id", op_ids())
+    def test_slots_have_the_right_file_suffixes(self, op_id: str) -> None:
+        op = lookup(op_id)
+        for decl in (*op.inputs.values(), *op.outputs.values()):
+            expected = ".parquet" if isinstance(decl, Table) else ".safetensors"
+            assert decl.suffix == expected
+
+    @pytest.mark.parametrize("op_id", op_ids())
+    def test_identity_mappings_name_declared_params(self, op_id: str) -> None:
+        op = lookup(op_id)
+        for param in op.identity_from_params.values():
+            assert param in op.params
+
+    @pytest.mark.parametrize("op_id", op_ids())
+    def test_the_callable_takes_inputs_and_params(self, op_id: str) -> None:
+        """The runner calls every op the same way, so the signature is part of
+        the contract, not a per-op convention."""
+        import inspect
+
+        signature = inspect.signature(lookup(op_id).fn)
+        assert set(signature.parameters) == {"inputs", "params"}
+        assert all(
+            parameter.kind is inspect.Parameter.KEYWORD_ONLY
+            for parameter in signature.parameters.values()
+        )
+
+    @pytest.mark.parametrize("op_id", op_ids())
+    def test_a_tensor_output_can_prove_its_provenance(self, op_id: str) -> None:
+        """A tensor a protocol step may load has to be identity-stamped, and
+        the only identity an op can add beyond what it inherits is from its
+        params — so an op whose tensor output is meant to be loaded declares
+        that mapping. `fit_pca@1` is the case; assert the rule holds where it
+        applies rather than asserting it vacuously everywhere."""
+        op = lookup(op_id)
+        writes_tensor = any(isinstance(d, Tensor) for d in op.outputs.values())
+        reads_tensor = any(isinstance(d, Tensor) for d in op.inputs.values())
+        if writes_tensor:
+            assert reads_tensor or op.identity_from_params, (
+                f"{op_id} writes a tensor but can neither inherit nor declare "
+                "an identity for it"
+            )
+
+
+class TestParamValidation:
+    def test_defaults_are_materialized(self) -> None:
+        schema = {"k": Int(default=4), "mode": Str(default="a")}
+        assert validate_params(schema, {}, path="p") == {"k": 4, "mode": "a"}
+
+    def test_a_required_parameter_is_required(self) -> None:
+        with pytest.raises(TransformError) as err:
+            validate_params({"k": Int(min=1)}, {}, path="p")
+        assert "missing required parameter 'k'" in str(err.value)
+
+    def test_unknown_parameter_suggests(self) -> None:
+        with pytest.raises(TransformError) as err:
+            validate_params({"seed": Int(default=0)}, {"seeed": 1}, path="p")
+        assert "unknown parameter 'seeed'" in str(err.value)
+        assert "seed" in str(err.value)
+
+    def test_wrong_type_is_refused(self) -> None:
+        with pytest.raises(TransformError) as err:
+            validate_params({"k": Int(min=1)}, {"k": "8"}, path="p")
+        assert "is an integer" in str(err.value)
+
+    def test_a_boolean_is_not_an_integer(self) -> None:
+        """`bool` subclasses `int` in Python, so `{"k": true}` would silently
+        mean k = 1 without this check."""
+        with pytest.raises(TransformError) as err:
+            validate_params({"k": Int(min=1)}, {"k": True}, path="p")
+        assert "boolean" in str(err.value)
+
+    def test_bounds_are_enforced(self) -> None:
+        with pytest.raises(TransformError):
+            validate_params({"k": Int(min=1)}, {"k": 0}, path="p")
+        with pytest.raises(TransformError):
+            validate_params({"k": Int(default=1, max=3)}, {"k": 4}, path="p")
+
+    def test_choices_are_a_closed_enum(self) -> None:
+        schema = {"mode": Str(default="mean", choices=("mean", "median"))}
+        with pytest.raises(TransformError) as err:
+            validate_params(schema, {"mode": "meen"}, path="p")
+        assert "mean" in str(err.value)  # the suggestion
+
+    def test_an_int_is_accepted_for_a_float_and_normalized(self) -> None:
+        out = validate_params({"x": Float(default=0.0)}, {"x": 2}, path="p")
+        assert out == {"x": 2.0} and isinstance(out["x"], float)
+
+    def test_a_boolean_parameter_takes_a_boolean(self) -> None:
+        assert validate_params({"b": Bool(default=False)}, {"b": True}, path="p") == {
+            "b": True
+        }
+        with pytest.raises(TransformError):
+            validate_params({"b": Bool(default=False)}, {"b": 1}, path="p")

--- a/uv.lock
+++ b/uv.lock
@@ -389,6 +389,8 @@ dependencies = [
     { name = "rich" },
     { name = "safetensors" },
     { name = "scikit-learn" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.16.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "seaborn" },
     { name = "tensorboard" },
     { name = "torch" },
@@ -408,6 +410,9 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scikit-learn-stubs" },
+    { name = "scipy-stubs", version = "1.15.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy-stubs", version = "1.17.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "scipy-stubs", version = "1.18.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -432,6 +437,7 @@ requires-dist = [
     { name = "rich" },
     { name = "safetensors" },
     { name = "scikit-learn" },
+    { name = "scipy", specifier = ">=1.10" },
     { name = "seaborn" },
     { name = "tensorboard" },
     { name = "torch" },
@@ -451,6 +457,7 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff" },
     { name = "scikit-learn-stubs" },
+    { name = "scipy-stubs" },
 ]
 
 [[package]]
@@ -2903,6 +2910,38 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy-typing-compat"
+version = "20251206.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/83/dd90774d6685664cbe5525645a50c4e6c7454207aee552918790e879137f/numpy_typing_compat-20251206.2.3.tar.gz", hash = "sha256:18e00e0f4f2040fe98574890248848c7c6831a975562794da186cf4f3c90b935", size = 5009, upload-time = "2025-12-06T20:02:04.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/6f/dde8e2a79a3b6cbc31bc1037c1a1dbc07c90d52d946851bd7cba67e730a8/numpy_typing_compat-20251206.2.3-py3-none-any.whl", hash = "sha256:bfa2e4c4945413e84552cbd34a6d368c88a06a54a896e77ced760521b08f0f61", size = 6300, upload-time = "2025-12-06T20:01:56.664Z" },
+]
+
+[[package]]
+name = "numpy-typing-compat"
+version = "20260602.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/1b/c3906ddf31b083d73ac93ca2fdee5f4db6cb3bddd18ceff4ebd49b720726/numpy_typing_compat-20260602.2.3.tar.gz", hash = "sha256:f06c8aaca9fa6a9047a7aba5474a7e33870b954544ff276de000dad68c640fbf", size = 4597, upload-time = "2026-06-02T15:52:37.686Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b2/99c1f33f85198d504edb0e1ff5342c3af6ecf2cd5b71d4529fdd05f837c9/numpy_typing_compat-20260602.2.3-py3-none-any.whl", hash = "sha256:2fa13965f068e2ecc7dec9a1883e1381ea506f1d19d435399dde88fc68f0da01", size = 5882, upload-time = "2026-06-02T15:52:32.108Z" },
+]
+
+[[package]]
 name = "nvidia-cublas-cu12"
 version = "12.8.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3053,6 +3092,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload-time = "2026-05-21T21:23:39.636Z" },
+]
+
+[[package]]
+name = "optype"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/3c/9d59b0167458b839273ad0c4fc5f62f787058d8f5aed7f71294963a99471/optype-0.9.3.tar.gz", hash = "sha256:5f09d74127d316053b26971ce441a4df01f3a01943601d3712dd6f34cdfbaf48", size = 96143, upload-time = "2025-03-31T17:00:08.392Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d8/ac50e2982bdc2d3595dc2bfe3c7e5a0574b5e407ad82d70b5f3707009671/optype-0.9.3-py3-none-any.whl", hash = "sha256:2935c033265938d66cc4198b0aca865572e635094e60e6e79522852f029d9e8d", size = 84357, upload-time = "2025-03-31T17:00:06.464Z" },
+]
+
+[[package]]
+name = "optype"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/86/e6f1f6f3487492dfcf3b7a2d4e2534d27af6ac05b364b276706906c34865/optype-0.17.1.tar.gz", hash = "sha256:07bfa32b795dea28fba8605a6288d36370d072f25183fb9c29b5a90f4b6f5638", size = 53572, upload-time = "2026-05-17T22:13:28.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/d4/c6a2b043e33f0dd012486dcebe0593585588d400175d22aad42049c88321/optype-0.17.1-py3-none-any.whl", hash = "sha256:82f2508ca31cb21e53a41648482d890fe1f5c6cb153720551af41161555adaf1", size = 65954, upload-time = "2026-05-17T22:13:27.549Z" },
+]
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy-typing-compat", version = "20251206.2.3", source = { registry = "https://pypi.org/simple" } },
+]
+
+[[package]]
+name = "optype"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/51/51dc9b1009e020f44703933d4d1ee3429c647c026ce7806b37ee2b257998/optype-0.18.0.tar.gz", hash = "sha256:ea10dee61b15ca299ed0d97025d362585c4dfc5481159bb999a1d0d414bbcb04", size = 59967, upload-time = "2026-06-07T22:13:17.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/91/2b064a117cb2593bc3eb04ee994134ca2a6bf2162c92961769947e3258cc/optype-0.18.0-py3-none-any.whl", hash = "sha256:91822ed8516e7a4f225ba53d30f291776c35f31553fb952d7cda98286679c5a6", size = 73410, upload-time = "2026-06-07T22:13:16.324Z" },
+]
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy-typing-compat", version = "20260602.2.3", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -4565,6 +4663,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/c2/e276a237acb09824822b0ada11b028ed4067fdc367a946730979feacb870/scipy-1.16.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b0348d8ddb55be2a844c518cd8cc8deeeb8aeba707cf834db5758fc89b476a2c", size = 38790088, upload-time = "2025-09-11T17:44:53.011Z" },
     { url = "https://files.pythonhosted.org/packages/c6/b4/5c18a766e8353015439f3780f5fc473f36f9762edc1a2e45da3ff5a31b21/scipy-1.16.2-cp314-cp314t-win_amd64.whl", hash = "sha256:26284797e38b8a75e14ea6631d29bda11e76ceaa6ddb6fdebbfe4c4d90faf2f9", size = 39457455, upload-time = "2025-09-11T17:44:58.899Z" },
     { url = "https://files.pythonhosted.org/packages/97/30/2f9a5243008f76dfc5dee9a53dfb939d9b31e16ce4bd4f2e628bfc5d89d2/scipy-1.16.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d2a4472c231328d4de38d5f1f68fdd6d28a615138f842580a8a321b5845cf779", size = 26448374, upload-time = "2025-09-11T17:45:03.45Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.15.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "optype", version = "0.9.3", source = { registry = "https://pypi.org/simple" } },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/35c43bd7d412add4adcd68475702571b2489b50c40b6564f808b2355e452/scipy_stubs-1.15.3.0.tar.gz", hash = "sha256:e8f76c9887461cf9424c1e2ad78ea5dac71dd4cbb383dc85f91adfe8f74d1e17", size = 275699, upload-time = "2025-05-08T16:58:35.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/42/cd8dc81f8060de1f14960885ad5b2d2651f41de8b93d09f3f919d6567a5a/scipy_stubs-1.15.3.0-py3-none-any.whl", hash = "sha256:a251254cf4fd6e7fb87c55c1feee92d32ddbc1f542ecdf6a0159cdb81c2fb62d", size = 459062, upload-time = "2025-05-08T16:58:33.356Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.17.1.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version == '3.11.*'",
+]
+dependencies = [
+    { name = "optype", version = "0.17.1", source = { registry = "https://pypi.org/simple" }, extra = ["numpy"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/30/7a2e621918d1317ab972f797161131f2635648ad5d92baf0695dd009e4f9/scipy_stubs-1.17.1.5.tar.gz", hash = "sha256:284b1dd1dd46107a614971d170030d310cd88b2ac6b483f85285ee0ff87720bd", size = 399933, upload-time = "2026-05-25T21:34:33.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/26/d4bc2ba3427a623f79a6c10c8f427c7a55b56eb8b3eddc369319d97f741b/scipy_stubs-1.17.1.5-py3-none-any.whl", hash = "sha256:58ebf054a86c000c72e8982e121c4ead0d3d9ba7a6c38aa5fa71b07f96a427fd", size = 607388, upload-time = "2026-05-25T21:34:32.073Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.18.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+]
+dependencies = [
+    { name = "optype", version = "0.18.0", source = { registry = "https://pypi.org/simple" }, extra = ["numpy"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/99/02c608a58cf99774c577f22e457427f87c8e608652c5de95178daa003e1f/scipy_stubs-1.18.1.0.tar.gz", hash = "sha256:87bec0df883cd9cd6b7dc4c74a33362cf550e9cad679643a29a886ab2b438ddc", size = 448822, upload-time = "2026-08-22T09:22:52.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/11/263ced30149fbede00614a11f01de792842d3636b5a9e3abfee34e764a0e/scipy_stubs-1.18.1.0-py3-none-any.whl", hash = "sha256:fc1f00da3eb6bf1adf2138774b5e6a91dcf7c77039ff199577dc47929c10793e", size = 653731, upload-time = "2026-08-22T09:22:51.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements #32. Stacked on #20 (`can/protocol-refactor`), which is where `causalab/protocol/` lives — `main` has no protocol layer yet.

## What this adds

A fourth workflow step type whose `op` comes from a closed-but-growable registry of named, versioned, deterministic ops (`causalab/transform/`). The seam is the small one the issue predicted: one record, one parse branch, one canonical branch, one runner branch, plus two deliberately narrow loosenings.

```json
"fit": {
  "type": "transform", "op": "fit_pca@1",
  "inputs": {"acts": {"step": "harvest", "value": "acts.safetensors"}},
  "params": {"k": 8},
  "outputs": {"weight": "basis.safetensors", "spectrum": "spectrum.parquet"}
}
```

Seed ops — `fit_pca@1` (tensor → tensor + table), `head_stats@1` (table → table), `paired_ttest@1` (two tables → one) — chosen to exercise both directions of the IO contract and multi-input slots, not to cover the analyses.

## Three deltas from the issue text, all deliberate

**1. The step type is `transform`, not `compute`.** `compute` reads as a generic verb; the issue's own framing is "transform this table (or this tensor) into that one, deterministically", and the name now says input→output purity. Issue text, #36/#37 and the epic still say `compute`.

**2. "`validate` never imports the op body" is restated.** With a decorator registry that is unachievable — a decorator only populates the registry when its module is imported. The guarantee that actually matters is **`validate`/`digest` never imports torch**, which is what keeps the pure verbs cheap. It is pinned by a subprocess test (`tests/transform/test_load_is_torch_free.py`), because `tests/conftest.py` imports torch at session scope and an in-process `sys.modules` check could never see the difference. A `causalab validate` of a transform workflow runs in <0.1s including process spawn, with `torch` absent.

**3. Rule 10's run-tree half also loosens.** The issue names only `from`. But without letting a *protocol* step load a transform step's tensor, #37's `geodesic_path@1` → inject chain is impossible — so that direction ships here, identity and all. Rule 10's **artifact-ref** half is untouched: only `select` steps emit values tables.

## Design points worth review

- **An op declares the columns of every table it writes.** Loosening `from` broke three load-time checks that all read the producer's sweep axes (rule 7 columns, plot axis coverage, select representatives). Declared columns keep all three honest for a transform producer, so nothing degrades to "checked at run time".
- **A transform table is ranked as written.** It has no sweep coordinates and its op already decided what a row is, so re-aggregating would collapse the rows the document was validated against. Consequently there is **no implicit `value` column** — a select over a transform table names the column it ranks.
- **Tensor outputs are identity-stamped**: fields inherited from the tensor inputs they agree on, fields the op's params define (`identity_from_params`, e.g. a basis's rank `k`), and `produced_by` set to the digest of the step's own canonical entry. Without this `check_artifact_identity` refuses the bundle outright and the transform→protocol direction is dead on arrival. `commit` is deliberately not stamped: an op's **version** is its code identity, and it is already in the digest.

## Two changes outside the step type, because the work needed them

- **A saved read's bundle now records its site.** It stamped only `produced_by`, so an inherited identity could not answer a consuming featurizer's `site` expectation. A harvested activation genuinely is bound to where it was read; this is useful on its own.
- **`tests/test_architecture_layering.py` guards something again.** Its forbidden-import list named `causalab.methods` / `analyses` / `runner`, all deleted by the refactor, so it had been vacuous. It now also enforces that `causalab/transform/` imports no numerics at module level and that `protocol/` keeps no module-level edge to `transform/`.

Plus: `tests/protocol/workflow_digests.json` + its updater, so "a new step type changed no existing document" is a test; and scipy is now declared rather than relied on transitively through scikit-learn.

## Verification

- `uv run pytest -m "not golden"` — **1640 passed**, 8 golden deselected.
- `uv run pre-commit run --all-files` — clean.
- `basedpyright` on the touched files — 0 errors.
- **`weekdays_8b.json`'s digest is byte-identical** to this branch's base (`ccf7893c…`), verified both by regenerating the new pin with no diff and by digesting the same document against a checkout of `can/protocol-refactor`.
- The capstone `tests/neural/pytorch_hooks/test_transform_run.py` runs both directions end to end on tiny-random through the real CLI: `protocol → transform → select/plot`, and `protocol → transform → protocol` with the identity check live.

Not here, per the issue's non-goals: no arbitrary-Python step, no new tensor channel, no loops or conditionals, and no manifold ops — those arrive with #37, which consumes this.