### PR TITLE
Protocol: generation as a position frame — greedy decode addressed by `pos`

### DIFF
--- a/causalab/neural/pytorch_hooks/backend.py
+++ b/causalab/neural/pytorch_hooks/backend.py
@@ -1,9 +1,10 @@
 """The reference backend: intervention protocols on native pytorch hooks.
 
-Implements the spec §8 services for prefill-only documents on the two
-supported architecture families. Capabilities: ``grad`` (the train loop,
-train.py), ``paired_forward`` (cross-input operand flow via the lazy group
-executor), ``full_logits`` (lm_head is an ordinary tap), and
+Implements the spec §8 services on the two supported architecture families.
+Capabilities: ``grad`` (the train loop, train.py), ``paired_forward``
+(cross-input operand flow via the lazy group executor), ``full_logits``
+(lm_head is an ordinary tap), ``generate`` (the greedy decode in
+executor.py, which interventions reach only through the prefill), and
 ``pytorch_fn_local`` (this backend is local). ``writable_attention_probs``
 is deliberately absent — no attention-internal tap yet — so capability
 routing refuses those documents before anything runs.
@@ -36,7 +37,7 @@ __all__ = ["PytorchHooksBackend"]
 class PytorchHooksBackend(Backend):
     name = "pytorch_hooks"
     capabilities = frozenset(
-        {"grad", "paired_forward", "full_logits", "pytorch_fn_local"}
+        {"grad", "paired_forward", "full_logits", "generate", "pytorch_fn_local"}
     )
     is_local = True
 

--- a/causalab/neural/pytorch_hooks/encoding.py
+++ b/causalab/neural/pytorch_hooks/encoding.py
@@ -35,6 +35,22 @@ Position rules implemented against this frame (spec §2.3, §6.1):
 Every resolved index is bounds-checked in the padded frame — a stale or
 impossible position must fail here as a legible error, never reach a
 gather (the #176 failure class the old resolver guarded the same way).
+
+**The continuation frame.** A position carrying ``generated`` resolves
+against a :class:`Continuation` instead: the greedy decode's steps, indexed
+from 0, one per generated token. Step indices are not padded-frame indices
+and the two never mix — a decode *step* is the unit here, and the same
+anchors mean what they say inside it (``{"index": -1}`` is the last real
+generated token, ``{"all": true}`` is every one).
+
+Rows end where they end: the frame stops at a row's first EOS, so widths
+differ and continuation reads are ragged. A window that reaches past a
+row's end **clips** rather than refusing, and a row that generated nothing
+contributes no positions at all. That is deliberate and it is where this
+frame differs from the prompt: how far a row generates is a *result*, so
+refusing on it would make a document fail on data rather than on authoring
+(the prompt frame keeps its strict bounds check, where an out-of-range
+index really is an authoring error).
 """
 
 from __future__ import annotations
@@ -48,7 +64,13 @@ import torch
 from causalab.protocol.errors import ProtocolError
 from causalab.protocol.schema import PositionSpec, concrete_int
 
-__all__ = ["EncodedBatch", "encode", "resolve_position"]
+__all__ = [
+    "Continuation",
+    "EncodedBatch",
+    "encode",
+    "resolve_position",
+    "resolve_steps",
+]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -75,6 +97,41 @@ class EncodedBatch:
         plain-forward convention (RoPE is shift-blind, absolute embeddings
         like GPT-2's ``wpe`` are not, so this must always be passed)."""
         return (self.attention_mask.cumsum(dim=1) - 1).clamp(min=0)
+
+
+@dataclasses.dataclass(frozen=True)
+class Continuation:
+    """One batch's greedy continuation: the frame ``generated`` addresses.
+
+    ``token_ids`` is ``(batch, steps)`` as decoded — every row runs the same
+    number of steps, because a batched decode has no way not to — and
+    ``widths`` says how much of each row is real: the count before its first
+    EOS, or every step for a row that never emitted one. Positions resolve
+    against ``widths``, so a row that stopped early simply contributes fewer
+    of them.
+
+    ``texts`` and ``offsets`` describe the same tokens as characters (per
+    row: the decoded continuation, and each token's ``[start, end)`` span
+    inside it), which is what a ``variable`` anchor searches. They come from
+    incremental detokenization rather than a tokenizer's offset mapping:
+    re-encoding ``prompt + continuation`` is not the same token sequence the
+    decode produced (merges cross the boundary), so the spans have to be
+    built as the tokens arrive.
+    """
+
+    token_ids: torch.Tensor
+    widths: tuple[int, ...]
+    texts: tuple[str, ...] = ()
+    offsets: tuple[tuple[tuple[int, int], ...], ...] = ()
+
+    @property
+    def steps(self) -> int:
+        """How many steps the decode ran — the same for every row."""
+        return int(self.token_ids.shape[1])
+
+    def real_ids(self, row: int) -> list[int]:
+        """``row``'s generated ids up to its first EOS."""
+        return [int(t) for t in self.token_ids[row, : self.widths[row]]]
 
 
 def encode(
@@ -190,6 +247,37 @@ def _variable_token_run(batch: EncodedBatch, row: int, value: str) -> list[int]:
     return run
 
 
+def resolve_steps(
+    spec: PositionSpec, continuation: Continuation, row: int
+) -> list[int]:
+    """Resolve one ``generated`` spec for one row into **decode-step** indices.
+
+    Indices are 0-based into the decode, bounded by the row's real width —
+    see the module docstring on why a window past a row's end clips and a
+    row that generated nothing yields nothing.
+    """
+    width = continuation.widths[row]
+    if width == 0:
+        return []
+    if spec.all is not None:
+        return list(range(width))
+    if spec.index is not None:
+        n = concrete_int(spec.index, "position index")
+        step = width + n if n < 0 else n
+        return [step] if 0 <= step < width else []
+    if spec.span is not None:
+        span = spec.span
+        if not isinstance(span, tuple) or len(span) != 2:
+            raise ProtocolError("P2", f"span is not concrete: {span!r}")
+        a, b = (int(v) for v in span)
+        return list(range(min(a, width), min(b, width)))
+    raise ProtocolError(
+        "P2",
+        f"anchor {spec!r} has no continuation-frame resolution — v1 addresses "
+        "generated tokens by index, span or all",
+    )
+
+
 def resolve_position(
     spec: PositionSpec,
     batch: EncodedBatch,
@@ -197,8 +285,18 @@ def resolve_position(
     *,
     dataset_row: Mapping[str, Any] | None = None,
     field: str | None = None,
+    continuation: Continuation | None = None,
 ) -> list[int]:
-    """Resolve one position spec for one row into padded-frame indices."""
+    """Resolve one position spec for one row into padded-frame indices, or
+    into decode-step indices when the spec selects the continuation frame."""
+    if spec.generated is not None:
+        if continuation is None:
+            raise ProtocolError(
+                "P2",
+                "a generated position needs the decode's continuation — the "
+                "frame it addresses does not exist until the model has run",
+            )
+        return resolve_steps(spec, continuation, row)
     padded = batch.padded_len
     start = batch.content_start(row)
 

--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -28,9 +28,11 @@ from typing import Any, Callable, Iterator, Mapping
 import torch
 
 from causalab.neural.pytorch_hooks.encoding import (
+    Continuation,
     EncodedBatch,
     encode,
     resolve_position,
+    resolve_steps,
     select_field,
 )
 from causalab.neural.pytorch_hooks.featurizers import (
@@ -49,8 +51,15 @@ from causalab.neural.pytorch_hooks.mechanisms import (
 from causalab.neural.pytorch_hooks.sites import ResolvedSite, resolve_site
 from causalab.protocol.bundles import entry_selection, selector_slot
 from causalab.protocol.errors import ProtocolError
+from causalab.protocol.plan import generated_budget
 from causalab.protocol.registry import component_width
-from causalab.protocol.schema import Document, WriteSpec, PositionSpec, ReadSpec
+from causalab.protocol.schema import (
+    Document,
+    PositionSpec,
+    ReadSpec,
+    SiteSpec,
+    WriteSpec,
+)
 
 __all__ = ["PointExecutor", "RaggedValue", "document_seed"]
 
@@ -127,6 +136,7 @@ class PointExecutor:
         self._read_values: dict[str, torch.Tensor | RaggedValue] = {}
         self._groups_run: set[tuple[str, str]] = set()
         self._batches: dict[str, EncodedBatch] = {}
+        self._continuations: dict[tuple[str, str], Continuation] = {}
 
     # ------------------------------------------------------------------ #
     # public surface
@@ -219,6 +229,7 @@ class PointExecutor:
         forwards with updated featurizer parameters)."""
         self._read_values.clear()
         self._groups_run.clear()
+        self._continuations.clear()
 
     # ------------------------------------------------------------------ #
     # group execution
@@ -248,16 +259,43 @@ class PointExecutor:
                         self.read_value(operand)
 
         batch = self._batch(input_role)
-        taps = [
+        all_taps = [
             (rname, read)
             for rname, read in self.doc.reads.items()
             if str(read.model) == model and str(read.input) == input_role
         ]
+        depth = 0
+        taps: list[tuple[str, ReadSpec]] = []
+        gen_taps: list[tuple[str, ReadSpec]] = []
+        for rname, read in all_taps:
+            budget = generated_budget(self.doc, read.pos)
+            if budget is None:
+                taps.append((rname, read))
+            else:
+                gen_taps.append((rname, read))
+                depth = max(depth, budget)
+
         write_hooks = self._build_write_hooks(write_names, input_role, batch)
         capture: dict[tuple[int, str], torch.Tensor] = {}
         capture_sites = {
             (rname): resolve_site(self.bundle, self.doc.sites[str(read.site)])
             for rname, read in taps
+        }
+        # A continuation read at lm_head is served from kept ln_final
+        # activations (d_model, not vocab) and projected at its addressed
+        # steps — the same value, without ever building the whole vocabulary
+        # for every step. Any other site is captured as itself.
+        gen_sites = {
+            rname: resolve_site(self.bundle, self.doc.sites[str(read.site)])
+            for rname, read in gen_taps
+        }
+        gen_capture_sites = {
+            rname: (
+                resolve_site(self.bundle, SiteSpec(component="ln_final"))
+                if site.component == "lm_head"
+                else site
+            )
+            for rname, site in gen_sites.items()
         }
 
         with contextlib.ExitStack() as hooks:
@@ -271,10 +309,11 @@ class PointExecutor:
                         _capturing(site.module, site.kind, capture, key)
                     )
             with torch.enable_grad() if self.grad_enabled else torch.no_grad():
-                self.bundle.model(
+                prefill = self.bundle.model(
                     input_ids=batch.input_ids,
                     attention_mask=batch.attention_mask,
                     position_ids=batch.position_ids(),
+                    use_cache=depth > 0,
                 )
 
         for rname, read in taps:
@@ -283,7 +322,129 @@ class PointExecutor:
             self._read_values[rname] = self._finalize_read(
                 rname, read, site, raw, batch, input_role
             )
+
+        if depth:
+            self._decode(
+                model,
+                input_role,
+                batch=batch,
+                prefill=prefill,
+                depth=depth,
+                gen_taps=gen_taps,
+                gen_sites=gen_sites,
+                gen_capture_sites=gen_capture_sites,
+            )
         self._groups_run.add((model, input_role))
+
+    # ------------------------------------------------------------------ #
+    # generation
+    # ------------------------------------------------------------------ #
+
+    def _decode(
+        self,
+        model: str,
+        input_role: str,
+        *,
+        batch: EncodedBatch,
+        prefill: Any,
+        depth: int,
+        gen_taps: list[tuple[str, ReadSpec]],
+        gen_sites: Mapping[str, ResolvedSite],
+        gen_capture_sites: Mapping[str, ResolvedSite],
+    ) -> None:
+        """Greedy-decode this group's continuation and finalize its reads.
+
+        The prefill above produced the first token; each step here consumes
+        the token before it, so ``depth`` tokens need ``depth`` steps and
+        every generated position has activations — including the last, whose
+        ``lm_head`` value is the distribution *after* it (§2.3).
+
+        **Write hooks are gone by now**: they lived in the prefill's
+        ``ExitStack``, which closed before this runs. That is the whole of
+        "writes are prefill-only" — an intervention reaches the continuation
+        through the first token's logits and through what it left in the KV
+        cache, and nothing re-fires per step.
+        """
+        eos = self.bundle.tokenizer.eos_token_id
+        mask = batch.attention_mask
+        next_pos = batch.position_ids()[:, -1:]
+        nxt = prefill.logits[:, -1:, :].argmax(dim=-1)
+        rows = int(mask.shape[0])
+
+        tokens: list[torch.Tensor] = [nxt]
+        steps: dict[tuple[int, str], list[torch.Tensor]] = {}
+        cache = prefill.past_key_values
+        with contextlib.ExitStack() as hooks:
+            for site in gen_capture_sites.values():
+                key = (id(site.module), site.kind)
+                if key not in steps:
+                    steps[key] = []
+                    hooks.enter_context(
+                        _accumulating(site.module, site.kind, steps[key])
+                    )
+            for _ in range(depth):
+                mask = torch.cat([mask, torch.ones_like(nxt)], dim=1)
+                next_pos = next_pos + 1
+                with torch.enable_grad() if self.grad_enabled else torch.no_grad():
+                    out = self.bundle.model(
+                        input_ids=nxt,
+                        attention_mask=mask,
+                        position_ids=next_pos,
+                        past_key_values=cache,
+                        use_cache=True,
+                    )
+                cache = out.past_key_values
+                nxt = out.logits[:, -1:, :].argmax(dim=-1)
+                tokens.append(nxt)
+
+        # tokens[i] entered step i; the last draw is never consumed, so the
+        # generated sequence is exactly the first `depth` of them
+        generated = torch.cat(tokens[:depth], dim=1)
+        widths: list[int] = []
+        for row in range(rows):
+            width = depth
+            if eos is not None:
+                hit = (generated[row] == eos).nonzero()
+                if hit.numel():
+                    width = int(hit[0].item())
+            widths.append(width)
+        continuation = _continuation_frame(
+            self.bundle.tokenizer, generated, tuple(widths)
+        )
+        self._continuations[(model, input_role)] = continuation
+
+        head = None
+        for rname, read in gen_taps:
+            site = gen_sites[rname]
+            capture_site = gen_capture_sites[rname]
+            stacked = torch.cat(steps[(id(capture_site.module), capture_site.kind)], 1)
+            per_row = [
+                resolve_steps(self._spec(read.pos), continuation, row)
+                for row in range(rows)
+            ]
+            project = None
+            if capture_site is not site:  # ln_final kept, lm_head owed
+                head = (
+                    head
+                    or resolve_site(self.bundle, SiteSpec(component="lm_head")).module
+                )
+                project = head
+            self._read_values[rname] = self._finalize_read(
+                rname,
+                read,
+                site,
+                stacked,
+                batch,
+                input_role,
+                per_row=per_row,
+                project=project,
+            )
+
+    def _spec(self, pos: Any) -> PositionSpec:
+        spec = self.doc.positions[pos] if isinstance(pos, str) else pos
+        if not isinstance(spec, PositionSpec):
+            raise ProtocolError("P2", f"unresolved position {pos!r}")
+        return spec
 
     # ------------------------------------------------------------------ #
     # reads
@@ -357,9 +518,29 @@ class PointExecutor:
         raw: torch.Tensor,
         batch: EncodedBatch,
         input_role: str,
+        *,
+        per_row: list[list[int]] | None = None,
+        project: Callable[[torch.Tensor], torch.Tensor] | None = None,
     ) -> "torch.Tensor | RaggedValue":
-        per_row = self._positions(read.pos, batch, input_role)
+        """One read's value: gather at its positions, then featurize.
+
+        ``per_row`` overrides position resolution — the continuation frame
+        resolves to decode steps, which the caller has already worked out
+        against the decode. ``project`` runs on the gathered slice before
+        anything else, which is how an ``lm_head`` continuation read is
+        served from kept ``ln_final`` activations: the vocabulary projection
+        happens at the addressed positions and nowhere else.
+        """
+        if per_row is None:
+            per_row = self._positions(read.pos, batch, input_role)
         gathered = self._gather(raw, per_row, f"read {rname!r}")
+        if project is not None:
+            if isinstance(gathered, RaggedValue):
+                gathered = RaggedValue(
+                    flat=project(gathered.flat), widths=gathered.widths
+                )
+            else:
+                gathered = project(gathered)
         ragged = isinstance(gathered, RaggedValue)
         value = gathered.flat if isinstance(gathered, RaggedValue) else gathered
         if site.feature_slice is not None:
@@ -572,3 +753,61 @@ def _capturing(
         yield
     finally:
         handle.remove()
+
+
+@contextlib.contextmanager
+def _accumulating(module: Any, kind: str, sink: list[torch.Tensor]) -> Iterator[None]:
+    """Like :func:`_capturing`, but append instead of overwrite.
+
+    A decode calls the same modules once per step, so the single-tensor sink
+    would keep only the last step. Continuation reads need every step, and
+    stacking them on the sequence axis gives a ``(batch, steps, …)`` tensor
+    that gathers exactly like a padded frame does.
+    """
+    if kind == "out":
+
+        def out_hook(_m: Any, _i: Any, out: Any) -> None:
+            sink.append(_hidden_of(out))
+
+        handle = module.register_forward_hook(out_hook)
+    else:
+
+        def pre_hook(_m: Any, args: tuple[Any, ...]) -> None:
+            sink.append(args[0])
+
+        handle = module.register_forward_pre_hook(pre_hook)
+    try:
+        yield
+    finally:
+        handle.remove()
+
+
+def _continuation_frame(
+    tokenizer: Any, generated: torch.Tensor, widths: tuple[int, ...]
+) -> Continuation:
+    """Build the frame the decode produced, characters included.
+
+    Token spans come from incremental detokenization — decode the row's
+    first ``k`` tokens, then ``k + 1``, and the growth is token ``k``'s
+    span. Re-encoding the finished text would not do: a tokenizer is free
+    to merge across a boundary the decode never saw, and the spans have to
+    describe the tokens the model actually emitted.
+    """
+    texts: list[str] = []
+    offsets: list[tuple[tuple[int, int], ...]] = []
+    for row, width in enumerate(widths):
+        ids = [int(t) for t in generated[row, :width]]
+        spans: list[tuple[int, int]] = []
+        text = ""
+        for k in range(width):
+            grown = tokenizer.decode(ids[: k + 1], skip_special_tokens=True)
+            spans.append((len(text), len(grown)))
+            text = grown
+        texts.append(text)
+        offsets.append(tuple(spans))
+    return Continuation(
+        token_ids=generated.detach().cpu(),
+        widths=widths,
+        texts=tuple(texts),
+        offsets=tuple(offsets),
+    )

--- a/causalab/protocol/backend.py
+++ b/causalab/protocol/backend.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Mapping, Sequence
 
 from causalab.protocol.errors import ValidationError
+from causalab.protocol.plan import generated_budget
 from causalab.protocol.resolve import ResolutionEnv
 from causalab.protocol.schema import Document
 
@@ -37,6 +38,7 @@ CAPABILITIES: tuple[str, ...] = (
     "full_logits",
     "writable_attention_probs",
     "pytorch_fn_local",
+    "generate",
 )
 
 #: Metric kinds that need the whole vocabulary materialized (§8).
@@ -82,6 +84,11 @@ def requires(doc: Document) -> frozenset[str]:
     for metric in doc.metrics.values():
         if metric.kind in _FULL_VOCAB_METRICS:
             needed.add("full_logits")
+    for read in doc.reads.values():
+        if generated_budget(doc, read.pos) is not None:
+            # a continuation to address means the backend must decode one
+            needed.add("generate")
+            break
     return frozenset(needed)
 
 

--- a/causalab/protocol/cli.py
+++ b/causalab/protocol/cli.py
@@ -272,6 +272,17 @@ def _explain(loaded: LoadedProtocol) -> None:
     for group in plan.groups:
         taps = ", ".join(t.read for t in group.taps) or "(no reads — operands only)"
         print(f"  {group.model} on {group.input}: {taps}")
+        if group.decode_depth:
+            # print what the decode obliges, so the bill of a document is
+            # readable before it runs — the mechanism stays the backend's
+            print(f"    decode {group.decode_depth} tokens (greedy)")
+            for item in group.materialize:
+                needs = (
+                    "distribution per addressed position"
+                    if item.needs_distribution
+                    else "no distribution — ids and activations only"
+                )
+                print(f"    {item.read} at {item.site}: {needs}")
     print("save")
     for entry in doc.save:
         binding = (

--- a/causalab/protocol/errors.py
+++ b/causalab/protocol/errors.py
@@ -8,9 +8,9 @@ that something raised:
   bad JSON/YAML, a non-object where a table is required, a wrong value type,
   an unknown key (code ``P<n>``).
 * :class:`ValidationError` — the document parses but violates one of the
-  fifteen load-error rules of the spec's validation checklist
+  load-error rules of the spec's validation checklist
   (``docs/intervention_protocol.md`` §5); ``rule`` is the checklist item
-  number (code ``V1`` … ``V15``).
+  number (code ``V1`` … ``V<CHECKLIST_RULES>``).
 
 Both derive from :class:`ProtocolError` so callers that only care about
 "this document was refused" catch one type. ``path`` is the JSON-pointer-ish
@@ -25,11 +25,17 @@ import difflib
 from typing import Iterable, Sequence
 
 __all__ = [
+    "CHECKLIST_RULES",
     "ParseError",
     "ProtocolError",
     "ValidationError",
     "suggest",
 ]
+
+#: How many rules the §5 load-error checklist has. Named so the range guard
+#: below and the spec move together: adding a rule means editing §5 and this
+#: number, and nothing else.
+CHECKLIST_RULES: int = 16
 
 
 class ProtocolError(ValueError):
@@ -74,7 +80,7 @@ class ValidationError(ProtocolError):
     """
 
     def __init__(self, rule: int, message: str, *, path: str | None = None) -> None:
-        if not 1 <= rule <= 15:
+        if not 1 <= rule <= CHECKLIST_RULES:
             raise AssertionError(f"checklist rule out of range: {rule}")
         self.rule = rule
         super().__init__(f"V{rule}", message, path=path)

--- a/causalab/protocol/plan.py
+++ b/causalab/protocol/plan.py
@@ -20,13 +20,15 @@ import hashlib
 import json
 from typing import Any, Mapping
 
-from causalab.protocol.schema import Document, PositionSpec
+from causalab.protocol.schema import Document, PositionSpec, concrete_int
 
 __all__ = [
     "COMPONENT_RANK",
     "ForwardGroup",
+    "Materialization",
     "PointPlan",
     "Tap",
+    "generated_budget",
     "plan_point",
     "closure_digest",
 ]
@@ -61,22 +63,46 @@ class Tap:
 
 
 @dataclasses.dataclass(frozen=True)
+class Materialization:
+    """What one continuation read obliges a backend to build.
+
+    ``needs_distribution`` is the expensive bit: a vocabulary-wide tensor
+    per addressed position. It is false when the read is neither saved nor
+    reduced by a metric that consumes distributions, in which case the
+    backend must not build one (§8). *How* it avoids building one — a
+    narrowed projection, per-step captures, a replay — is the backend's
+    choice; this is the requirement, not the mechanism."""
+
+    read: str
+    site: str
+    needs_distribution: bool
+
+
+@dataclasses.dataclass(frozen=True)
 class ForwardGroup:
     """One forward pass: a model (original or an IM) on one input role.
 
     ``digest`` is the content identity of everything that determines this
     group's activations — equal digests across points mean one shared
-    forward."""
+    forward. ``decode_depth`` is the greedy budget this group must decode
+    for (0 = prefill only), and ``materialize`` states what its
+    continuation reads oblige — both derived, never authored (§6)."""
 
     model: str
     input: str
     taps: tuple[Tap, ...]
     digest: str
+    decode_depth: int = 0
+    materialize: tuple[Materialization, ...] = ()
 
     @property
     def stop_after(self) -> tuple[int, int] | None:
         """The deepest tap's depth — a backend may end the forward there
-        (§4 elision). ``None`` when the group has no taps."""
+        (§4 elision). ``None`` when the group has no taps, and also when it
+        decodes: every decode step needs the head, so there is nothing to
+        elide."""
+        if self.decode_depth:
+            return None
         return max((tap.depth for tap in self.taps), default=None)
 
 
@@ -135,7 +161,63 @@ def _build_group(
             body, sort_keys=True, separators=(",", ":"), default=_encode
         ).encode()
     ).hexdigest()
-    return ForwardGroup(model=model, input=input_role, taps=taps, digest=digest)
+    # The digest stays activation-identity: a decode changes what the group
+    # *produces*, not what its prefill computes — the same reason taps are
+    # not in it. Two points that differ only in decode depth share a prefill.
+    depth = 0
+    materialize: list[Materialization] = []
+    for rname, read in doc.reads.items():
+        if read.model != model or str(read.input) != input_role:
+            continue
+        budget = generated_budget(doc, read.pos)
+        if budget is None:
+            continue
+        depth = max(depth, budget)
+        materialize.append(
+            Materialization(
+                read=rname,
+                site=str(read.site),
+                needs_distribution=_needs_distribution(doc, rname),
+            )
+        )
+    return ForwardGroup(
+        model=model,
+        input=input_role,
+        taps=taps,
+        digest=digest,
+        decode_depth=depth,
+        materialize=tuple(materialize),
+    )
+
+
+def generated_budget(doc: Document, pos: Any) -> int | None:
+    """The decode budget of a position, or ``None`` for the prompt frame.
+
+    Takes the spelling a read carries (a positions-table name or an inline
+    spec) and returns the concrete budget — points are concrete by the time
+    they are planned, so a surviving sweep wrapper is a caller error."""
+    spec = doc.positions.get(pos) if isinstance(pos, str) else pos
+    if not isinstance(spec, PositionSpec) or spec.generated is None:
+        return None
+    return concrete_int(spec.generated["max_new_tokens"], "generated.max_new_tokens")
+
+
+def _needs_distribution(doc: Document, read: str) -> bool:
+    """Whether anything downstream of ``read`` consumes a full distribution.
+
+    Saving the read is the obvious case. So is any metric over it: every v1
+    metric kind reduces logits. When metric kinds declare a domain, an
+    ids-only kind stops counting here — and a text-only probe then obliges
+    no vocabulary projection at all."""
+    if any(entry.value == read for entry in doc.save):
+        return True
+    for metric in doc.metrics.values():
+        if str(metric.of) == read:
+            return True
+        target = metric.fields.get("target")
+        if isinstance(target, str) and target == read:
+            return True
+    return False
 
 
 def closure_digest(

--- a/causalab/protocol/schema.py
+++ b/causalab/protocol/schema.py
@@ -370,7 +370,12 @@ class PositionSpec:
     ``index``/``span``, and are mutually exclusive. ``all`` selects every
     content token of the row and takes no modifiers. Positions are never
     resolved to integers in the document — resolution is a backend
-    service against a ``PositionFrame`` (§2.3, §8)."""
+    service against a ``PositionFrame`` (§2.3, §8).
+
+    ``generated`` is a **frame selector**, not an anchor: it says the
+    anchor resolves inside the row's greedy continuation instead of its
+    prompt, and it carries the decode budget (``{"max_new_tokens": n}``).
+    The anchor vocabulary is unchanged inside that frame."""
 
     index: Leaf | None = None
     span: Leaf | None = None
@@ -379,6 +384,9 @@ class PositionSpec:
     all: Leaf | None = None
     scope: Leaf | None = None
     relative_to: Leaf | None = None
+    #: The continuation frame and its decode budget (§2.3). ``None`` is
+    #: the prompt frame — where every position lived before generation.
+    generated: Mapping[str, Leaf] | None = None
     #: Where ``scope``/``relative_to`` resolve from: ``"variable"`` (the
     #: role's prompt variables) or ``"column"`` (a top-level row column).
     #: Not authored on its own — it comes from the anchor's spelling.
@@ -851,7 +859,16 @@ def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
     obj = _require_mapping(raw, path)
     _check_keys(
         obj,
-        ("index", "span", "variable", "column", "all", "scope", "relative_to"),
+        (
+            "index",
+            "span",
+            "variable",
+            "column",
+            "all",
+            "scope",
+            "relative_to",
+            "generated",
+        ),
         path,
     )
     anchors = [k for k in ("index", "span", "variable", "column", "all") if k in obj]
@@ -910,6 +927,33 @@ def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
         raise ParseError(
             "P2", "scope and relative_to are mutually exclusive", path=path
         )
+    generated = (
+        _parse_generated(obj["generated"], f"{path}.generated")
+        if "generated" in obj
+        else None
+    )
+    if generated is not None:
+        # The continuation frame carries no prompt-frame notions: a `column`
+        # holds a substring of the *input* text, and scope/relative_to anchor
+        # on a prompt variable's token run. Both are meaningless in a frame
+        # the prompt does not contain (§2.3).
+        offenders = [
+            key
+            for key, present in (
+                ("column", column is not None),
+                ("scope", scope is not None),
+                ("relative_to", relative_to is not None),
+            )
+            if present
+        ]
+        if offenders:
+            raise ParseError(
+                "P2",
+                f"{offenders} resolve against the prompt, so they cannot combine "
+                "with 'generated' — anchor inside the continuation with "
+                "index/span/variable/all instead",
+                path=path,
+            )
     if isinstance(span, tuple):
         lo, hi = span
         if scope is None and (lo < 0 or hi <= lo):
@@ -936,7 +980,32 @@ def _parse_position_spec(raw: Any, path: str) -> PositionSpec:
         scope=scope,
         relative_to=relative_to,
         anchor_source=anchor_source,
+        generated=generated,
     )
+
+
+def _parse_generated(value: Any, path: str) -> dict[str, Any]:
+    """§2.3 — the continuation frame selector: ``{"max_new_tokens": n}``.
+
+    A mapping rather than a bare int on purpose: stopping conditions
+    (``stop``, ``min_new_tokens``) join this object later without any
+    ambiguity about what a bare number would have meant.
+    """
+    obj = _require_mapping(value, path)
+    _check_keys(obj, ("max_new_tokens",), path)
+    if "max_new_tokens" not in obj:
+        raise ParseError(
+            "P2", "generated needs 'max_new_tokens' — the decode budget", path=path
+        )
+    budget = _wrapped(obj["max_new_tokens"], _scalar_int, f"{path}.max_new_tokens")
+    if isinstance(budget, int) and budget < 1:
+        raise ParseError(
+            "P2",
+            f"max_new_tokens is {budget} — a continuation frame needs at least "
+            "one generated token",
+            path=f"{path}.max_new_tokens",
+        )
+    return {"max_new_tokens": budget}
 
 
 def _parse_span(value: Any, path: str) -> tuple[int, int]:

--- a/causalab/protocol/validate.py
+++ b/causalab/protocol/validate.py
@@ -1,6 +1,6 @@
 """The load-error checklist (spec §5) over one concrete document.
 
-:func:`validate_document` runs rules 3–13 on a parsed, *concrete*
+:func:`validate_document` runs rules 3–13 and 16 on a parsed, *concrete*
 :class:`~causalab.protocol.schema.Document` — a point protocol, or an
 un-swept document. The other rules live where their information lives:
 
@@ -59,7 +59,7 @@ _TRAINABLE_KINDS = frozenset({"subspace", "gate", "sae"})
 
 
 def validate_document(doc: Document, *, backend_is_local: bool | None = None) -> None:
-    """Run checklist rules 3–13 (and 13 only when ``backend_is_local`` is
+    """Run checklist rules 3–13 and 16 (13 only when ``backend_is_local`` is
     given). Raises :class:`ValidationError` on the first violation."""
     names = _check_namespace(doc)  # rule 3
     _check_references(doc, names)  # rule 4 (+ the rule-5 read bindings)
@@ -69,6 +69,7 @@ def validate_document(doc: Document, *, backend_is_local: bool | None = None) ->
     _check_save(doc)  # rule 10
     _check_sinks(doc)  # rule 11
     _check_trainability(doc)  # rule 12
+    _check_generation(doc)  # rule 16
     if backend_is_local is not None:
         _check_pytorch_fn(doc, backend_is_local)  # rule 13
 
@@ -882,6 +883,63 @@ def _check_trainability(doc: Document) -> None:
                     "train section (§2.6)",
                     path=f"params.{pname}",
                 )
+
+
+# --------------------------------------------------------------------------- #
+# rule 16 — generation is read-only and prefill-only
+# --------------------------------------------------------------------------- #
+
+
+def _generated_positions(doc: Document) -> dict[str, PositionSpec]:
+    """Every declared position that selects the continuation frame, by the
+    name (or ``"<section>.<entry>"`` path) it was authored under."""
+    found: dict[str, PositionSpec] = {}
+    for name, entry in doc.positions.items():
+        if isinstance(entry, PositionSpec) and entry.generated is not None:
+            found[name] = entry
+    for section in ("reads", "writes"):
+        for name, spec in getattr(doc, section).items():
+            pos = spec.pos
+            if isinstance(pos, PositionSpec) and pos.generated is not None:
+                found[f"{section}.{name}"] = pos
+    return found
+
+
+def _check_generation(doc: Document) -> None:
+    """§5.16 — a decode is something a read *addresses*, never something a
+    write or a fit runs inside.
+
+    Two refusals, one rule. **Writes stay prefill-only**: the continuation
+    only exists because the prefill already ran, and a write there would be
+    a decode-step intervention — out of scope for v1 by §7's scope clause,
+    and the reason no other rule has to reason about two frames (rules 8/9
+    compare writes only, so both sides are always prompt-frame). **Training
+    cannot see a decode**: `train` differentiates through the graph a
+    forward builds, and a greedy continuation is an argmax chain, not a
+    differentiable path.
+    """
+    for ename, write in doc.writes.items():
+        pos = write.pos
+        spec = doc.positions.get(pos) if isinstance(pos, str) else pos
+        if isinstance(spec, PositionSpec) and spec.generated is not None:
+            where = f" (position {pos!r})" if isinstance(pos, str) else ""
+            raise ValidationError(
+                16,
+                f"write {ename!r} addresses the continuation frame{where} — writes "
+                "are prefill-only (§2.3): reads may address generated tokens, "
+                "writes may not",
+                path=f"writes.{ename}",
+            )
+    if doc.train is not None:
+        generated = _generated_positions(doc)
+        if generated:
+            raise ValidationError(
+                16,
+                f"train and the continuation frame do not combine: {sorted(generated)} "
+                "select generated tokens, and a greedy decode is an argmax chain "
+                "with no gradient path (§2.11)",
+                path="train",
+            )
 
 
 # --------------------------------------------------------------------------- #

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -91,10 +91,42 @@ Named entries; a read/write `pos` is a name here, or an inline spec.
 | `{"all": true}` | every content token of the row — ragged across rows |
 | + `"scope": {"variable": "x"}` / `{"column": "c"}` | interpret the index/span inside the anchor's span |
 | + `"relative_to": {"variable": "x"}` / `{"column": "c"}` | offset from the anchor's span |
+| + `"generated": {"max_new_tokens": n}` | resolve the anchor inside the row's greedy continuation instead of its prompt |
 
 - Positions are **never resolved to integers in the document**. Resolution is
   a backend service against a `PositionFrame` (pad side, packing, sequence
   shard map) — sec. 8.
+
+**The continuation frame (`generated`).** A decode produces a second frame, so
+addressing it needs no new vocabulary: `generated` is a **frame selector**, not
+an anchor, and exactly one anchor accompanies it. `{"generated": {…}, "index":
+-1}` is the last generated token, `{…, "all": true}` every generated token,
+`{…, "span": [0, 3]}` the first three, `{…, "variable": "x"}` the tokens where
+the model said the row's value for `x`.
+
+- The decode is **greedy** — argmax at every step. Sampling is not expressible:
+  a document is a value (sec. 7), and a sampled continuation is not a function
+  of it.
+- `max_new_tokens` is required, ≥ 1, and sweepable. It is a mapping rather than a
+  bare int so stopping conditions can join it later. Two positions on one
+  (model, input) with different budgets are legal: the run decodes the deepest,
+  and each read windows its own.
+- The frame **ends at the row's first EOS**, so widths differ and continuation
+  reads are ragged. A window reaching past a row's end clips; a row that
+  generated nothing contributes no positions. Unlike the prompt frame — where an
+  out-of-range index is an authoring error and refused — how far a row generates
+  is a *result*, and refusing on it would make a document fail on data.
+- **Reads only.** A write may not carry `generated` (rule 16): the continuation
+  exists because the prefill already ran, and an intervention reaches it through
+  the first token's logits and through what the prefill left in the KV cache —
+  nothing re-fires per decode step. `train` and `generated` do not combine
+  either: a greedy decode is an argmax chain with no gradient path.
+- **`lm_head` at generated position `j` is the distribution *after* token `j`.**
+  The one that *produced* token `j` sits at `j − 1`, and for `j = 0` that is the
+  last prompt position — an ordinary `{"index": -1}`. Stated here so no document
+  has to rediscover it.
+- `column`, `scope` and `relative_to` are refused with `generated`: they resolve
+  against the prompt, which the continuation does not contain.
 - `variable` vs `column`. A **prompt variable** is looked up per role: the
   `<field>_variables` sibling of the role's text column first, then a
   same-named column. A **column** is looked up only as a top-level column of
@@ -407,7 +439,14 @@ everything that leaves the run. Three saveable kinds, two entry shapes:
   the backend stages them (fused multi-pass, saved constants, or microbatch
   wiring — its call).
 - **Elision**: a model whose reads are all satisfied may stop its forward
-  after the deepest tap; a full-depth pass is never owed.
+  after the deepest tap; a full-depth pass is never owed. A group that
+  decodes is the exception — every step needs the head, so nothing is
+  elided.
+- **Decoding groups.** A group whose reads address the continuation
+  (sec. 2.3) runs one prefill plus `max_new_tokens` greedy steps: `n` tokens
+  need `n` steps, because the last generated token must be consumed by a
+  forward for its own activations to exist. Writes apply in the prefill only.
+  The depth is derived from the group's positions, never authored.
 - **Determinism**: `gaussian` draws from its declared seed; sweep expansion
   and canonicalization are pure functions of the document.
 
@@ -441,6 +480,8 @@ A conforming loader rejects the document unless all of these hold:
     be capped without an explicit override flag).
 15. Artifact-valued fields resolve (missing artifact = error, never a
     default).
+16. Generation is read-only and prefill-only: no write's `pos` carries
+    `generated`, and `train` does not co-occur with a `generated` position.
 
 ## 6. Derived — never authored
 
@@ -450,6 +491,7 @@ A conforming loader rejects the document unless all of these hold:
 | param slots | per featurizer kind (sec. 2.5) |
 | `requires` | capability set, sec. 8 |
 | `num_forwards`, fusion, staging | from the model graph; a compile property |
+| decode depth, and what a continuation read obliges | from the group's `generated` positions, `save` and the metrics over it (sec. 8) |
 | dataset content digest | resolved + stamped at load |
 | point protocols + digests | deterministic sweep expansion |
 | `ArtifactIdentity` | stamped into artifacts, sec. 8 |
@@ -469,8 +511,9 @@ A conforming loader rejects the document unless all of these hold:
 - **Format**: strict JSON (unknown keys = error). YAML is accepted at the
   authoring surface; the object model is normative. JSON has no comments —
   use `description`.
-- **v1 scope**: prefill-only. No generation, no decode-step writes, one neural
-  model per document.
+- **v1 scope**: prefill-only *interventions*. Greedy decode is addressable as a
+  position frame (sec. 2.3) and readable; there are no decode-step writes, no
+  sampling, and one neural model per document.
 - **Canonical-stamp principle**: the authored file may be minimal; the
   canonical form materializes *everything* — every default (constant LR,
   optimizer betas, dtypes), every resolved reference (dataset digests,
@@ -496,6 +539,7 @@ A backend implements these services:
 | mechanisms | the closed `do` set, class order per address; refuse `pytorch_fn` if non-local |
 | featurizers | kinds table with declared dtypes; error-term contract |
 | metrics | lower kinds to native ops; derive minimal logit materialization (`logits_to_keep`, vocab-parallel CE) from `save` + metric needs |
+| generation | greedy-decode a group to its derived depth; materialize a distribution only where `save` or a metric needs one (see below); writes stay in the prefill |
 | training | own the `train` loop (optimizer, accumulation, anneal, early stop, checkpoints) — the document never changes across backends |
 | RNG | realize `gaussian` per declared seed + axis semantics, bit-stable across parallelism layouts |
 | stamping | write canonical point protocols + digests; `ArtifactIdentity` into every featurizer bundle's safetensors header |
@@ -523,6 +567,7 @@ refusal messages generate from the missing capability.
 | `grad` | `train` present |
 | `paired_forward` | a write's operand read has a different `input` than the write's model |
 | `full_logits` | a full `lm_head` read is saved, or a metric needs the full vocab (`top_k`, `class_probs`) |
+| `generate` | any position carries `generated` (sec. 2.3) |
 | `writable_attention_probs` | a write targets `attention_probs` |
 | `pytorch_fn_local` | any `pytorch_fn` |
 
@@ -535,6 +580,22 @@ Reference matrix:
 | arbitrary writes | ✓ | ✓ | additive steering only |
 | `full_logits` | ✓ | ✗ vocab-parallel only | ✓ |
 | `pytorch_fn_local` | ✓ | ✗ | ✗ |
+
+**Materialization (generation).** A continuation read's cost is not the decode,
+it is the vocabulary: at batch 32 and 16 steps, every step's distribution over a
+128k vocabulary is ~260 MB in fp32, one step is ~16 MB, a site's activations
+~8 MB, the token ids ~2 KB. The planner therefore derives, per group, the decode
+depth and — per continuation read — whether anything downstream consumes a
+distribution (it is saved, or a metric over it reduces one). A backend **must
+not** build one where the answer is no.
+
+*How* it complies is its own business: keeping only the addressed steps,
+projecting a narrower slice (`logits_to_keep` takes an index tensor), replaying
+the sequence teacher-forced, or a vocab-parallel reduction. The reference
+backend keeps `ln_final` activations across steps and projects through the head
+only at the addressed positions, which needs no second pass — an implementation
+note, not a requirement. `explain` prints the obligation so the bill is legible
+before a run.
 
 **Execution scale.** Documents and workflows are scheduler-agnostic — they
 never name devices, hosts, or job systems. The division of labor:

--- a/tests/neural/pytorch_hooks/test_generate_frame.py
+++ b/tests/neural/pytorch_hooks/test_generate_frame.py
@@ -1,0 +1,246 @@
+"""Greedy decode through the protocol, against HF's own generate (§2.3, §4).
+
+``model.generate(do_sample=False)`` is the oracle here, never the
+implementation: it reads a checkpoint's ``generation_config``, whose
+defaults would leak into a run that has to be a pure function of the
+document. So the executor decodes explicitly and these tests pin that the
+two agree token-for-token.
+
+The batch is deliberately two rows of unequal length: left padding is what
+makes ``logits[:, -1]`` the whole batch's next token, and a same-length
+batch would not notice if that broke.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+
+from causalab.neural.pytorch_hooks.encoding import encode
+from causalab.neural.pytorch_hooks.executor import PointExecutor, RaggedValue
+from causalab.protocol.schema import SECTION_ORDER, parse_document
+
+from tests.neural.pytorch_hooks.conftest import TINY_GPT2, TINY_LLAMA
+
+pytestmark = pytest.mark.smoke
+
+PROMPTS = ["the quick brown fox jumps", "a slow green turtle sleeps deeply today"]
+BUDGET = 6
+
+
+def _rows() -> list[dict[str, Any]]:
+    return [{"input": text} for text in PROMPTS]
+
+
+def _doc(
+    key: str,
+    *,
+    anchor: dict[str, Any] | None = None,
+    site: str = "lm_head",
+    steer: float | None = None,
+) -> dict[str, Any]:
+    """A document reading the continuation, optionally under a steer."""
+    raw: dict[str, Any] = {
+        "version": "1",
+        "model": {"key": key, "revision": "main"},
+        "data": {"base": {"dataset": "probe", "field": "input"}},
+        "positions": {
+            "cont": {"generated": {"max_new_tokens": BUDGET}, **(anchor or {"all": True})}
+        },
+        "sites": {
+            "lm_head": {"component": "lm_head"},
+            "mid": {"component": "block_output", "layer": 1},
+        },
+    }
+    model = "original"
+    if steer is not None:
+        # a literal-scalar operand (§2.8) — enough to move the continuation
+        # without dragging a tensor fixture into the test
+        raw["writes"] = {
+            "steer": {
+                "site": "mid",
+                "pos": -1,
+                "do": {"add_scaled": {"op": steer, "alpha": 1.0}},
+            }
+        }
+        raw["intervened_models"] = {"steered": {"input": "base", "writes": ["steer"]}}
+        model = "steered"
+    raw["reads"] = {
+        "cont": {"site": site, "pos": "cont", "model": model, "input": "base"}
+    }
+    raw["save"] = [
+        {
+            "value": "cont",
+            "model": model,
+            "input": "base",
+            "file_path": "cont.safetensors",
+        }
+    ]
+    return {key_: raw[key_] for key_ in SECTION_ORDER if key_ in raw}
+
+
+def _executor(bundle, raw: dict[str, Any]):
+    def load_tensors(path: str) -> Any:
+        raise AssertionError(f"no document here loads tensors ({path})")
+
+    return PointExecutor(
+        parse_document(raw),
+        bundle,
+        role_rows={"base": _rows()},
+        role_fields={"base": "input"},
+        load_tensors=load_tensors,
+    )
+
+
+def _hf_greedy(bundle, budget: int = BUDGET) -> torch.Tensor:
+    batch = encode(bundle.tokenizer, PROMPTS)
+    with torch.no_grad():
+        out = bundle.model.generate(
+            input_ids=batch.input_ids,
+            attention_mask=batch.attention_mask,
+            max_new_tokens=budget,
+            do_sample=False,
+            use_cache=True,
+        )
+    return out[:, batch.input_ids.shape[1] :]
+
+
+def _decoded_ids(executor: PointExecutor) -> torch.Tensor:
+    executor.run_all()
+    (continuation,) = executor._continuations.values()
+    return continuation.token_ids
+
+
+@pytest.mark.parametrize("key", [TINY_LLAMA, TINY_GPT2])
+def test_continuation_matches_hf_greedy(key):
+    from causalab.neural.pytorch_hooks.loading import load_model
+
+    bundle = load_model(key)
+    ours = _decoded_ids(_executor(bundle, _doc(key)))
+    assert torch.equal(ours, _hf_greedy(bundle))
+
+
+def test_lm_head_read_reproduces_the_tokens_it_generated(llama_bundle):
+    """The read is the distribution *after* each generated token, so its
+    argmax is the next token — for steps 0..n-2 that is the token the decode
+    actually emitted next. A read that disagreed here would mean the kept
+    activations and the decode had drifted apart."""
+    executor = _executor(llama_bundle, _doc(TINY_LLAMA))
+    value = executor.read_value("cont")
+    assert isinstance(value, torch.Tensor)  # equal widths, no EOS in tiny-random
+    predicted = value.argmax(dim=-1)
+    (continuation,) = executor._continuations.values()
+    assert torch.equal(predicted[:, :-1], continuation.token_ids[:, 1:])
+
+
+def test_last_step_is_one_position(llama_bundle):
+    executor = _executor(llama_bundle, _doc(TINY_LLAMA, anchor={"index": -1}))
+    value = executor.read_value("cont")
+    assert isinstance(value, torch.Tensor)
+    assert value.shape[:2] == (len(PROMPTS), 1)
+
+
+def test_any_site_is_readable_at_generated_positions(llama_bundle):
+    """Not just the head: a continuation read at a residual-stream site
+    harvests activations over the generated tokens, which is what
+    "read where the model said it" will need."""
+    executor = _executor(llama_bundle, _doc(TINY_LLAMA, site="mid"))
+    value = executor.read_value("cont")
+    assert isinstance(value, torch.Tensor)
+    width = llama_bundle.model.config.hidden_size
+    assert value.shape == (len(PROMPTS), BUDGET, width)
+
+
+def test_a_steer_in_the_prefill_moves_the_continuation(llama_bundle):
+    """Writes are prefill-only, and this is what that buys: the intervention
+    reaches the continuation through the first token's logits and the KV
+    cache it left behind — no hook fires during a decode step."""
+    plain = _decoded_ids(_executor(llama_bundle, _doc(TINY_LLAMA)))
+    steered = _decoded_ids(_executor(llama_bundle, _doc(TINY_LLAMA, steer=5.0)))
+    assert not torch.equal(plain, steered)
+
+
+def test_a_decode_moves_prompt_frame_reads_only_by_float_noise(llama_bundle):
+    """Adding a continuation read leaves prompt-frame values alone to within
+    float noise — not bit-identically.
+
+    Measured: ~4e-9 on tiny-random fp32. The cause is `use_cache=True`, which
+    a decoding group needs and which takes a slightly different kernel path
+    through the prefill. It is why the flag is set from the decode depth
+    rather than always: a document that does not decode keeps the exact
+    numbers its goldens were captured with."""
+    without: dict[str, Any] = {
+        "version": "1",
+        "model": {"key": TINY_LLAMA, "revision": "main"},
+        "data": {"base": {"dataset": "probe", "field": "input"}},
+        "sites": {"mid": {"component": "block_output", "layer": 1}},
+        "reads": {
+            "tail": {"site": "mid", "pos": -1, "model": "original", "input": "base"}
+        },
+        "save": [
+            {
+                "value": "tail",
+                "model": "original",
+                "input": "base",
+                "file_path": "tail.safetensors",
+            }
+        ],
+    }
+    plain = _executor(llama_bundle, without).read_value("tail")
+
+    withgen = {
+        **without,
+        "positions": {"cont": {"generated": {"max_new_tokens": BUDGET}, "all": True}},
+        "reads": {
+            **without["reads"],
+            "cont": {
+                "site": "mid",
+                "pos": "cont",
+                "model": "original",
+                "input": "base",
+            },
+        },
+    }
+    withgen["save"] = [
+        *without["save"],
+        {
+            "value": "cont",
+            "model": "original",
+            "input": "base",
+            "file_path": "cont.safetensors",
+        },
+    ]
+    ordered = {k: withgen[k] for k in SECTION_ORDER if k in withgen}
+    also = _executor(llama_bundle, ordered).read_value("tail")
+    assert isinstance(plain, torch.Tensor) and isinstance(also, torch.Tensor)
+    assert torch.allclose(plain, also, atol=1e-7, rtol=0)
+    assert not torch.equal(plain, also), (
+        "if these became bit-identical, use_cache stopped changing the kernel "
+        "path and this test's premise (and its tolerance) should be revisited"
+    )
+
+
+def test_an_early_eos_shortens_that_row(llama_bundle):
+    """Rows end where they end: forcing row 0's first draw to be EOS leaves
+    it with no real generated tokens, and the read goes ragged rather than
+    failing."""
+    executor = _executor(llama_bundle, _doc(TINY_LLAMA))
+    eos = llama_bundle.tokenizer.eos_token_id
+    original = llama_bundle.model.forward
+
+    def eos_first(*args, **kwargs):
+        out = original(*args, **kwargs)
+        if kwargs.get("past_key_values") is None:  # the prefill
+            out.logits[0, -1, :] = -1e4
+            out.logits[0, -1, eos] = 1e4
+        return out
+
+    llama_bundle.model.forward = eos_first  # type: ignore[method-assign]
+    try:
+        value = executor.read_value("cont")
+    finally:
+        llama_bundle.model.forward = original  # type: ignore[method-assign]
+    assert isinstance(value, RaggedValue)
+    assert value.widths == (0, BUDGET)

--- a/tests/neural/pytorch_hooks/test_generate_frame.py
+++ b/tests/neural/pytorch_hooks/test_generate_frame.py
@@ -47,7 +47,10 @@ def _doc(
         "model": {"key": key, "revision": "main"},
         "data": {"base": {"dataset": "probe", "field": "input"}},
         "positions": {
-            "cont": {"generated": {"max_new_tokens": BUDGET}, **(anchor or {"all": True})}
+            "cont": {
+                "generated": {"max_new_tokens": BUDGET},
+                **(anchor or {"all": True}),
+            }
         },
         "sites": {
             "lm_head": {"component": "lm_head"},

--- a/tests/neural/pytorch_hooks/test_positions_frame.py
+++ b/tests/neural/pytorch_hooks/test_positions_frame.py
@@ -6,7 +6,14 @@ from __future__ import annotations
 
 import pytest
 
-from causalab.neural.pytorch_hooks.encoding import encode, resolve_position
+import torch
+
+from causalab.neural.pytorch_hooks.encoding import (
+    Continuation,
+    encode,
+    resolve_position,
+    resolve_steps,
+)
 from causalab.protocol.errors import ProtocolError
 from causalab.protocol.schema import PositionSpec
 
@@ -156,3 +163,70 @@ def test_out_of_bounds_refuses(tokenizer):
     with pytest.raises(ProtocolError) as err:
         resolve_position(PositionSpec(index=500), batch, 0)
     assert "out of bounds" in str(err.value)
+
+
+# the continuation frame (§2.3) ---------------------------------------------- #
+
+
+def _continuation(widths: tuple[int, ...], steps: int = 4) -> Continuation:
+    """A decode of ``steps`` steps whose rows stopped at ``widths``."""
+    ids = torch.arange(len(widths) * steps).reshape(len(widths), steps)
+    return Continuation(token_ids=ids, widths=widths)
+
+
+def test_all_steps_is_the_rows_real_width():
+    cont = _continuation((4, 2))
+    spec = PositionSpec(generated={"max_new_tokens": 4}, all=True)
+    assert resolve_steps(spec, cont, 0) == [0, 1, 2, 3]
+    assert resolve_steps(spec, cont, 1) == [0, 1]
+
+
+def test_last_step_is_the_last_real_token():
+    """``index: -1`` on a row that stopped early means *its* last generated
+    token, not the batch's last step — that is what "the final generated
+    token" has to mean when rows end at different places."""
+    cont = _continuation((4, 2))
+    spec = PositionSpec(generated={"max_new_tokens": 4}, index=-1)
+    assert resolve_steps(spec, cont, 0) == [3]
+    assert resolve_steps(spec, cont, 1) == [1]
+
+
+def test_a_row_that_generated_nothing_contributes_no_positions():
+    """An immediate EOS is a result, not an authoring error: the row drops
+    out of the read instead of failing the run."""
+    cont = _continuation((3, 0))
+    for spec in (
+        PositionSpec(generated={"max_new_tokens": 3}, all=True),
+        PositionSpec(generated={"max_new_tokens": 3}, index=-1),
+        PositionSpec(generated={"max_new_tokens": 3}, index=0),
+    ):
+        assert resolve_steps(spec, cont, 1) == []
+
+
+def test_a_window_past_a_rows_end_clips():
+    cont = _continuation((4, 2))
+    spec = PositionSpec(generated={"max_new_tokens": 4}, span=(0, 3))
+    assert resolve_steps(spec, cont, 0) == [0, 1, 2]
+    assert resolve_steps(spec, cont, 1) == [0, 1]
+
+
+def test_an_index_past_a_rows_end_drops_it():
+    cont = _continuation((4, 2))
+    spec = PositionSpec(generated={"max_new_tokens": 4}, index=3)
+    assert resolve_steps(spec, cont, 0) == [3]
+    assert resolve_steps(spec, cont, 1) == []
+
+
+def test_real_ids_stop_at_the_rows_width():
+    cont = _continuation((4, 2))
+    assert cont.real_ids(1) == [4, 5]
+    assert cont.steps == 4
+
+
+def test_a_generated_position_without_a_decode_refuses():
+    """The frame does not exist until the model has run, so asking for it
+    outside a decode is a backend misuse, not a document error."""
+    batch = None
+    spec = PositionSpec(generated={"max_new_tokens": 4}, index=-1)
+    with pytest.raises(ProtocolError, match="does not exist until"):
+        resolve_position(spec, batch, 0)  # type: ignore[arg-type]

--- a/tests/neural/pytorch_hooks/test_run_corpus.py
+++ b/tests/neural/pytorch_hooks/test_run_corpus.py
@@ -18,6 +18,7 @@ would hand seed 0's rotation to every other seed and no unit test on
 
 from __future__ import annotations
 
+import json
 import shutil
 from pathlib import Path
 
@@ -256,3 +257,15 @@ def test_run_output_is_stamped(roots, tmp_path):
     assert meta["model_key"] == TINY_LLAMA
     assert meta["backend"] == "pytorch_hooks"
     assert len(meta["produced_by"]) == 64
+
+
+def test_11_probe_generate_runs_and_scores(roots, tmp_path):
+    """The exploration probe end to end: decode under a steer, score the last
+    generated token with an ordinary metric."""
+    code = _run("11_probe_generate_im.json", roots, tmp_path, "sites.target.layer=1")
+    assert code == 0
+    probe = pd.read_parquet(tmp_path / "probe.parquet")
+    assert len(probe) == 4  # one row per example
+    for value in probe["value"]:
+        top = json.loads(value)
+        assert len(top["tokens"]) == 1 and len(top["probs"]) == 1

--- a/tests/protocol/corpus_digests.json
+++ b/tests/protocol/corpus_digests.json
@@ -129,5 +129,11 @@
     "points": [
       "f7b135f41b911aec5337ca1b0ea9522c0781c9c35277d9fac42a3ca333e5565e"
     ]
+  },
+  "11_probe_generate_im.json": {
+    "document": "22bbf1cad970b283c308a8208caba1212558d76cb8091c4858039653ad483d12",
+    "points": [
+      "22bbf1cad970b283c308a8208caba1212558d76cb8091c4858039653ad483d12"
+    ]
   }
 }

--- a/tests/protocol/test_backend_routing.py
+++ b/tests/protocol/test_backend_routing.py
@@ -14,7 +14,7 @@ from causalab.protocol.backend import (
 from causalab.protocol.errors import ValidationError
 from causalab.protocol.schema import parse_document
 
-from tests.protocol._docs import base_doc
+from tests.protocol._docs import base_doc, in_order
 
 pytestmark = pytest.mark.unit
 
@@ -89,3 +89,18 @@ def test_refusal_names_missing_capabilities():
         choose_backend(doc, [weak])
     message = str(err.value)
     assert "paired_forward" in message and "serving" in message
+
+
+def test_a_backend_without_generate_refuses_with_the_capability_named():
+    """Routing is how a decode-less backend declines a continuation document,
+    and the refusal names what it lacks rather than failing mid-run."""
+    raw = base_doc()
+    raw["positions"] = {"tail": {"generated": {"max_new_tokens": 8}, "index": -1}}
+    raw["reads"]["logits"]["pos"] = "tail"
+    doc = parse_document(in_order(raw))
+    prefill_only = _Stub("prefill_only", frozenset({"paired_forward", "full_logits"}))
+    with pytest.raises(ValidationError) as err:
+        choose_backend(doc, [prefill_only])
+    assert "generate" in str(err.value)
+    decoder = _Stub("decoder", prefill_only.capabilities | {"generate"})
+    assert choose_backend(doc, [prefill_only, decoder]) is decoder

--- a/tests/protocol/test_canonical.py
+++ b/tests/protocol/test_canonical.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+
 import pytest
 
 from causalab.protocol.canonical import canonical_bytes, canonicalize, digest
@@ -165,3 +167,29 @@ def test_column_position_canonicalizes_verbatim(env):
     raw["reads"]["v_cf"]["pos"] = "subj"
     canonical = canonicalize(in_order(raw), env)
     assert canonical["positions"]["subj"] == {"column": "entity"}
+
+
+def test_generated_frame_canonicalizes_verbatim(env):
+    """The frame selector is authored data with no defaults to materialize,
+    so it carries through untouched — and a different budget is a different
+    document, because the position enters the read's closure."""
+    raw = base_doc()
+    raw["positions"] = {"tail": {"generated": {"max_new_tokens": 8}, "index": -1}}
+    raw["reads"]["v_cf"]["pos"] = "tail"
+    canonical = canonicalize(in_order(raw), env)
+    assert canonical["positions"]["tail"] == {
+        "generated": {"max_new_tokens": 8},
+        "index": -1,
+    }
+    # deep-copied: canonicalize passes this section through by reference, so
+    # mutating a shared nested dict would rewrite the form just measured
+    longer = copy.deepcopy(in_order(raw))
+    longer["positions"]["tail"]["generated"]["max_new_tokens"] = 16
+    assert digest(canonical) != digest(canonicalize(longer, env))
+
+
+def test_prompt_frame_documents_digest_unchanged(env):
+    """The new field is absent, not defaulted, on every position that does
+    not ask for a continuation — the reason no existing digest moves."""
+    canonical = canonicalize(base_doc(), env)
+    assert "generated" not in canonical["reads"]["v_cf"]["pos"]

--- a/tests/protocol/test_cli.py
+++ b/tests/protocol/test_cli.py
@@ -270,3 +270,13 @@ def test_validate_data_flags_a_missing_relative_to_column(env):
     with pytest.raises(Exception) as err:
         check_data_columns(load(raw, env), env)
     assert "not_a_column" in str(err.value)
+
+
+def test_explain_reports_the_decode_and_what_it_obliges(capsys, artifacts_root):
+    """A generate document's cost is legible before it runs: how far it
+    decodes, and which reads oblige a vocabulary tensor."""
+    assert main(_argv("explain", "11_probe_generate_im.json", artifacts_root)) == 0
+    out = capsys.readouterr().out
+    assert "generate" in out
+    assert "decode 8 tokens (greedy)" in out
+    assert "tail at lm_head: distribution per addressed position" in out

--- a/tests/protocol/test_corpus.py
+++ b/tests/protocol/test_corpus.py
@@ -37,6 +37,7 @@ CORPUS_SHAPE = [
     ("08_weekdays_das_sweep_im.json", 9, 2, {"grad", "paired_forward"}),
     ("09_das_apply_im.json", 1, 2, {"paired_forward"}),
     ("10_task_table_iia_im.json", 1, 3, {"full_logits", "paired_forward"}),
+    ("11_probe_generate_im.json", 1, 1, {"generate", "full_logits"}),
 ]
 
 

--- a/tests/protocol/test_generate_plan.py
+++ b/tests/protocol/test_generate_plan.py
@@ -1,0 +1,133 @@
+"""The decode's derived shape: depth, materialization, capability (§4, §6, §8).
+
+The point of these tests is that the *cost* of a generate document is a
+value the planner emits, not a backend heuristic: a document that wants one
+token's distribution must not oblige the same work as one that wants every
+token's. So they assert the plan, never memory.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from causalab.protocol.backend import requires
+from causalab.protocol.plan import plan_point
+from causalab.protocol.schema import parse_document
+
+from tests.protocol._docs import base_doc, in_order
+
+pytestmark = pytest.mark.unit
+
+
+def probe_doc(anchor: dict[str, Any], budget: int = 8) -> dict[str, Any]:
+    """A minimal document whose saved metric reduces a continuation read."""
+    raw = base_doc()
+    raw["positions"] = {"cont": {"generated": {"max_new_tokens": budget}, **anchor}}
+    raw["reads"]["logits"]["pos"] = "cont"
+    return in_order(raw)
+
+
+def group_for(raw: dict[str, Any], model: str = "patched"):
+    plan = plan_point(parse_document(raw))
+    return next(g for g in plan.groups if g.model == model)
+
+
+def test_decode_depth_is_the_budget():
+    group = group_for(probe_doc({"index": -1}, budget=12))
+    assert group.decode_depth == 12
+
+
+def test_prompt_frame_documents_do_not_decode():
+    for group in plan_point(parse_document(base_doc())).groups:
+        assert group.decode_depth == 0
+        assert group.materialize == ()
+
+
+def test_depth_is_the_max_over_the_groups_reads():
+    """Two reads of one model at different budgets share one decode: the run
+    goes as deep as the deepest, each read windows its own."""
+    raw = probe_doc({"index": -1}, budget=4)
+    raw["positions"]["long"] = {"generated": {"max_new_tokens": 16}, "all": True}
+    raw["reads"]["tail"] = {
+        "site": "lm_head",
+        "pos": "long",
+        "model": "patched",
+        "input": "base",
+    }
+    raw["save"].append(
+        {
+            "value": "tail",
+            "model": "patched",
+            "input": "base",
+            "file_path": "tail.safetensors",
+        }
+    )
+    group = group_for(in_order(raw))
+    assert group.decode_depth == 16
+    assert {m.read for m in group.materialize} == {"logits", "tail"}
+
+
+def test_a_metric_input_needs_a_distribution():
+    """`logits` feeds a logit_diff, so its addressed position has to exist as
+    a full vocabulary vector somewhere."""
+    group = group_for(probe_doc({"index": -1}))
+    (item,) = group.materialize
+    assert (item.read, item.site) == ("logits", "lm_head")
+    assert item.needs_distribution is True
+
+
+def test_saving_a_read_obliges_building_it():
+    """A continuation harvest at a non-head site: saved, so the backend owes
+    the tensor whatever the site is. The *false* branch of
+    ``needs_distribution`` is unreachable in v1 — every metric kind reduces
+    logits — and becomes reachable when metric kinds declare a domain and an
+    ids-only kind (a text probe) stops counting as a consumer."""
+    raw = base_doc()
+    raw["positions"] = {"cont": {"generated": {"max_new_tokens": 8}, "all": True}}
+    raw["reads"] = {
+        "v_cf": raw["reads"]["v_cf"],
+        "acts": {
+            "site": "tgt",
+            "pos": "cont",
+            "model": "patched",
+            "input": "base",
+        },
+    }
+    raw["metrics"] = {}
+    raw["save"] = [
+        {
+            "value": "acts",
+            "model": "patched",
+            "input": "base",
+            "file_path": "acts.safetensors",
+        }
+    ]
+    group = group_for(in_order(raw))
+    (item,) = group.materialize
+    assert (item.read, item.site) == ("acts", "tgt")
+    assert item.needs_distribution is True
+
+
+def test_a_generating_group_does_not_elide():
+    """Elision ends the forward at the deepest tap; a decode needs the head
+    on every step, so there is nothing left to skip."""
+    group = group_for(probe_doc({"index": -1}))
+    assert group.stop_after is None
+
+
+def test_generate_is_a_required_capability():
+    doc = parse_document(probe_doc({"index": -1}))
+    assert "generate" in requires(doc)
+    assert "generate" not in requires(parse_document(base_doc()))
+
+
+def test_decode_depth_is_not_in_the_group_digest():
+    """A decode changes what a group *produces*, not what its prefill
+    computes — so two points differing only in depth still share a prefill,
+    the same reason taps are not in the digest."""
+    short = group_for(probe_doc({"index": -1}, budget=4))
+    long = group_for(probe_doc({"index": -1}, budget=32))
+    assert short.decode_depth != long.decode_depth
+    assert short.digest == long.digest

--- a/tests/protocol/test_schema.py
+++ b/tests/protocol/test_schema.py
@@ -197,3 +197,95 @@ def test_metric_token_form_is_not_sweepable():
     with pytest.raises(ValidationError) as err:
         parse_document(in_order(raw))
     assert err.value.rule == 14
+
+
+# the continuation frame (§2.3) ---------------------------------------------- #
+
+
+def _generated(anchor: dict, budget: int = 8) -> dict:
+    return {"generated": {"max_new_tokens": budget}, **anchor}
+
+
+@pytest.mark.parametrize(
+    "anchor,attr,expected",
+    [
+        ({"all": True}, "all", True),
+        ({"index": -1}, "index", -1),
+        ({"span": [0, 3]}, "span", (0, 3)),
+        ({"variable": "expected"}, "variable", "expected"),
+    ],
+)
+def test_generated_frame_takes_every_anchor(anchor, attr, expected):
+    """``generated`` is a frame selector, not an anchor: the anchor
+    vocabulary is unchanged inside the continuation."""
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = _generated(anchor)
+    pos = parse_document(raw).reads["v_cf"].pos
+    assert isinstance(pos, PositionSpec)
+    assert getattr(pos, attr) == expected
+    assert pos.generated == {"max_new_tokens": 8}
+
+
+def test_generated_needs_an_anchor():
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"generated": {"max_new_tokens": 8}}
+    with pytest.raises(ParseError) as err:
+        parse_document(raw)
+    assert "exactly one" in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        {"column": "entity"},
+        {"index": 0, "scope": {"variable": "subject"}},
+        {"index": 1, "relative_to": {"variable": "subject"}},
+    ],
+)
+def test_generated_refuses_prompt_frame_notions(extra):
+    """A ``column`` holds a substring of the *input* text and
+    ``scope``/``relative_to`` anchor on a prompt variable's token run —
+    neither exists in a frame the prompt does not contain."""
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"generated": {"max_new_tokens": 8}, **extra}
+    with pytest.raises(ParseError) as err:
+        parse_document(raw)
+    assert "generated" in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "budget,fragment",
+    [
+        ({"max_new_tokens": 0}, "at least"),
+        ({"max_new_tokens": -3}, "at least"),
+        ({}, "max_new_tokens"),
+        ({"max_new_tokens": 4, "temperature": 0.7}, "temperature"),
+        (8, "expected an object"),
+    ],
+)
+def test_generated_budget_shapes(budget, fragment):
+    """The budget is a mapping so stopping conditions can join it later —
+    a bare int, a missing budget, and sampling knobs all refuse."""
+    raw = base_doc()
+    raw["reads"]["v_cf"]["pos"] = {"generated": budget, "index": -1}
+    with pytest.raises(ParseError) as err:
+        parse_document(raw)
+    assert fragment in str(err.value)
+
+
+def test_generated_budget_is_sweepable():
+    raw = base_doc()
+    raw["positions"] = {
+        "tail": {"generated": {"max_new_tokens": {"sweep": [4, 16]}}, "index": -1}
+    }
+    raw["reads"]["v_cf"]["pos"] = "tail"
+    pos = parse_document(in_order(raw)).positions["tail"]
+    assert isinstance(pos, PositionSpec)
+    assert isinstance(pos.generated["max_new_tokens"], Sweep)
+
+
+def test_prompt_frame_positions_carry_no_generated():
+    """Every pre-existing position stays prompt-frame: the field is absent,
+    not defaulted, so existing canonical forms are untouched."""
+    pos = parse_document(base_doc()).reads["v_cf"].pos
+    assert isinstance(pos, PositionSpec) and pos.generated is None

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -650,3 +650,17 @@ def test_rule_16_train_with_a_generated_position():
     doc["save"].append({"value": "rot", "site": "tgt", "file_path": "rot.safetensors"})
     err = expect_rule(16, doc)
     assert "gradient path" in str(err)
+
+
+def test_the_checklist_and_the_spec_agree_on_how_many_rules_there_are():
+    """`CHECKLIST_RULES` guards every ValidationError's number, so it has to
+    match §5 or the guard silently drifts from the document it enforces."""
+    import re
+    from pathlib import Path
+
+    from causalab.protocol.errors import CHECKLIST_RULES
+
+    spec = Path(__file__).resolve().parents[2] / "docs" / "intervention_protocol.md"
+    section = spec.read_text().split("## 5. Validation")[1].split("\n## ")[0]
+    numbered = {int(m) for m in re.findall(r"^(\d+)\. ", section, flags=re.M)}
+    assert numbered == set(range(1, CHECKLIST_RULES + 1))

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -601,3 +601,52 @@ def test_rule_8_column_positions_are_conservatively_overlapping():
     }
     doc["intervened_models"]["patched"]["writes"] = ["patch", "patch2"]
     expect_rule(8, doc)
+
+
+# rule 16 — generation is read-only and prefill-only ------------------------- #
+
+
+def _reads_the_continuation(doc: dict[str, Any]) -> dict[str, Any]:
+    """Point the saved read at the continuation, which is legal."""
+    doc["positions"] = {"tail": {"generated": {"max_new_tokens": 8}, "index": -1}}
+    doc["reads"]["logits"]["pos"] = "tail"
+    return doc
+
+
+def test_a_read_may_address_the_continuation():
+    """The positive control for rule 16: reads are exactly what the frame is
+    for, so nothing about a generate read is a load error."""
+    parse_and_validate(_reads_the_continuation(base_doc()))
+
+
+def test_rule_16_write_at_a_generated_position():
+    doc = _reads_the_continuation(base_doc())
+    doc["writes"]["patch"]["pos"] = "tail"
+    err = expect_rule(16, doc)
+    assert "prefill-only" in str(err)
+
+
+def test_rule_16_write_at_an_inline_generated_position():
+    """Inline specs are refused on the same footing as named ones — the rule
+    reads the resolved spec, not the spelling."""
+    doc = _reads_the_continuation(base_doc())
+    doc["writes"]["patch"]["pos"] = {"generated": {"max_new_tokens": 4}, "index": -1}
+    expect_rule(16, doc)
+
+
+def test_rule_16_train_with_a_generated_position():
+    """A greedy decode is an argmax chain: there is no gradient path from a
+    continuation read back to a featurizer's parameters."""
+    doc = _reads_the_continuation(base_doc())
+    doc["featurizers"] = {"rot": {"kind": "subspace", "k": 2}}
+    doc["reads"]["v_cf"]["featurizer"] = "rot"
+    doc["train"] = {
+        "objective": [[1.0, "ld"]],
+        "params": ["rot"],
+        "optimizer": {"name": "adamw", "lr": 0.001},
+        "steps": {"epochs": 1},
+        "batch": {"pairs": 2},
+    }
+    doc["save"].append({"value": "rot", "site": "tgt", "file_path": "rot.safetensors"})
+    err = expect_rule(16, doc)
+    assert "gradient path" in str(err)

--- a/tests/protocols/11_probe_generate_im.json
+++ b/tests/protocols/11_probe_generate_im.json
@@ -1,0 +1,30 @@
+{
+  "version": "1",
+  "description": "Exploration probe: greedy-decode 8 tokens under a residual-stream steer, then read the distribution at the last generated token. The continuation is addressed by an ordinary position (the `generated` frame), so it is a read, and an ordinary metric scores it — top_k with k=1 is the greedy continuation itself.",
+  "model": {"key": "meta-llama/Llama-3.1-8B", "revision": "main"},
+  "data": {
+    "base": {"dataset": "weekdays/train", "field": "input"}
+  },
+  "positions": {
+    "last_new": {"generated": {"max_new_tokens": 8}, "index": -1}
+  },
+  "sites": {
+    "target":  {"component": "block_output", "layer": 18},
+    "lm_head": {"component": "lm_head"}
+  },
+  "reads": {
+    "tail": {"site": "lm_head", "pos": "last_new", "model": "probed", "input": "base"}
+  },
+  "writes": {
+    "push": {"site": "target", "pos": -1, "do": {"add_scaled": {"op": 1.0, "alpha": 2.0}}}
+  },
+  "intervened_models": {
+    "probed": {"input": "base", "writes": ["push"]}
+  },
+  "metrics": {
+    "greedy": {"kind": "top_k", "of": "tail", "k": 1}
+  },
+  "save": [
+    {"value": "greedy", "model": "probed", "input": "base", "file_path": "probe.parquet"}
+  ]
+}


### PR DESCRIPTION
Implements the first half of #25: **generation as a position frame**. A greedy decode
produces a second position frame, so addressing it needs no new section and no new save
shape — a continuation is still a *read*, which is what keeps metrics composable.

```json
"positions": {"last_new": {"generated": {"max_new_tokens": 8}, "index": -1}},
"reads":     {"tail": {"site": "lm_head", "pos": "last_new",
                       "model": "probed", "input": "base"}},
"metrics":   {"greedy": {"kind": "top_k", "of": "tail", "k": 1}}
```

That is corpus document 11, and it needed **no new metric vocabulary**: `top_k` with `k=1`
over a single-position continuation read *is* the greedy token. The argument for the frame
over a `generations` section is demonstrated rather than asserted.

## What is in this PR

| commit | what |
|---|---|
| `protocol: a generated position frame` | `PositionSpec.generated`, the parse rules, and rule 16 (reads only, no `train`) |
| `protocol: the generate capability, and the decode's derived cost` | the `generate` capability, `decode_depth` + `materialize` per forward group, `explain` output |
| `neural: the continuation frame` | `Continuation` — decode steps, per-row widths, char spans |
| `neural: greedy decode, and continuation reads` | the decode loop, per-step capture, the reference backend's advert |
| `protocol: the probe corpus document, and the spec for the frame` | corpus 11, §2.3/§4/§5/§6/§7/§8 |

**Not in this PR** (a follow-up branch): metrics over multi-position/ragged continuation
reads with `step`/`matched` columns, metric domains (`ids` vs `distribution`), the ids-only
`decode` kind, and the `variable` anchor that matches inside the generated text. So today a
continuation read is scored one position at a time, or saved as a tensor.

## Semantics worth reviewing

- **Writes stay prefill-only.** Write hooks live in the prefill's `ExitStack` and are gone
  before the first decode step; an intervention reaches the continuation through the first
  token's logits and through what the prefill left in the KV cache. `generated` on a write
  is a load error. That is also why rules 8/9 never have to reason about two frames.
- **`n` tokens need `n` steps, not `n − 1`.** The last generated token has to be *consumed*
  by a forward for its own activations to exist, and reading `lm_head` there is the
  documented "distribution after the last generated token".
- **The frame ends at the row's first EOS**, so widths differ and continuation reads are
  ragged (free — #27 built that path). A window past a row's end clips, and a row that
  generated nothing contributes no positions: how far a row generates is a *result*, so
  refusing on it would make a document fail on data rather than on authoring.
- **`lm_head` at generated position `j` is the distribution *after* token `j`.** Written
  down once in §2.3 so no document rediscovers the off-by-one.

## The cost of a decode is a value, not a heuristic

Per group the planner derives the decode depth and, per continuation read,
`needs_distribution` — saved, or reduced by a metric. §8 already made minimal logit
materialization the backend's obligation; this states it for the decode and deliberately
leaves the mechanism open. `explain` prints it:

```
requires  ['full_logits', 'generate']
forwards  1 per point
  probed on base: tail
    decode 8 tokens (greedy)
    tail at lm_head: distribution per addressed position
```

The reference backend's own choice — keep `ln_final` activations across steps, project
through the head only at the addressed positions — is a note in §8, not spec. It means
`{"index": -1}` costs one vocabulary slice instead of one per step, and it is why *any*
site (not just the head) is readable at generated positions. `lm_head(ln_final_out)` is
bit-identical to the model's own logits on both supported families; that was checked before
relying on it.

## Verification

- **Parity with `model.generate(do_sample=False)`** token-for-token, both tiny families,
  over a two-row batch of *unequal* length — left padding is what makes the batched decode
  correct, and an equal-length batch would not have noticed.
- `model.generate` is the oracle, never the implementation: it inherits a checkpoint's
  `generation_config` into a run that has to be a pure function of the document, and the
  capture sink would be clobbered by its last decode step.
- The corpus document runs end to end through the real CLI on tiny-random.
- **Only document 11's entry appears in `corpus_digests.json`** — the field is absent by
  default, so no existing canonical form moves and this is not a loader migration.
- 1608 tests pass (`-m "not golden"`); `pre-commit run --all-files` clean.

## One measured caveat, pinned rather than hidden

`use_cache=True` takes a slightly different kernel path, so a prompt-frame read inside a
*decoding* document differs from the same read in a non-decoding one by ~4e-9 (fp32,
tiny-random). The flag follows the decode depth exactly so that no existing document's
numbers move; a test asserts the tolerance and fails if the two ever become bit-identical,
so the premise cannot rot silently.

Stacked on `can/protocol-refactor` (#20). Builds on #27's `all` spelling and its ragged
read/save path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
