### PR TITLE
Point the nnterp pin at our fork for the text-tower fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,24 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-# nnterp packaging fix merged upstream (ndif-team/nnterp#49): released wheels
-# (<= 1.3.0) omit nnterp/data/ (package-data globs tests/* but not data/*),
-# which crashes `python -m nnterp run_tests` on import. This pins the upstream
-# merge commit while awaiting a PyPI release that ships the fix; dropping this
-# git source is then a routine dep bump.
-nnterp = { git = "https://github.com/ndif-team/nnterp", rev = "b4a31274692f986e493ac5d20ba20a4ec8640955" }
+# Pinned to our fork, which is upstream b4a3127 plus one unmerged fix. Two
+# reasons stack here, and both are temporary:
+#
+#   1. Packaging (ndif-team/nnterp#49, merged upstream): released wheels
+#      (<= 1.3.0) omit nnterp/data/ — package-data globs tests/* but not
+#      data/* — which crashes `python -m nnterp run_tests` on import. Fixed at
+#      b4a3127, still awaiting a PyPI release that ships it.
+#   2. Text-tower loading (ndif-team/nnterp#52, open): nnsight's LanguageModel
+#      refuses any config registered with AutoModelForImageTextToText, so it
+#      cannot load qwen3_5_moe — the text tower of Qwen3.6-35B-A3B, and the
+#      target of the hookpoint-vocabulary work — even though
+#      AutoModelForCausalLM resolves to it cleanly. Without this, nnterp cannot
+#      load the model at all.
+#
+# 45f386b is b4a3127 + those two commits, so this is a strict superset of the
+# upstream pin. When #52 merges, repoint at ndif-team and drop this note's item
+# 2; when a wheel ships both, drop the git source entirely.
+nnterp = { git = "https://github.com/can-goodfire/nnterp", rev = "45f386b7cf27f104b2585849ed76416d8fad11c8" }
 
 [tool.pytest.ini_options]
 markers = [

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ requires-dist = [
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "nnsight", specifier = ">=0.6" },
-    { name = "nnterp", git = "https://github.com/ndif-team/nnterp?rev=b4a31274692f986e493ac5d20ba20a4ec8640955" },
+    { name = "nnterp", git = "https://github.com/can-goodfire/nnterp?rev=45f386b7cf27f104b2585849ed76416d8fad11c8" },
     { name = "numpy" },
     { name = "openai", specifier = ">=1.50.0" },
     { name = "pandas" },
@@ -2797,8 +2797,8 @@ wheels = [
 
 [[package]]
 name = "nnterp"
-version = "1.3.1.dev14+gb4a312746"
-source = { git = "https://github.com/ndif-team/nnterp?rev=b4a31274692f986e493ac5d20ba20a4ec8640955#b4a31274692f986e493ac5d20ba20a4ec8640955" }
+version = "1.3.1.dev16+g45f386b7c"
+source = { git = "https://github.com/can-goodfire/nnterp?rev=45f386b7cf27f104b2585849ed76416d8fad11c8#45f386b7cf27f104b2585849ed76416d8fad11c8" }
 dependencies = [
     { name = "nnsight" },
     { name = "transformers" },


### PR DESCRIPTION
Unblocks us from waiting on [ndif-team/nnterp#52](https://github.com/ndif-team/nnterp/pull/52) to be reviewed.

## Why

nnsight's `LanguageModel` refuses any config registered with `AutoModelForImageTextToText`. `qwen3_5_moe` — the text tower of [Qwen3.6-35B-A3B](https://huggingface.co/Qwen/Qwen3.6-35B-A3B), and the target of the hookpoint-vocabulary work — is registered there *and* under `AutoModelForCausalLM`, so the tower loads cleanly and the refusal is over-broad. Without the fix, nnterp cannot load the model at all.

#52 fixes it upstream and is open for review. This repoints the existing git source at our fork in the meantime.

## What changes

One line plus its comment:

```
-nnterp = { git = "https://github.com/ndif-team/nnterp", rev = "b4a3127…" }
+nnterp = { git = "https://github.com/can-goodfire/nnterp", rev = "45f386b…" }
```

`45f386b` is the previous upstream pin `b4a3127` plus the two commits in #52, so this is a **strict superset** of what we had — the packaging fix ([#49](https://github.com/ndif-team/nnterp/pull/49)) that motivated the git source in the first place is still in there. The comment now records both reasons and how each retires:

- when #52 merges → repoint at `ndif-team`
- when a PyPI wheel ships both fixes → drop the git source entirely

`uv lock --upgrade-package nnterp` moved only nnterp (`1.3.1.dev14+gb4a312746` → `1.3.1.dev16+g45f386b7c`); the other 239 packages are unchanged.

## Verification

Installed from the fork's **public URL** rather than a local path, to prove the fork actually unblocks a clean checkout:

```
uv pip install "nnterp @ git+https://github.com/can-goodfire/nnterp@can/text-tower-loading"
```

`tiny-random/qwen3.5-moe` then loads as `Qwen3_5MoeForCausalLM` with no vision tower attached, and traces to logits.

## One caveat worth knowing

This branch still resolves **transformers 4.57.1**, which carries no `qwen3_5_moe`. So the fix ships here but cannot be *exercised* on this lineage until a `transformers >= 5.16` bump reaches it. That bump landed downstream on `can/protocol-refactor` (#46, merged) and whether it should also come to the path to `main` is a separate call — flagging rather than bundling it.

Also worth noting: `can/protocol-refactor` has no nnterp dependency at all, so the round-1 hookpoint work is **not** blocked by #52 — its `pytorch_hooks` backend loads the tower through `AutoModelForCausalLM` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)