### PR TITLE
Protocol: metrics over the continuation, the ids domain, and the `variable` anchor

### DIFF
--- a/causalab/neural/pytorch_hooks/backend.py
+++ b/causalab/neural/pytorch_hooks/backend.py
@@ -12,6 +12,7 @@ routing refuses those documents before anything runs.
 
 from __future__ import annotations
 
+import dataclasses
 import functools
 import json
 from pathlib import Path
@@ -20,7 +21,10 @@ from typing import Any, Mapping
 
 from causalab.neural.pytorch_hooks.executor import PointExecutor
 from causalab.neural.pytorch_hooks.loading import TensorBundle, load_model
-from causalab.neural.pytorch_hooks.metrics import compute_metric
+from causalab.neural.pytorch_hooks.metrics import (
+    compute_metric,
+    compute_windowed_metric,
+)
 from causalab.neural.pytorch_hooks.outputs import (
     MetricTable,
     TensorFile,
@@ -29,9 +33,25 @@ from causalab.neural.pytorch_hooks.outputs import (
 )
 from causalab.protocol.backend import Backend, ExecutionRequest, RunResult
 from causalab.protocol.errors import ProtocolError
-from causalab.protocol.schema import Document, parse_document
+from causalab.protocol.schema import (
+    METRIC_DOMAINS,
+    WHOLE_WINDOW_METRIC_KINDS,
+    Document,
+    parse_document,
+)
 
 __all__ = ["PytorchHooksBackend"]
+
+
+@dataclasses.dataclass(frozen=True)
+class _Windowed:
+    """One continuation metric's per-example results, plus what the rows need
+    to stay legible: the steps each value scored, and whether the example
+    addressed anything at all."""
+
+    values: list[list[Any]]
+    steps: list[list[int]] | None
+    matched: list[bool]
 
 
 class PytorchHooksBackend(Backend):
@@ -125,23 +145,69 @@ class PytorchHooksBackend(Backend):
             trained_stages = run_training(doc, executor, request)
         executor.run_all()
         metric_values: dict[str, list[Any]] = {}
+        windowed: dict[str, _Windowed] = {}
         for qname, metric in doc.metrics.items():
-            of_value = executor.dense_value(str(metric.of))
-            target = None
-            if metric.kind == "kl":
-                target = executor.dense_value(str(metric.fields["target"]))
+            of_name = str(metric.of)
+            target_name = str(metric.fields["target"]) if metric.kind == "kl" else None
+            if executor.is_generated(of_name):
+                # a continuation read addresses as many positions as the row
+                # generated, so its metric reduces per step and reports which
+                # steps it saw (§2.3, §2.10)
+                windowed[qname] = _Windowed(
+                    values=compute_windowed_metric(
+                        metric,
+                        executor.windowed_value(of_name),
+                        executor.rows_for_metrics(),
+                        executor.bundle.tokenizer,
+                        target_windows=(
+                            executor.windowed_value(target_name)
+                            if target_name is not None
+                            else None
+                        ),
+                        generated_ids=(
+                            executor.generated_ids(of_name)
+                            if METRIC_DOMAINS.get(str(metric.kind)) == "ids"
+                            else None
+                        ),
+                    ),
+                    steps=(
+                        None
+                        if str(metric.kind) in WHOLE_WINDOW_METRIC_KINDS
+                        else executor.addressed_steps(of_name)
+                    ),
+                    matched=[
+                        bool(steps) for steps in executor.addressed_steps(of_name)
+                    ],
+                )
+                continue
             metric_values[qname] = compute_metric(
                 metric,
-                of_value,
+                executor.dense_value(of_name),
                 executor.rows_for_metrics(),
                 executor.bundle.tokenizer,
-                target_value=target,
+                target_value=(
+                    executor.dense_value(target_name)
+                    if target_name is not None
+                    else None
+                ),
             )
         for entry in doc.save:
             if entry.value in doc.metrics:
-                metric_files.setdefault(entry.file_path, MetricTable()).add(
-                    entry.value, metric_values[entry.value], coords, point_digest
-                )
+                table = metric_files.setdefault(entry.file_path, MetricTable())
+                if entry.value in windowed:
+                    window = windowed[entry.value]
+                    table.add_windowed(
+                        entry.value,
+                        window.values,
+                        coords,
+                        point_digest,
+                        steps=window.steps,
+                        matched=window.matched,
+                    )
+                else:
+                    table.add(
+                        entry.value, metric_values[entry.value], coords, point_digest
+                    )
             elif entry.value in doc.reads:
                 # the site goes on the entry too: a harvested activation is
                 # bound to where it was read, and a consumer (a transform op

--- a/causalab/neural/pytorch_hooks/encoding.py
+++ b/causalab/neural/pytorch_hooks/encoding.py
@@ -41,7 +41,16 @@ against a :class:`Continuation` instead: the greedy decode's steps, indexed
 from 0, one per generated token. Step indices are not padded-frame indices
 and the two never mix — a decode *step* is the unit here, and the same
 anchors mean what they say inside it (``{"index": -1}`` is the last real
-generated token, ``{"all": true}`` is every one).
+generated token, ``{"all": true}`` is every one, ``{"variable": "x"}`` is
+the tokens where the model *said* the row's value for ``x``).
+
+The ``variable`` anchor differs from its prompt-side twin in two ways, both
+because the continuation is a result rather than an input: it takes the
+**first** occurrence instead of demanding exactly one (a repetitive
+generation is a normal outcome, not an authoring error), and **zero**
+occurrences yield zero positions instead of refusing — whether the model
+says the thing is usually the experiment, so it has to be a value the run
+reports, not an exception that ends it.
 
 Rows end where they end: the frame stops at a row's first EOS, so widths
 differ and continuation reads are ragged. A window that reaches past a
@@ -62,7 +71,7 @@ from typing import Any, Mapping, Sequence
 import torch
 
 from causalab.protocol.errors import ProtocolError
-from causalab.protocol.schema import PositionSpec, concrete_int
+from causalab.protocol.schema import PositionSpec, concrete_int, concrete_str
 
 __all__ = [
     "Continuation",
@@ -247,8 +256,39 @@ def _variable_token_run(batch: EncodedBatch, row: int, value: str) -> list[int]:
     return run
 
 
+def _generated_variable_run(
+    continuation: Continuation, row: int, value: str
+) -> list[int]:
+    """Step indices covering the **first** occurrence of ``value`` in the
+    row's generated text, or ``[]`` when the model never said it.
+
+    Char spans come from the decode's incremental detokenization
+    (:class:`Continuation`), so a match that starts mid-piece still lands on
+    the steps that produced it — the sentencepiece case a post-hoc
+    ``offset_mapping`` cannot resolve.
+    """
+    if row >= len(continuation.texts):
+        return []
+    text = continuation.texts[row]
+    start = text.find(value)
+    if start < 0:
+        return []
+    lo, hi = start, start + len(value)
+    width = continuation.widths[row]
+    return [
+        step
+        for step, (a, b) in enumerate(continuation.offsets[row][:width])
+        if a < hi and b > lo
+    ]
+
+
 def resolve_steps(
-    spec: PositionSpec, continuation: Continuation, row: int
+    spec: PositionSpec,
+    continuation: Continuation,
+    row: int,
+    *,
+    dataset_row: Mapping[str, Any] | None = None,
+    field: str | None = None,
 ) -> list[int]:
     """Resolve one ``generated`` spec for one row into **decode-step** indices.
 
@@ -271,10 +311,20 @@ def resolve_steps(
             raise ProtocolError("P2", f"span is not concrete: {span!r}")
         a, b = (int(v) for v in span)
         return list(range(min(a, width), min(b, width)))
+    if spec.variable is not None:
+        if dataset_row is None or field is None:
+            raise ProtocolError(
+                "P2",
+                "a generated 'variable' position needs its dataset row — the "
+                "value the model may have said comes from the table",
+            )
+        variable = concrete_str(spec.variable, "position variable")
+        value = variable_value(dataset_row, field, variable)
+        return _generated_variable_run(continuation, row, value)
     raise ProtocolError(
         "P2",
         f"anchor {spec!r} has no continuation-frame resolution — v1 addresses "
-        "generated tokens by index, span or all",
+        "generated tokens by index, span, variable or all",
     )
 
 
@@ -296,7 +346,9 @@ def resolve_position(
                 "a generated position needs the decode's continuation — the "
                 "frame it addresses does not exist until the model has run",
             )
-        return resolve_steps(spec, continuation, row)
+        return resolve_steps(
+            spec, continuation, row, dataset_row=dataset_row, field=field
+        )
     padded = batch.padded_len
     start = batch.content_start(row)
 

--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -137,6 +137,10 @@ class PointExecutor:
         self._groups_run: set[tuple[str, str]] = set()
         self._batches: dict[str, EncodedBatch] = {}
         self._continuations: dict[tuple[str, str], Continuation] = {}
+        #: per generate read, the decode steps each row addresses — the
+        #: same list the gather used, kept because metrics need to know
+        #: *which* steps a value covers (and that a row covered none)
+        self._read_steps: dict[str, list[list[int]]] = {}
 
     # ------------------------------------------------------------------ #
     # public surface
@@ -161,6 +165,48 @@ class PointExecutor:
                 "metrics reduce one aligned position per example",
             )
         return value
+
+    def is_generated(self, name: str) -> bool:
+        """Whether this read addresses the continuation frame (§2.3)."""
+        return generated_budget(self.doc, self.doc.reads[name].pos) is not None
+
+    def windowed_value(self, name: str) -> list[torch.Tensor]:
+        """One read's value split per example: ``(positions_i, …)`` each.
+
+        The metric surface for a continuation read. Unlike
+        :meth:`dense_value` it welcomes ragged widths, because in the
+        continuation frame they are the answer rather than a
+        misalignment — a row that stopped early, or never said the value a
+        ``variable`` anchor looks for, contributes an **empty** tensor.
+        """
+        value = self.read_value(name)
+        if isinstance(value, RaggedValue):
+            widths = list(value.widths)
+            return list(torch.split(value.flat, widths)) if widths else []
+        if value.dim() == 2:  # one position per row, already squeezed
+            return [value[i].unsqueeze(0) for i in range(value.shape[0])]
+        return [value[i] for i in range(value.shape[0])]
+
+    def addressed_steps(self, name: str) -> list[list[int]]:
+        """Per example, the decode steps one generate read covers."""
+        if name not in self._read_steps:
+            self.read_value(name)  # materialize the group that fills it
+        return self._read_steps[name]
+
+    def generated_ids(self, name: str) -> list[list[int]]:
+        """Per example, the token ids at a generate read's addressed steps.
+
+        The ``ids`` metric domain (§2.10): these come from the decode
+        itself, so a metric that only needs them obliges no vocabulary
+        projection anywhere.
+        """
+        read = self.doc.reads[name]
+        steps = self.addressed_steps(name)
+        continuation = self._continuations[(str(read.model), str(read.input))]
+        return [
+            [int(continuation.token_ids[row, step]) for step in row_steps]
+            for row, row_steps in enumerate(steps)
+        ]
 
     def run_all(self) -> None:
         """Run every group the document implies (all reads materialize)."""
@@ -230,6 +276,7 @@ class PointExecutor:
         self._read_values.clear()
         self._groups_run.clear()
         self._continuations.clear()
+        self._read_steps.clear()
 
     # ------------------------------------------------------------------ #
     # group execution
@@ -418,10 +465,19 @@ class PointExecutor:
             site = gen_sites[rname]
             capture_site = gen_capture_sites[rname]
             stacked = torch.cat(steps[(id(capture_site.module), capture_site.kind)], 1)
+            dataset_rows = self.role_rows[input_role]
+            field = self.role_fields[input_role]
             per_row = [
-                resolve_steps(self._spec(read.pos), continuation, row)
+                resolve_steps(
+                    self._spec(read.pos),
+                    continuation,
+                    row,
+                    dataset_row=dataset_rows[row],
+                    field=field,
+                )
                 for row in range(rows)
             ]
+            self._read_steps[rname] = per_row
             project = None
             if capture_site is not site:  # ln_final kept, lm_head owed
                 head = (

--- a/causalab/neural/pytorch_hooks/metrics.py
+++ b/causalab/neural/pytorch_hooks/metrics.py
@@ -38,13 +38,14 @@ from typing import Any, Mapping, Sequence
 import torch
 
 from causalab.protocol.errors import ProtocolError
-from causalab.protocol.schema import MetricSpec
+from causalab.protocol.schema import WHOLE_WINDOW_METRIC_KINDS, MetricSpec
 
 __all__ = [
     "column_first_token_id",
     "column_token_id",
     "column_token_ids",
     "compute_metric",
+    "compute_windowed_metric",
 ]
 
 
@@ -312,4 +313,73 @@ def compute_metric(
             {name: float(probs[i, ids].sum()) for name, ids in group_ids.items()}
             for i in range(logits.shape[0])
         ]
+    if kind == "decode":
+        raise ProtocolError(
+            "P2",
+            "'decode' reduces the tokens a decode produced, so it binds to a "
+            "read in the continuation frame (§2.3) — validation refuses it "
+            "anywhere else",
+        )
     raise ProtocolError("P4", f"unknown metric kind {kind!r}")
+
+
+def compute_windowed_metric(
+    metric: MetricSpec,
+    windows: Sequence[torch.Tensor],
+    rows: Sequence[Mapping[str, Any]],
+    tokenizer: Any,
+    *,
+    target_windows: Sequence[torch.Tensor] | None = None,
+    generated_ids: Sequence[Sequence[int]] | None = None,
+) -> list[list[Any]]:
+    """One metric over a read that addresses **several** positions per row.
+
+    ``windows[i]`` is example ``i``'s value at the positions it addresses,
+    ``(positions_i, vocab)`` — empty when the row addressed none, which in
+    the continuation frame is a result (§2.3), not a misalignment. Returns
+    the same shape: one list of values per example.
+
+    Every ``distribution`` kind reduces **per position**, and does so
+    through :func:`compute_metric` on the flattened positions — one
+    implementation of the kinds, not two. ``ids`` kinds never look at
+    ``windows`` at all: they consume ``generated_ids``, which is why a text
+    probe obliges no vocabulary projection (§8).
+    """
+    kind = str(metric.kind)
+    if kind in WHOLE_WINDOW_METRIC_KINDS:
+        if generated_ids is None:
+            raise ProtocolError(
+                "P2", f"metric kind {kind!r} needs the decode's token ids"
+            )
+        if kind == "decode":
+            return [
+                [tokenizer.decode(list(ids))] if len(ids) else []
+                for ids in generated_ids
+            ]
+        raise ProtocolError("P4", f"unhandled whole-window metric kind {kind!r}")
+
+    counts = [int(window.shape[0]) for window in windows]
+    if not any(counts):
+        return [[] for _ in windows]
+    flat = torch.cat([w for w in windows if w.shape[0]], dim=0)
+    flat_rows = [rows[i] for i, count in enumerate(counts) for _ in range(count)]
+    flat_target = None
+    if target_windows is not None:
+        target_counts = [int(w.shape[0]) for w in target_windows]
+        if target_counts != counts:
+            raise ProtocolError(
+                "P2",
+                f"kl compares reads addressing different position counts "
+                f"({counts} vs {target_counts}) — a comparison needs a "
+                "position-for-position pairing",
+            )
+        flat_target = torch.cat([w for w in target_windows if w.shape[0]], dim=0)
+    values = compute_metric(
+        metric, flat, flat_rows, tokenizer, target_value=flat_target
+    )
+    out: list[list[Any]] = []
+    cursor = 0
+    for count in counts:
+        out.append(values[cursor : cursor + count])
+        cursor += count
+    return out

--- a/causalab/neural/pytorch_hooks/outputs.py
+++ b/causalab/neural/pytorch_hooks/outputs.py
@@ -132,16 +132,83 @@ class MetricTable:
         self, name: str, values: list[Any], coords: Mapping[str, Any], point_digest: str
     ) -> None:
         for example, value in enumerate(values):
-            row: dict[str, Any] = {"example": example, "metric": name}
-            if isinstance(value, dict):
-                import json
+            self.rows.append(self._row(name, example, value, coords, point_digest))
 
-                row["value"] = json.dumps(value, sort_keys=True)
-            else:
-                row["value"] = value
-            row.update({axis: _plain(coord) for axis, coord in coords.items()})
-            row["produced_by"] = point_digest
-            self.rows.append(row)
+    def add_windowed(
+        self,
+        name: str,
+        values: list[list[Any]],
+        coords: Mapping[str, Any],
+        point_digest: str,
+        *,
+        steps: list[list[int]] | None,
+        matched: list[bool],
+    ) -> None:
+        """Rows for a metric over a read that addresses several positions.
+
+        One row per (example, position), carrying the ``step`` it scored and
+        whether the example addressed anything at all. An example that
+        addressed **nothing** — a row that stopped generating, or never said
+        the value a ``variable`` anchor looks for — still gets exactly one
+        row, with a null value and ``matched=false``: "the model never said
+        it" has to be distinguishable from "it said it and scored 0", and a
+        missing row would make the two look identical after a group-by.
+
+        ``steps`` is ``None`` for a kind that reduces the whole window to
+        one value (``decode``): there is no single step such a value belongs
+        to, so the column stays null rather than lying about one.
+        """
+        for example, row_values in enumerate(values):
+            if not row_values:
+                self.rows.append(
+                    self._row(
+                        name,
+                        example,
+                        None,
+                        coords,
+                        point_digest,
+                        step=None,
+                        matched=matched[example],
+                    )
+                )
+                continue
+            for offset, value in enumerate(row_values):
+                self.rows.append(
+                    self._row(
+                        name,
+                        example,
+                        value,
+                        coords,
+                        point_digest,
+                        step=steps[example][offset] if steps is not None else None,
+                        matched=matched[example],
+                    )
+                )
+
+    def _row(
+        self,
+        name: str,
+        example: int,
+        value: Any,
+        coords: Mapping[str, Any],
+        point_digest: str,
+        *,
+        step: int | None = None,
+        matched: bool | None = None,
+    ) -> dict[str, Any]:
+        row: dict[str, Any] = {"example": example, "metric": name}
+        if isinstance(value, dict):
+            import json
+
+            row["value"] = json.dumps(value, sort_keys=True)
+        else:
+            row["value"] = value
+        if matched is not None:
+            row["step"] = step
+            row["matched"] = matched
+        row.update({axis: _plain(coord) for axis, coord in coords.items()})
+        row["produced_by"] = point_digest
+        return row
 
 
 def _plain(value: Any) -> Any:

--- a/causalab/protocol/plan.py
+++ b/causalab/protocol/plan.py
@@ -20,7 +20,12 @@ import hashlib
 import json
 from typing import Any, Mapping
 
-from causalab.protocol.schema import Document, PositionSpec, concrete_int
+from causalab.protocol.schema import (
+    METRIC_DOMAINS,
+    Document,
+    PositionSpec,
+    concrete_int,
+)
 
 __all__ = [
     "COMPONENT_RANK",
@@ -205,14 +210,16 @@ def generated_budget(doc: Document, pos: Any) -> int | None:
 def _needs_distribution(doc: Document, read: str) -> bool:
     """Whether anything downstream of ``read`` consumes a full distribution.
 
-    Saving the read is the obvious case. So is any metric over it: every v1
-    metric kind reduces logits. When metric kinds declare a domain, an
-    ids-only kind stops counting here — and a text-only probe then obliges
-    no vocabulary projection at all."""
+    Saving the read is the obvious case. So is any metric in the
+    ``distribution`` domain (§2.10). An ``ids`` kind does **not** count: it
+    consumes the tokens the decode produced, so a text-only probe obliges no
+    vocabulary projection anywhere — which is the whole point of stating the
+    requirement rather than always paying it."""
     if any(entry.value == read for entry in doc.save):
         return True
     for metric in doc.metrics.values():
-        if str(metric.of) == read:
+        domain = METRIC_DOMAINS.get(str(metric.kind), "distribution")
+        if str(metric.of) == read and domain == "distribution":
             return True
         target = metric.fields.get("target")
         if isinstance(target, str) and target == read:

--- a/causalab/protocol/schema.py
+++ b/causalab/protocol/schema.py
@@ -52,9 +52,11 @@ __all__ = [
     "MATCH_MODES",
     "MECHANISMS",
     "METRIC_FIELD_DEFAULTS",
+    "METRIC_DOMAINS",
     "METRIC_KINDS",
     "Mechanism",
     "MetricKind",
+    "MetricDomain",
     "MetricSpec",
     "ModelRef",
     "OPTIONAL_METRIC_FIELDS",
@@ -67,6 +69,7 @@ __all__ = [
     "SiteSpec",
     "TOKEN_COLUMN_METRIC_KINDS",
     "TOKEN_FORMS",
+    "WHOLE_WINDOW_METRIC_KINDS",
     "TokenForm",
     "concrete_int",
     "concrete_str",
@@ -155,6 +158,7 @@ MetricKind = Literal[
     "class_probs",
     "top_k",
     "match",
+    "decode",
 ]
 METRIC_KINDS: tuple[MetricKind, ...] = get_args(MetricKind)
 
@@ -169,7 +173,32 @@ METRIC_FIELDS: dict[str, tuple[str, ...]] = {
     "class_probs": ("groups",),
     "top_k": ("k",),
     "match": ("expected",),
+    "decode": (),
 }
+
+#: What each metric kind consumes from its read (§2.10). ``distribution``
+#: kinds reduce the vocabulary projection at the addressed positions;
+#: ``ids`` kinds consume only the tokens the decode actually produced. The
+#: split is what lets the planner (§8) tell a text probe — which obliges no
+#: vocabulary projection at all — from a scoring one, so it is a property of
+#: the kind, never of the document.
+MetricDomain = Literal["distribution", "ids"]
+METRIC_DOMAINS: dict[str, MetricDomain] = {
+    "logit_diff": "distribution",
+    "token_logit": "distribution",
+    "cross_entropy": "distribution",
+    "kl": "distribution",
+    "class_probs": "distribution",
+    "top_k": "distribution",
+    "match": "distribution",
+    "decode": "ids",
+}
+
+#: Metric kinds that reduce the whole addressed window to one value per
+#: example rather than one per position: ``decode`` joins its tokens into a
+#: string, so a per-step row would be a per-character-ish lie.
+WHOLE_WINDOW_METRIC_KINDS: frozenset[str] = frozenset({"decode"})
+
 
 TokenForm = Literal["auto", "bare", "space_prefixed"]
 

--- a/causalab/protocol/validate.py
+++ b/causalab/protocol/validate.py
@@ -39,6 +39,7 @@ from causalab.protocol.errors import ValidationError
 from causalab.protocol.schema import (
     ADDITIVE_MECHANISMS,
     FEATURIZER_SLOTS,
+    METRIC_DOMAINS,
     Do,
     Document,
     WriteSpec,
@@ -227,6 +228,23 @@ def _check_references(doc: Document, names: dict[str, str]) -> None:
                 "kinds bind to lm_head reads",
                 path=f"{p}.of",
             )
+        if METRIC_DOMAINS.get(str(metric.kind)) == "ids":
+            # an ids-domain kind reduces the tokens a decode produced, so its
+            # read has to be one that decoded something: in the prompt frame
+            # there are no produced tokens to reduce, only given ones
+            of_pos = of_read.pos
+            of_spec = doc.positions.get(of_pos) if isinstance(of_pos, str) else of_pos
+            if not (
+                isinstance(of_spec, PositionSpec) and of_spec.generated is not None
+            ):
+                raise ValidationError(
+                    4,
+                    f"metric {qname!r} is a {metric.kind!r} over {metric.of!r}, but "
+                    f"that read addresses the prompt — {metric.kind!r} reduces the "
+                    "tokens a decode produced, so it binds to a read whose position "
+                    "carries 'generated' (§2.3, §2.10)",
+                    path=f"{p}.of",
+                )
         if metric.kind == "kl":
             target = metric.fields.get("target")
             if target not in doc.reads:

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -114,6 +114,17 @@ the model said the row's value for `x`.
   generated nothing contributes no positions. Unlike the prompt frame — where an
   out-of-range index is an authoring error and refused — how far a row generates
   is a *result*, and refusing on it would make a document fail on data.
+- **`variable` in the continuation** — "the tokens where the model said the
+  row's value for `x`" — differs from its prompt-side twin in two ways, both
+  because the continuation is a *result* rather than an input. It takes the
+  **first** occurrence instead of demanding exactly one, since a generation may
+  repeat itself as a matter of course; and **zero** occurrences yield zero
+  positions rather than refusing, because whether the model says the thing is
+  usually the experiment. A metric over such a read reports the miss as a null
+  value with `matched: false` (sec. 2.10), so it is data, not an exception.
+  Character spans come from the decode's own incremental detokenization, so a
+  match that starts inside a merged piece still lands on every token that
+  produced it.
 - **Reads only.** A write may not carry `generated` (rule 16): the continuation
   exists because the prefill already ran, and an intervention reaches it through
   the first token's logits and through what the prefill left in the KV cache —
@@ -314,6 +325,35 @@ Closed vocabulary; `of` names a read; other value fields name dataset columns.
 | `class_probs` | `of, groups` | summed probability per group |
 | `top_k` | `of, k` | top-k tokens + probs |
 | `match` | `of, expected` (+ optional `mode`) | match indicator |
+| `decode` | `of` | the addressed tokens as text |
+
+**Domains.** Every kind consumes one of two things from its read, and which
+one is a property of the kind:
+
+| domain | kinds | consumes |
+|---|---|---|
+| `distribution` | everything above except `decode` | the vocabulary projection at the addressed positions |
+| `ids` | `decode` | only the tokens the decode produced |
+
+An `ids` kind therefore obliges **no** vocabulary projection anywhere (§8's
+materialization requirement) — a text probe is cheap by construction, not by a
+backend's cleverness. It also only means something where tokens were
+*produced*: `decode` binds to a read whose position carries `generated` (§2.3),
+and a `decode` over a prompt-frame read is a load error.
+
+**Metrics over several positions.** A read may address more than one position —
+every generated token of a row, a window of them, the tokens where the model
+said something (§2.3). A metric over such a read reduces **per position**, and
+its table says which:
+
+- one row per (example, position), carrying the `step` it scored and a
+  `matched` flag; `decode` is the exception that reduces the whole window to
+  one string, and its `step` is null because no single step owns it;
+- an example that addressed **nothing** — it stopped generating, or never said
+  what a `variable` anchor looked for — still gets exactly one row, with a null
+  value and `matched: false`. "The model never said it" must not be
+  indistinguishable from "it said it and scored 0";
+- prompt-frame metrics are unchanged: one row per example, no `step` column.
 
 - A metric binds to exactly one read → one (model, input). Same metric in two
   models = two reads + two metrics.
@@ -584,8 +624,11 @@ it is the vocabulary: at batch 32 and 16 steps, every step's distribution over a
 128k vocabulary is ~260 MB in fp32, one step is ~16 MB, a site's activations
 ~8 MB, the token ids ~2 KB. The planner therefore derives, per group, the decode
 depth and — per continuation read — whether anything downstream consumes a
-distribution (it is saved, or a metric over it reduces one). A backend **must
-not** build one where the answer is no.
+distribution: the read is saved, or a metric in the `distribution` domain
+reduces it (sec. 2.10). An `ids`-domain metric does **not** count, which is the
+point of the domain: a text probe — `decode` over a continuation read, nothing
+saved — obliges no vocabulary projection at all, and a backend **must not**
+build one where the answer is no.
 
 *How* it complies is its own business: keeping only the addressed steps,
 projecting a narrower slice (`logits_to_keep` takes an index tensor), replaying

--- a/tests/neural/pytorch_hooks/test_generate_metrics.py
+++ b/tests/neural/pytorch_hooks/test_generate_metrics.py
@@ -1,0 +1,256 @@
+"""Metrics over the continuation frame (§2.10): per-step reduction, the ids
+domain, and the row that addressed nothing.
+
+A continuation read addresses as many positions as its row generated, so a
+metric over it reduces **per step** and the table says which step each value
+came from. Two consequences this module pins:
+
+* a row that addressed *nothing* — it stopped generating, or never said the
+  value a ``variable`` anchor looks for — still produces one row, with a null
+  value and ``matched=false``. "The model never said it" and "it said it and
+  scored 0" must not look alike after a group-by;
+* an ``ids``-domain metric (``decode``) reads the tokens the decode produced
+  and never the vocabulary projection, which is what makes a text probe cheap
+  (§8) — asserted on the plan in ``tests/protocol/test_generate_plan.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import torch
+
+from causalab.neural.pytorch_hooks.metrics import compute_windowed_metric
+from causalab.neural.pytorch_hooks.outputs import MetricTable
+from causalab.protocol.errors import ProtocolError
+from causalab.protocol.schema import parse_document
+
+from tests.neural.pytorch_hooks._drive import executor_for
+from tests.neural.pytorch_hooks.conftest import TINY_LLAMA
+
+pytestmark = pytest.mark.smoke
+
+PROMPTS = ["the quick brown fox jumps", "a slow green turtle sleeps deeply today"]
+BUDGET = 6
+
+
+def _doc(metric: dict[str, Any], *, anchor: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "version": "1",
+        "model": {"key": TINY_LLAMA, "revision": "main"},
+        "data": {"base": {"dataset": "probe", "field": "input"}},
+        "positions": {
+            "window": {"generated": {"max_new_tokens": BUDGET}, **anchor},
+        },
+        "sites": {"lm_head": {"component": "lm_head"}},
+        "reads": {
+            "cont": {
+                "site": "lm_head",
+                "pos": "window",
+                "model": "original",
+                "input": "base",
+            }
+        },
+        "metrics": {"scored": metric},
+        "save": [
+            {
+                "value": "scored",
+                "model": "original",
+                "input": "base",
+                "file_path": "scored.parquet",
+            }
+        ],
+    }
+
+
+def _run(bundle, raw: dict[str, Any], *, columns: dict[str, list[Any]] | None = None):
+    executor = executor_for(
+        raw, bundle, base_texts=PROMPTS, extra_columns=columns or {}
+    )
+    executor.run_all()
+    return executor
+
+
+def _score(executor, name: str = "scored", of: str = "cont") -> list[list[Any]]:
+    metric = executor.doc.metrics[name]
+    ids = executor.generated_ids(of) if str(metric.kind) == "decode" else None
+    return compute_windowed_metric(
+        metric,
+        executor.windowed_value(of),
+        executor.rows_for_metrics(),
+        executor.bundle.tokenizer,
+        generated_ids=ids,
+    )
+
+
+def test_top_k_scores_every_generated_step(llama_bundle):
+    """One value per step, and each one is the distribution *after* that
+    token — so its argmax is the token the decode emitted next (§2.3's
+    off-by-one, seen from the metric side)."""
+    executor = _run(
+        llama_bundle,
+        _doc({"kind": "top_k", "of": "cont", "k": 1}, anchor={"all": True}),
+    )
+    values = _score(executor)
+    (continuation,) = executor._continuations.values()
+    assert [len(row) for row in values] == list(continuation.widths)
+    for example, row in enumerate(values):
+        assert all(len(value["tokens"]) == 1 for value in row)  # k=1
+        # compare ids, not the decoded strings: a decode round-trip is lossy
+        top_ids = executor.windowed_value("cont")[example].argmax(dim=-1)
+        assert torch.equal(top_ids[:-1], continuation.token_ids[example][1 : len(row)])
+
+
+def test_decode_returns_the_text_the_model_generated(llama_bundle):
+    executor = _run(
+        llama_bundle, _doc({"kind": "decode", "of": "cont"}, anchor={"all": True})
+    )
+    values = _score(executor)
+    (continuation,) = executor._continuations.values()
+    for example, row in enumerate(values):
+        assert len(row) == 1  # one string per example, not one per step
+        assert row[0] == llama_bundle.tokenizer.decode(continuation.real_ids(example))
+
+
+def test_decode_over_a_window_reads_only_that_window(llama_bundle):
+    executor = _run(
+        llama_bundle, _doc({"kind": "decode", "of": "cont"}, anchor={"index": -1})
+    )
+    values = _score(executor)
+    (continuation,) = executor._continuations.values()
+    for example, row in enumerate(values):
+        last = continuation.real_ids(example)[-1]
+        assert row == [llama_bundle.tokenizer.decode([last])]
+
+
+def test_a_variable_the_model_said_scores_where_it_said_it(llama_bundle):
+    """Run once to learn what this model says, then ask for it by name: the
+    anchor must land on the steps that produced that text."""
+    seen = _run(
+        llama_bundle, _doc({"kind": "decode", "of": "cont"}, anchor={"all": True})
+    )
+    (continuation,) = seen._continuations.values()
+    texts = [
+        llama_bundle.tokenizer.decode(continuation.real_ids(row))
+        for row in range(len(PROMPTS))
+    ]
+    said = [text[len(text) // 3 : len(text) // 3 + 4] or text[:2] for text in texts]
+
+    executor = _run(
+        llama_bundle,
+        _doc({"kind": "decode", "of": "cont"}, anchor={"variable": "said"}),
+        columns={"said": said},
+    )
+    values = _score(executor)
+    for example, row in enumerate(values):
+        assert row, f"row {example} addressed no steps for {said[example]!r}"
+        assert said[example] in row[0]
+
+
+def test_a_variable_the_model_never_said_is_null_and_unmatched(llama_bundle):
+    """The one place a loud refusal would be wrong: whether the model says
+    the thing is the experiment, so it has to come back as data."""
+    executor = _run(
+        llama_bundle,
+        _doc({"kind": "decode", "of": "cont"}, anchor={"variable": "said"}),
+        columns={"said": ["definitely-not-generated-xyzzy"] * len(PROMPTS)},
+    )
+    values = _score(executor)
+    assert values == [[], []]
+
+    table = MetricTable()
+    table.add_windowed(
+        "scored",
+        values,
+        {},
+        "digest",
+        steps=None,
+        matched=[bool(steps) for steps in executor.addressed_steps("cont")],
+    )
+    assert len(table.rows) == len(PROMPTS)  # the example survives as a row
+    assert all(row["value"] is None for row in table.rows)
+    assert all(row["matched"] is False for row in table.rows)
+    assert all(row["step"] is None for row in table.rows)
+
+
+def test_rows_name_the_step_they_scored(llama_bundle):
+    executor = _run(
+        llama_bundle,
+        _doc({"kind": "top_k", "of": "cont", "k": 1}, anchor={"all": True}),
+    )
+    steps = executor.addressed_steps("cont")
+    table = MetricTable()
+    table.add_windowed(
+        "scored",
+        _score(executor),
+        {},
+        "digest",
+        steps=steps,
+        matched=[bool(row) for row in steps],
+    )
+    assert [row["step"] for row in table.rows] == [s for row in steps for s in row]
+    assert all(row["matched"] is True for row in table.rows)
+    assert all(row["value"] is not None for row in table.rows)
+
+
+def test_a_prompt_frame_read_keeps_its_single_row_shape(llama_bundle):
+    """The windowed path is for the continuation; a prompt-frame metric must
+    not grow a step column just because this landed."""
+    raw = _doc({"kind": "top_k", "of": "cont", "k": 1}, anchor={"all": True})
+    raw["positions"] = {"window": {"index": -1}}
+    raw["reads"]["cont"]["pos"] = "window"
+    executor = _run(llama_bundle, raw)
+    assert executor.is_generated("cont") is False
+    table = MetricTable()
+    table.add("scored", [1.0, 2.0], {}, "digest")
+    assert all("step" not in row for row in table.rows)
+
+
+def test_kl_across_different_widths_refuses(llama_bundle):
+    """A comparison needs a position-for-position pairing; two continuations
+    that stopped at different places have none."""
+    executor = _run(
+        llama_bundle,
+        _doc({"kind": "top_k", "of": "cont", "k": 1}, anchor={"all": True}),
+    )
+    metric = parse_document(
+        {
+            "version": "1",
+            "model": {"key": TINY_LLAMA},
+            "data": {"base": {"dataset": "probe", "field": "input"}},
+            "sites": {"lm_head": {"component": "lm_head"}},
+            "reads": {
+                "a": {
+                    "site": "lm_head",
+                    "pos": -1,
+                    "model": "original",
+                    "input": "base",
+                },
+                "b": {
+                    "site": "lm_head",
+                    "pos": -1,
+                    "model": "original",
+                    "input": "base",
+                },
+            },
+            "metrics": {"d": {"kind": "kl", "of": "a", "target": "b"}},
+            "save": [
+                {
+                    "value": "d",
+                    "model": "original",
+                    "input": "base",
+                    "file_path": "d.parquet",
+                }
+            ],
+        }
+    ).metrics["d"]
+    windows = executor.windowed_value("cont")
+    with pytest.raises(ProtocolError, match="different position counts"):
+        compute_windowed_metric(
+            metric,
+            windows,
+            executor.rows_for_metrics(),
+            executor.bundle.tokenizer,
+            target_windows=[windows[0][:1], windows[1]],
+        )

--- a/tests/neural/pytorch_hooks/test_positions_frame.py
+++ b/tests/neural/pytorch_hooks/test_positions_frame.py
@@ -230,3 +230,110 @@ def test_a_generated_position_without_a_decode_refuses():
     spec = PositionSpec(generated={"max_new_tokens": 4}, index=-1)
     with pytest.raises(ProtocolError, match="does not exist until"):
         resolve_position(spec, batch, 0)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# the `variable` anchor inside the continuation (§2.3)
+# --------------------------------------------------------------------------- #
+
+
+def _said(text: str, pieces: list[str]) -> Continuation:
+    """A one-row decode whose tokens are ``pieces`` in order, with the char
+    spans incremental detokenization would have produced."""
+    offsets: list[tuple[int, int]] = []
+    cursor = 0
+    for piece in pieces:
+        offsets.append((cursor, cursor + len(piece)))
+        cursor += len(piece)
+    assert "".join(pieces) == text
+    return Continuation(
+        token_ids=torch.arange(len(pieces)).reshape(1, len(pieces)),
+        widths=(len(pieces),),
+        texts=(text,),
+        offsets=(tuple(offsets),),
+    )
+
+
+def _variable_spec() -> PositionSpec:
+    return PositionSpec(generated={"max_new_tokens": 8}, variable="answer")
+
+
+def test_variable_covers_the_tokens_that_said_it():
+    cont = _said(" the answer is Thursday", [" the", " answer", " is", " Thursday"])
+    steps = resolve_steps(
+        _variable_spec(),
+        cont,
+        0,
+        dataset_row={"answer": "Thursday"},
+        field="input",
+    )
+    assert steps == [3]
+
+
+def test_variable_the_model_never_said_yields_no_positions():
+    """Zero occurrences is the experiment's answer, not an error: the row
+    contributes nothing and the run continues."""
+    cont = _said(" the answer is Friday", [" the", " answer", " is", " Friday"])
+    steps = resolve_steps(
+        _variable_spec(),
+        cont,
+        0,
+        dataset_row={"answer": "Thursday"},
+        field="input",
+    )
+    assert steps == []
+
+
+def test_variable_takes_the_first_occurrence():
+    """The prompt side demands exactly one occurrence; a generation may
+    repeat itself as a matter of course, so repetition must not crash."""
+    cont = _said(" Thursday, Thursday", [" Thursday", ",", " Thursday"])
+    steps = resolve_steps(
+        _variable_spec(),
+        cont,
+        0,
+        dataset_row={"answer": "Thursday"},
+        field="input",
+    )
+    assert steps == [0]
+
+
+def test_variable_spanning_a_merge_covers_every_token_it_touches():
+    """A sentencepiece-style split is why the spans are built as the tokens
+    arrive: the match starts inside one piece and ends inside another, and
+    both pieces produced it."""
+    cont = _said(" Thursday", [" Th", "urs", "day"])
+    steps = resolve_steps(
+        _variable_spec(),
+        cont,
+        0,
+        dataset_row={"answer": "hursda"},
+        field="input",
+    )
+    assert steps == [0, 1, 2]
+
+
+def test_variable_does_not_reach_past_a_rows_width():
+    """A row that stopped early cannot have said anything in the steps after
+    its EOS, even though the batch decoded them."""
+    cont = _said(" a Thursday", [" a", " Thursday"])
+    narrowed = Continuation(
+        token_ids=cont.token_ids,
+        widths=(1,),
+        texts=cont.texts,
+        offsets=cont.offsets,
+    )
+    steps = resolve_steps(
+        _variable_spec(),
+        narrowed,
+        0,
+        dataset_row={"answer": "Thursday"},
+        field="input",
+    )
+    assert steps == []
+
+
+def test_variable_without_its_row_refuses():
+    cont = _said(" Thursday", [" Thursday"])
+    with pytest.raises(ProtocolError, match="needs its dataset row"):
+        resolve_steps(_variable_spec(), cont, 0)

--- a/tests/neural/pytorch_hooks/test_run_corpus.py
+++ b/tests/neural/pytorch_hooks/test_run_corpus.py
@@ -269,3 +269,32 @@ def test_11_probe_generate_runs_and_scores(roots, tmp_path):
     for value in probe["value"]:
         top = json.loads(value)
         assert len(top["tokens"]) == 1 and len(top["probs"]) == 1
+
+
+def test_12_probe_variable_scores_every_step_and_reports_what_was_said(roots, tmp_path):
+    """PR-2's surface end to end: a metric per decode step, an ids-domain
+    metric that never touches the vocabulary, and a `variable` anchor whose
+    misses come back as data.
+
+    Tiny-random says nothing resembling a weekday, so `said_answer` matches
+    nowhere — which is the case worth pinning: the run finishes, the rows
+    survive, and `matched` says why the values are null.
+    """
+    code = _run("12_probe_variable_im.json", roots, tmp_path, "sites.target.layer=1")
+    assert code == 0
+
+    per_step = pd.read_parquet(tmp_path / "per_step.parquet")
+    examples = per_step["example"].nunique()
+    assert len(per_step) == examples * 8  # one row per (example, decode step)
+    assert sorted(per_step["step"].unique()) == list(range(8))
+    assert per_step["matched"].all()
+
+    said = pd.read_parquet(tmp_path / "said.parquet")
+    assert len(said) == examples  # decode reduces the window to one string
+    assert said["step"].isna().all()  # no single step owns a joined string
+    assert said["value"].notna().all()
+
+    where = load_file(tmp_path / "where.safetensors")
+    # every row missed, so every row addressed zero positions: the harvest is
+    # empty but still shaped per example, and nothing about the run failed
+    assert where["where"].shape[:2] == (examples, 0)

--- a/tests/protocol/corpus_digests.json
+++ b/tests/protocol/corpus_digests.json
@@ -135,5 +135,11 @@
     "points": [
       "22bbf1cad970b283c308a8208caba1212558d76cb8091c4858039653ad483d12"
     ]
+  },
+  "12_probe_variable_im.json": {
+    "document": "0e896ba580e777685fb6f52fe65a2c6799d0df81e590cc85f472aefb06182d5b",
+    "points": [
+      "0e896ba580e777685fb6f52fe65a2c6799d0df81e590cc85f472aefb06182d5b"
+    ]
   }
 }

--- a/tests/protocol/test_corpus.py
+++ b/tests/protocol/test_corpus.py
@@ -38,6 +38,7 @@ CORPUS_SHAPE = [
     ("09_das_apply_im.json", 1, 2, {"paired_forward"}),
     ("10_task_table_iia_im.json", 1, 3, {"full_logits", "paired_forward"}),
     ("11_probe_generate_im.json", 1, 1, {"generate", "full_logits"}),
+    ("12_probe_variable_im.json", 1, 1, {"generate", "full_logits"}),
 ]
 
 

--- a/tests/protocol/test_generate_plan.py
+++ b/tests/protocol/test_generate_plan.py
@@ -131,3 +131,49 @@ def test_decode_depth_is_not_in_the_group_digest():
     long = group_for(probe_doc({"index": -1}, budget=32))
     assert short.decode_depth != long.decode_depth
     assert short.digest == long.digest
+
+
+def _decode_metric(raw: dict[str, Any]) -> dict[str, Any]:
+    """Replace the document's metrics with a single ids-domain one."""
+    raw["metrics"] = {"said": {"kind": "decode", "of": "logits"}}
+    raw["save"] = [
+        {
+            "value": "said",
+            "model": "patched",
+            "input": "base",
+            "file_path": "said.parquet",
+        }
+    ]
+    return in_order(raw)
+
+
+def test_an_ids_only_metric_obliges_no_distribution():
+    """A text probe reads the tokens the decode produced. Nothing downstream
+    wants the vocabulary, so the plan must not ask for it — this is the
+    whole reason metric kinds carry a domain."""
+    group = group_for(_decode_metric(probe_doc({"all": True})))
+    (item,) = group.materialize
+    assert item.needs_distribution is False
+
+
+def test_a_distribution_metric_still_obliges_one():
+    group = group_for(probe_doc({"all": True}))
+    (item,) = group.materialize
+    assert item.needs_distribution is True
+
+
+def test_saving_the_read_obliges_a_distribution_even_with_an_ids_metric():
+    """The save manifest is the other consumer: an ids-domain metric does not
+    excuse writing the read itself to disk."""
+    raw = _decode_metric(probe_doc({"all": True}))
+    raw["save"].append(
+        {
+            "value": "logits",
+            "model": "patched",
+            "input": "base",
+            "file_path": "logits.safetensors",
+        }
+    )
+    group = group_for(in_order(raw))
+    (item,) = group.materialize
+    assert item.needs_distribution is True

--- a/tests/protocol/test_schema.py
+++ b/tests/protocol/test_schema.py
@@ -289,3 +289,20 @@ def test_prompt_frame_positions_carry_no_generated():
     not defaulted, so existing canonical forms are untouched."""
     pos = parse_document(base_doc()).reads["v_cf"].pos
     assert isinstance(pos, PositionSpec) and pos.generated is None
+
+
+def test_decode_metric_takes_no_value_fields():
+    raw = base_doc()
+    raw["metrics"]["ld"] = {"kind": "decode", "of": "logits"}
+    metric = parse_document(in_order(raw)).metrics["ld"]
+    assert str(metric.kind) == "decode"
+    assert dict(metric.fields) == {}
+
+
+def test_decode_metric_rejects_a_stray_field():
+    """The kind reduces the tokens a decode produced; there is nothing to
+    parametrize, so an extra key is a typo, not an option."""
+    raw = base_doc()
+    raw["metrics"]["ld"] = {"kind": "decode", "of": "logits", "k": 1}
+    with pytest.raises(ParseError):
+        parse_document(in_order(raw))

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -664,3 +664,34 @@ def test_the_checklist_and_the_spec_agree_on_how_many_rules_there_are():
     section = spec.read_text().split("## 5. Validation")[1].split("\n## ")[0]
     numbered = {int(m) for m in re.findall(r"^(\d+)\. ", section, flags=re.M)}
     assert numbered == set(range(1, CHECKLIST_RULES + 1))
+
+
+def test_rule_4_decode_over_a_prompt_frame_read():
+    """``decode`` reduces tokens a decode produced; in the prompt frame there
+    are none — only tokens that were given."""
+    doc = base_doc()
+    doc["metrics"] = {"said": {"kind": "decode", "of": "logits"}}
+    doc["save"] = [
+        {
+            "value": "said",
+            "model": "patched",
+            "input": "base",
+            "file_path": "said.parquet",
+        }
+    ]
+    err = expect_rule(4, doc)
+    assert "generated" in str(err)
+
+
+def test_decode_over_a_continuation_read_is_legal():
+    doc = _reads_the_continuation(base_doc())
+    doc["metrics"] = {"said": {"kind": "decode", "of": "logits"}}
+    doc["save"] = [
+        {
+            "value": "said",
+            "model": "patched",
+            "input": "base",
+            "file_path": "said.parquet",
+        }
+    ]
+    parse_and_validate(doc)

--- a/tests/protocols/12_probe_variable_im.json
+++ b/tests/protocols/12_probe_variable_im.json
@@ -1,0 +1,29 @@
+{
+  "version": "1",
+  "description": "Exploration probe, scored: greedy-decode 8 tokens, reduce every step's distribution, read the answer back as text, and harvest the residual stream at the tokens where the model *said* the answer. The `variable` anchor searches the continuation, so a row where the model never said it contributes no positions and scores null rather than failing the run; `decode` reduces ids the decode already produced, so the text costs no vocabulary projection.",
+  "model": {"key": "meta-llama/Llama-3.1-8B", "revision": "main"},
+  "data": {
+    "base": {"dataset": "weekdays/train", "field": "input"}
+  },
+  "positions": {
+    "continuation": {"generated": {"max_new_tokens": 8}, "all": true},
+    "said_answer": {"generated": {"max_new_tokens": 8}, "variable": "answer"}
+  },
+  "sites": {
+    "target":  {"component": "block_output", "layer": 18},
+    "lm_head": {"component": "lm_head"}
+  },
+  "reads": {
+    "steps": {"site": "lm_head", "pos": "continuation", "model": "original", "input": "base"},
+    "where": {"site": "target", "pos": "said_answer", "model": "original", "input": "base"}
+  },
+  "metrics": {
+    "per_step": {"kind": "top_k", "of": "steps", "k": 1},
+    "said": {"kind": "decode", "of": "steps"}
+  },
+  "save": [
+    {"value": "per_step", "model": "original", "input": "base", "file_path": "per_step.parquet"},
+    {"value": "said", "model": "original", "input": "base", "file_path": "said.parquet"},
+    {"value": "where", "model": "original", "input": "base", "file_path": "where.safetensors"}
+  ]
+}


### PR DESCRIPTION
Closes the second half of #25. PR-1 (#40) made the continuation addressable; this makes it
**scoreable**, and finishes the `variable` anchor it left refused.

## What was in the way

Two refusals, both on the metric path, and both hit by the first `pos: "all"` continuation
read anyone writes:

| refusal | where | why it fires |
|---|---|---|
| `metric read spans N positions` | `metrics.py:189` `_last_pos_logits` | a continuation read addresses every step of its row |
| `read is ragged … metrics reduce one aligned position` | `executor.py:153` `dense_value` | rows stop at their own EOS, so widths differ by construction |

Plus `encoding.py:276`, which refused the `variable` anchor the schema already accepted.

## Metrics reduce per position

The kinds are **not** reimplemented. The addressed positions flatten into one pseudo-batch,
`compute_metric` runs over it exactly as before, and the results re-nest per example — so
`token_form`, form groups and `match` modes behave identically whether a read addresses one
position or twelve.

The table says what it scored: one row per (example, step), carrying the `step` and a
`matched` flag. **An example that addressed nothing still gets one row**, with a null value
and `matched: false` — after a group-by, "the model never said it" must not look like "it
said it and scored 0". Prompt-frame metrics are untouched, down to the absent columns.

## `decode`, and why metric kinds now carry a domain

`decode` is the first `ids`-domain kind: it reduces the tokens the decode produced, never the
vocabulary projection. That distinction is the whole point of the domain — `_needs_distribution`
already had the shape of it in its docstring — because it is what makes a **text probe cost no
projection at all**:

```json
"positions": {"window": {"generated": {"max_new_tokens": 8}, "all": true}},
"reads":     {"cont": {"site": "lm_head", "pos": "window", "model": "probed", "input": "base"}},
"metrics":   {"said": {"kind": "decode", "of": "cont"}}
```

`causalab explain` reports that group's obligation as `needs_distribution: false`, and the
backend must not build one. A `decode` over a prompt-frame read is a load error: there are no
produced tokens there, only given ones.

## The `variable` anchor

The expensive half already existed — the decode's incremental detokenization carries each
generated token's char span, which a post-hoc `offset_mapping` cannot reconstruct across
merges. Two rules differ from the prompt side, both because the continuation is a *result*
rather than an input:

- **first** occurrence, not "exactly one" — a generation repeats itself as a matter of course,
  and the prompt-side uniqueness rule would turn that into a crash that depends on what the
  model happened to say;
- **zero** occurrences yield zero positions rather than refusing — whether the model says the
  thing is usually the experiment, so a miss comes back as data.

## Tests

- `tests/neural/pytorch_hooks/test_positions_frame.py` — the anchor found, absent, repeated,
  spanning a sentencepiece merge, clipped by a row's width, and without its row.
- `tests/neural/pytorch_hooks/test_generate_metrics.py` — per-step `top_k` against the decode's
  own ids (§2.3's off-by-one from the metric side); `decode` equals the tokenizer's decode of
  the addressed window; a variable the model *did* say lands on the steps that said it; one it
  never said scores null with `matched: false`; a prompt-frame metric keeps its single-row
  shape; mismatched `kl` widths refuse.
- `tests/protocol/test_generate_plan.py` — an ids-only metric obliges no distribution; a
  distribution metric still does; saving the read obliges one regardless.
- `tests/protocol/test_validation_rules.py` — `decode` over a prompt-frame read refuses (rule 4);
  over a continuation read it validates.
- `tests/protocols/12_probe_variable_im.json` + `test_run_corpus.py` — the worked example end to
  end through the CLI. Tiny-random says nothing resembling a weekday, so the anchor matches
  nowhere: the run finishes, `per_step.parquet` has one row per (example, step), `said.parquet`
  has one string per example with a null `step`, and the harvest is empty but still shaped per
  example.

**The eleven existing corpus digests are byte-identical** — nothing here changes any existing
document's canonical form.

## Two corrections owed to #25's text

Filed as a comment there rather than implemented: the issue still describes a **teacher-forced
replay tier** for `variable` documents and asserts replay parity, which #40 made unnecessary by
capturing non-`lm_head` continuation activations per decode step directly
(`executor.py:288–299`); and its worked example is numbered `10_…` while the corpus documents
landed as `11_` and `12_`.

## Non-goals

Sampling; decode-step writes (still a load error); stopping conditions beyond EOS + budget;
`scope`/`relative_to` inside the continuation; a string-comparison `match` over generated text
(the ids domain is now the place for it, but it needs its own answer-column semantics);
`train` with a generated position.
