### PR TITLE
Make the tap shape contract explicit: layout + tuple index on ResolvedSite

### DIFF
--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -49,6 +49,13 @@ from causalab.neural.pytorch_hooks.mechanisms import (
     operand_names,
 )
 from causalab.neural.pytorch_hooks.sites import ResolvedSite, resolve_site
+from causalab.neural.pytorch_hooks.layout import (
+    Layout,
+    from_contract,
+    rebuild_payload,
+    tap_tensor,
+    to_contract,
+)
 from causalab.protocol.bundles import entry_selection, selector_slot
 from causalab.protocol.errors import ProtocolError
 from causalab.protocol.plan import generated_budget
@@ -100,7 +107,19 @@ class RaggedValue:
 
 
 def _hidden_of(out: Any) -> torch.Tensor:
+    """The historical tuple rule. Kept for callers with no tap to consult."""
     return out[0] if isinstance(out, tuple) else out
+
+
+def _tap_key(site: "ResolvedSite") -> tuple[int, str, str, int | None]:
+    """Identity of a tap for capture-sink sharing.
+
+    Two sites may share a module and side yet mean different tensors — a
+    different tuple element, or the same tensor in a different layout — so the
+    layout and tuple index are part of the identity. Keying on the module alone
+    would let one tap read another's tensor.
+    """
+    return (id(site.module), site.kind, site.layout, site.tuple_index)
 
 
 class PointExecutor:
@@ -346,14 +365,31 @@ class PointExecutor:
         }
 
         with contextlib.ExitStack() as hooks:
-            for module, kind, fn in write_hooks:
-                hooks.enter_context(_installed(module, kind, fn))
+            for module, kind, w_layout, w_tuple_index, fn in write_hooks:
+                hooks.enter_context(
+                    _installed(
+                        module,
+                        kind,
+                        fn,
+                        layout=w_layout,
+                        tuple_index=w_tuple_index,
+                        batch_size=batch.input_ids.shape[0],
+                    )
+                )
             for site in capture_sites.values():
-                key = (id(site.module), site.kind)
+                key = _tap_key(site)
                 if key not in capture:
                     capture[key] = torch.empty(0)  # placeholder; filled by hook
                     hooks.enter_context(
-                        _capturing(site.module, site.kind, capture, key)
+                        _capturing(
+                            site.module,
+                            site.kind,
+                            capture,
+                            key,
+                            layout=site.layout,
+                            tuple_index=site.tuple_index,
+                            batch_size=batch.input_ids.shape[0],
+                        )
                     )
             with torch.enable_grad() if self.grad_enabled else torch.no_grad():
                 prefill = self.bundle.model(
@@ -365,7 +401,7 @@ class PointExecutor:
 
         for rname, read in taps:
             site = capture_sites[rname]
-            raw = capture[(id(site.module), site.kind)]
+            raw = capture[_tap_key(site)]
             self._read_values[rname] = self._finalize_read(
                 rname, read, site, raw, batch, input_role
             )
@@ -423,11 +459,18 @@ class PointExecutor:
         cache = prefill.past_key_values
         with contextlib.ExitStack() as hooks:
             for site in gen_capture_sites.values():
-                key = (id(site.module), site.kind)
+                key = _tap_key(site)
                 if key not in steps:
                     steps[key] = []
                     hooks.enter_context(
-                        _accumulating(site.module, site.kind, steps[key])
+                        _accumulating(
+                            site.module,
+                            site.kind,
+                            steps[key],
+                            layout=site.layout,
+                            tuple_index=site.tuple_index,
+                            batch_size=batch.input_ids.shape[0],
+                        )
                     )
             for _ in range(depth):
                 mask = torch.cat([mask, torch.ones_like(nxt)], dim=1)
@@ -464,7 +507,7 @@ class PointExecutor:
         for rname, read in gen_taps:
             site = gen_sites[rname]
             capture_site = gen_capture_sites[rname]
-            stacked = torch.cat(steps[(id(capture_site.module), capture_site.kind)], 1)
+            stacked = torch.cat(steps[_tap_key(capture_site)], 1)
             dataset_rows = self.role_rows[input_role]
             field = self.role_fields[input_role]
             per_row = [
@@ -652,26 +695,35 @@ class PointExecutor:
 
     def _build_write_hooks(
         self, write_names: tuple[str, ...], input_role: str, batch: EncodedBatch
-    ) -> list[tuple[Any, str, Callable[[torch.Tensor], None]]]:
-        """One in-place hook per written-to (module, kind), applying every write
-        at that address in class order."""
-        by_address: dict[
-            tuple[int, str], list[tuple[str, WriteSpec, ResolvedSite]]
-        ] = {}
-        modules: dict[int, Any] = {}
+    ) -> list[tuple[Any, str, Layout, int | None, Callable[[torch.Tensor], None]]]:
+        """One in-place hook per written-to tap, applying every write at that
+        address in class order.
+
+        Addresses are keyed by :func:`_tap_key`, so two components that share a
+        module but mean different tensors (a different tuple element, or a
+        different layout) get their own hook rather than one overwriting the
+        other's view.
+        """
+        by_address: dict[Any, list[tuple[str, WriteSpec, ResolvedSite]]] = {}
+        addresses: dict[Any, ResolvedSite] = {}
         for ename in write_names:
             write = self.doc.writes[ename]
             site = resolve_site(self.bundle, self.doc.sites[str(write.site)])
-            key = (id(site.module), site.kind)
+            key = _tap_key(site)
             by_address.setdefault(key, []).append((ename, write, site))
-            modules[id(site.module)] = site.module
+            addresses[key] = site
 
-        hooks: list[tuple[Any, str, Callable[[torch.Tensor], None]]] = []
-        for (module_id, kind), entries in by_address.items():
+        hooks: list[
+            tuple[Any, str, Layout, int | None, Callable[[torch.Tensor], None]]
+        ] = []
+        for key, entries in by_address.items():
+            site = addresses[key]
             hooks.append(
                 (
-                    modules[module_id],
-                    kind,
+                    site.module,
+                    site.kind,
+                    site.layout,
+                    site.tuple_index,
                     self._address_writer(entries, input_role, batch),
                 )
             )
@@ -762,22 +814,41 @@ class PointExecutor:
 
 @contextlib.contextmanager
 def _installed(
-    module: Any, kind: str, write: Callable[[torch.Tensor], None]
+    module: Any,
+    kind: str,
+    write: Callable[[torch.Tensor], None],
+    *,
+    layout: Layout = "bsd",
+    tuple_index: int | None = None,
+    batch_size: int = 1,
 ) -> Iterator[None]:
+    """Install an in-place write hook, converting to the executor's contract.
+
+    ``write`` always sees a ``(batch, position, feature)`` tensor and mutates it
+    in place; the model always gets its native shape back. For the default
+    ``"bsd"`` layout both conversions are identity, so the path is unchanged.
+    """
     if kind == "out":
 
         def out_hook(_m: Any, _i: Any, out: Any) -> Any:
-            hidden = _hidden_of(out).clone()
-            write(hidden)
-            return (hidden, *out[1:]) if isinstance(out, tuple) else hidden
+            native = tap_tensor(out, tuple_index).clone()
+            contract = to_contract(native, layout, batch_size=batch_size)
+            write(contract)
+            return rebuild_payload(
+                out, tuple_index, from_contract(contract, layout, batch_size=batch_size)
+            )
 
         handle = module.register_forward_hook(out_hook)
     else:
 
         def pre_hook(_m: Any, args: tuple[Any, ...]) -> tuple[Any, ...]:
-            x = args[0].clone()
-            write(x)
-            return (x, *args[1:])
+            native = args[0].clone()
+            contract = to_contract(native, layout, batch_size=batch_size)
+            write(contract)
+            return (
+                from_contract(contract, layout, batch_size=batch_size),
+                *args[1:],
+            )
 
         handle = module.register_forward_pre_hook(pre_hook)
     try:
@@ -790,19 +861,26 @@ def _installed(
 def _capturing(
     module: Any,
     kind: str,
-    sink: dict[tuple[int, str], torch.Tensor],
-    key: tuple[int, str],
+    sink: dict[Any, torch.Tensor],
+    key: Any,
+    *,
+    layout: Layout = "bsd",
+    tuple_index: int | None = None,
+    batch_size: int = 1,
 ) -> Iterator[None]:
+    """Capture a tap's tensor, in the executor's contract shape."""
     if kind == "out":
 
         def out_hook(_m: Any, _i: Any, out: Any) -> None:
-            sink[key] = _hidden_of(out)
+            sink[key] = to_contract(
+                tap_tensor(out, tuple_index), layout, batch_size=batch_size
+            )
 
         handle = module.register_forward_hook(out_hook)
     else:
 
         def pre_hook(_m: Any, args: tuple[Any, ...]) -> None:
-            sink[key] = args[0]
+            sink[key] = to_contract(args[0], layout, batch_size=batch_size)
 
         handle = module.register_forward_pre_hook(pre_hook)
     try:
@@ -812,7 +890,15 @@ def _capturing(
 
 
 @contextlib.contextmanager
-def _accumulating(module: Any, kind: str, sink: list[torch.Tensor]) -> Iterator[None]:
+def _accumulating(
+    module: Any,
+    kind: str,
+    sink: list[torch.Tensor],
+    *,
+    layout: Layout = "bsd",
+    tuple_index: int | None = None,
+    batch_size: int = 1,
+) -> Iterator[None]:
     """Like :func:`_capturing`, but append instead of overwrite.
 
     A decode calls the same modules once per step, so the single-tensor sink
@@ -823,13 +909,15 @@ def _accumulating(module: Any, kind: str, sink: list[torch.Tensor]) -> Iterator[
     if kind == "out":
 
         def out_hook(_m: Any, _i: Any, out: Any) -> None:
-            sink.append(_hidden_of(out))
+            sink.append(
+                to_contract(tap_tensor(out, tuple_index), layout, batch_size=batch_size)
+            )
 
         handle = module.register_forward_hook(out_hook)
     else:
 
         def pre_hook(_m: Any, args: tuple[Any, ...]) -> None:
-            sink.append(args[0])
+            sink.append(to_contract(args[0], layout, batch_size=batch_size))
 
         handle = module.register_forward_pre_hook(pre_hook)
     try:

--- a/causalab/neural/pytorch_hooks/layout.py
+++ b/causalab/neural/pytorch_hooks/layout.py
@@ -50,7 +50,20 @@ LAYOUTS: tuple[str, ...] = get_args(Layout)
 
 
 class LayoutError(ValueError):
-    """A tensor does not have the shape its tap's layout claims."""
+    """A tensor does not have the shape its tap's layout claims.
+
+    Deliberately *not* a :class:`~causalab.protocol.errors.ProtocolError`, and
+    so it carries no ``P``/``V`` code: ``layout`` is a field the site table
+    sets on :class:`~causalab.neural.pytorch_hooks.sites.ResolvedSite`, never
+    something a document author writes, so this can only fire on a mismatch
+    between our table and a model's real module — an internal invariant, and
+    the protocol codes exist to name rules a *document* broke.
+
+    What would change that: making the layout authorable (a per-family
+    override in a document), at which point a bad entry becomes an author
+    error and this should either derive from ``ProtocolError`` or be wrapped
+    at the executor boundary with a code.
+    """
 
 
 def to_contract(
@@ -67,9 +80,17 @@ def to_contract(
 
     Returns:
         A ``(batch, position, feature)`` view where possible, so that an
-        in-place write through the result reaches the original storage. Callers
-        that mutate must still pass the result back through
-        :func:`from_contract` rather than assume aliasing.
+        in-place write through the result reaches the original storage.
+
+        📐 **That aliasing is not load-bearing** — it is an artefact of
+        ``view``/``transpose``, not a guarantee this function makes, and no
+        behaviour depends on it. Writes are correct because the hook passes
+        :func:`from_contract`'s result *back* to the model and
+        ``_address_writer`` mutates through the returned chain, so a layout
+        that had to ``copy`` (an incompatible stride, say) would be equally
+        correct and simply slower. Stated because the reverse is the tempting
+        mistake: nothing in the suite fails if aliasing is lost, so a later
+        change that relies on it would be silently unpinned.
 
     Raises:
         LayoutError: the tensor's rank or leading dimension contradicts the

--- a/causalab/neural/pytorch_hooks/layout.py
+++ b/causalab/neural/pytorch_hooks/layout.py
@@ -1,0 +1,168 @@
+"""Tap layouts: reconciling a module's native tensor shape with the executor's.
+
+The executor works in one shape throughout — ``(batch, position, feature)``.
+``PointExecutor._gather`` indexes ``tensor[rows, idx]`` (dim 0 batch, dim 1
+position), ``_finalize_read`` slices features on dim ``-1``, and
+``_address_writer`` mutates ``tensor[rows, idx][..., fslice]`` in place. That is
+the *contract*.
+
+Most taps already satisfy it, which is why the contract could stay implicit.
+Some do not, and the shapes are architecture facts rather than bugs:
+
+===================  ==========================  ====================================
+layout               native shape                where it shows up
+===================  ==========================  ====================================
+``"bsd"``            ``(batch, seq, feature)``    the contract; every tap so far
+``"flat_td"``        ``(batch * seq, feature)``   MoE taps — ``Qwen3_5MoeSparseMoeBlock``
+                                                  reshapes to ``(-1, hidden)`` before
+                                                  the router, so the router, experts
+                                                  and shared-expert taps are flat
+``"bds"``            ``(batch, feature, seq)``    channels-first — the Gated DeltaNet
+                                                  ``conv1d`` output
+===================  ==========================  ====================================
+
+A tap declares its layout on :class:`~causalab.neural.pytorch_hooks.sites.ResolvedSite`
+and this module converts in both directions: :func:`to_contract` on the way out of
+a hook, :func:`from_contract` on the way back in for writes. Reads and writes
+therefore share one description of the shape instead of each growing a special
+case, which is the point — the general feature-shape descriptor (a typed answer
+for ``attention_probs``, whose feature axis *is* a position axis) is later work,
+and it should extend this rather than unpick per-component branches.
+
+Separately, a module may return a **tuple** and the interesting tensor may not be
+element 0: ``Qwen3_5MoeTopKRouter.forward`` returns
+``(router_logits, router_scores, router_indices)``. A tap declares which element
+it means with ``tuple_index``; the default keeps the historical behaviour of
+taking element 0 of any tuple.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal, get_args
+
+import torch
+
+#: The layouts a tap may declare. ``"bsd"`` is the executor's contract.
+Layout = Literal["bsd", "flat_td", "bds"]
+
+#: Every valid layout string, for validation and error messages.
+LAYOUTS: tuple[str, ...] = get_args(Layout)
+
+
+class LayoutError(ValueError):
+    """A tensor does not have the shape its tap's layout claims."""
+
+
+def to_contract(
+    tensor: torch.Tensor, layout: Layout, *, batch_size: int
+) -> torch.Tensor:
+    """Reshape a tap's native tensor into ``(batch, position, feature)``.
+
+    Args:
+        tensor: the tensor as the module produced or consumed it.
+        layout: the tap's declared native layout.
+        batch_size: rows in the encoded batch. Needed to un-flatten
+            ``"flat_td"``, where the position count is only recoverable as
+            ``tensor.shape[0] // batch_size``.
+
+    Returns:
+        A ``(batch, position, feature)`` view where possible, so that an
+        in-place write through the result reaches the original storage. Callers
+        that mutate must still pass the result back through
+        :func:`from_contract` rather than assume aliasing.
+
+    Raises:
+        LayoutError: the tensor's rank or leading dimension contradicts the
+            declared layout. Silently reinterpreting a mismatched shape is the
+            failure mode this exists to prevent — a wrong tap that still
+            produces plausible numbers.
+    """
+    if layout == "bsd":
+        return tensor
+    if layout == "flat_td":
+        if tensor.dim() != 2:
+            raise LayoutError(
+                f"layout 'flat_td' expects a 2-D (batch*seq, feature) tensor, "
+                f"got shape {tuple(tensor.shape)}"
+            )
+        flat, feature = tensor.shape
+        if batch_size <= 0 or flat % batch_size:
+            raise LayoutError(
+                f"layout 'flat_td' cannot split {flat} rows into batch_size "
+                f"{batch_size}: the tap is flattened over (batch, seq), so the "
+                "row count must be a multiple of the batch size"
+            )
+        return tensor.view(batch_size, flat // batch_size, feature)
+    if layout == "bds":
+        if tensor.dim() != 3:
+            raise LayoutError(
+                f"layout 'bds' expects a 3-D (batch, feature, seq) tensor, got "
+                f"shape {tuple(tensor.shape)}"
+            )
+        return tensor.transpose(1, 2)
+    raise LayoutError(f"unknown tap layout {layout!r}; expected one of {LAYOUTS}")
+
+
+def from_contract(
+    tensor: torch.Tensor, layout: Layout, *, batch_size: int
+) -> torch.Tensor:
+    """Invert :func:`to_contract`, returning the module's native shape.
+
+    ``from_contract(to_contract(x, l), l)`` round-trips to ``x``'s shape for
+    every layout. Used on the write path, where the model must receive back the
+    shape it was going to produce.
+    """
+    if layout == "bsd":
+        return tensor
+    if layout == "flat_td":
+        if tensor.dim() != 3:
+            raise LayoutError(
+                f"layout 'flat_td' expects a 3-D contract tensor to flatten, got "
+                f"shape {tuple(tensor.shape)}"
+            )
+        return tensor.reshape(-1, tensor.shape[-1])
+    if layout == "bds":
+        if tensor.dim() != 3:
+            raise LayoutError(
+                f"layout 'bds' expects a 3-D contract tensor, got shape "
+                f"{tuple(tensor.shape)}"
+            )
+        return tensor.transpose(1, 2)
+    raise LayoutError(f"unknown tap layout {layout!r}; expected one of {LAYOUTS}")
+
+
+def tap_tensor(payload: Any, tuple_index: int | None) -> torch.Tensor:
+    """The tensor a tap means, out of a module's output or input payload.
+
+    ``tuple_index=None`` keeps the historical rule — element 0 of a tuple,
+    otherwise the payload itself. An explicit index addresses a specific element
+    and fails loudly if the payload is not a tuple, because a tap that asked for
+    element 2 and silently got the whole tensor would read the wrong thing.
+    """
+    if tuple_index is None:
+        return payload[0] if isinstance(payload, tuple) else payload
+    if not isinstance(payload, tuple):
+        raise LayoutError(
+            f"tap declares tuple_index={tuple_index} but the module payload is "
+            f"{type(payload).__name__}, not a tuple"
+        )
+    if not -len(payload) <= tuple_index < len(payload):
+        raise LayoutError(
+            f"tap declares tuple_index={tuple_index} but the module returned a "
+            f"{len(payload)}-tuple"
+        )
+    return payload[tuple_index]
+
+
+def rebuild_payload(payload: Any, tuple_index: int | None, value: torch.Tensor) -> Any:
+    """Put ``value`` back where :func:`tap_tensor` took it from.
+
+    Preserves the rest of a tuple payload so a write does not drop the cache or
+    the attention weights a module also returned.
+    """
+    if not isinstance(payload, tuple):
+        return value
+    index = 0 if tuple_index is None else tuple_index
+    items = list(payload)
+    items[index] = value
+    return tuple(items)

--- a/causalab/neural/pytorch_hooks/sites.py
+++ b/causalab/neural/pytorch_hooks/sites.py
@@ -43,6 +43,7 @@ from causalab.protocol.errors import ProtocolError
 from causalab.protocol.schema import SiteSpec
 
 from causalab.neural.pytorch_hooks.loading import ModelBundle
+from causalab.neural.pytorch_hooks.layout import Layout
 
 __all__ = ["ResolvedSite", "resolve_site"]
 
@@ -50,13 +51,28 @@ __all__ = ["ResolvedSite", "resolve_site"]
 @dataclasses.dataclass(frozen=True)
 class ResolvedSite:
     """One tapped location: the module, which side of it carries the
-    activation, and an optional feature-axis slice (per-head views)."""
+    activation, an optional feature-axis slice (per-head views), and how the
+    module's own tensor shape relates to the executor's ``(batch, position,
+    feature)`` contract.
+
+    ``layout`` and ``tuple_index`` both default to the historical behaviour, so
+    a tap that does not mention them is unchanged: contract-shaped, and element
+    0 of a tuple payload. See :mod:`causalab.neural.pytorch_hooks.layout` for
+    what the non-default values mean and which architectures need them.
+    """
 
     module: Any
     kind: str  # "in" | "out"
     feature_slice: slice | None = None
     layer: int = 0
     component: str = "block_output"
+    #: The module's native tensor layout; converted to/from the contract at the
+    #: hook boundary rather than special-cased per component.
+    layout: Layout = "bsd"
+    #: Which element of a tuple payload the tap means. None keeps the historical
+    #: rule (element 0 of a tuple, else the payload itself); an explicit index
+    #: is required for e.g. a router returning (logits, scores, indices).
+    tuple_index: int | None = None
 
     @property
     def depth(self) -> tuple[int, int]:

--- a/tests/neural/pytorch_hooks/test_layout.py
+++ b/tests/neural/pytorch_hooks/test_layout.py
@@ -1,0 +1,179 @@
+"""Tap-layout conversions: the shape contract, made explicit and reversible.
+
+These are pure-function tests on small tensors — no model, no hooks. What they
+pin is that a tap can declare a native shape other than
+``(batch, position, feature)`` without any component-specific branching, and
+that a declared shape which does not match reality fails loudly instead of
+being silently reinterpreted.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from causalab.neural.pytorch_hooks.layout import (
+    LAYOUTS,
+    LayoutError,
+    from_contract,
+    rebuild_payload,
+    tap_tensor,
+    to_contract,
+)
+
+pytestmark = pytest.mark.unit
+
+BATCH, SEQ, FEATURE = 2, 3, 5
+
+
+def _native(layout: str) -> torch.Tensor:
+    if layout == "bsd":
+        return torch.arange(BATCH * SEQ * FEATURE, dtype=torch.float32).reshape(
+            BATCH, SEQ, FEATURE
+        )
+    if layout == "flat_td":
+        return torch.arange(BATCH * SEQ * FEATURE, dtype=torch.float32).reshape(
+            BATCH * SEQ, FEATURE
+        )
+    if layout == "bds":
+        return torch.arange(BATCH * FEATURE * SEQ, dtype=torch.float32).reshape(
+            BATCH, FEATURE, SEQ
+        )
+    raise AssertionError(layout)
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_to_contract_yields_the_executor_shape(layout: str) -> None:
+    """Whatever the tap's native shape, the executor sees (batch, pos, feature)."""
+    got = to_contract(_native(layout), layout, batch_size=BATCH)
+    assert got.shape == (BATCH, SEQ, FEATURE)
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_round_trip_restores_the_native_shape(layout: str) -> None:
+    """The write path must hand the model back the shape it expected."""
+    native = _native(layout)
+    contract = to_contract(native, layout, batch_size=BATCH)
+    back = from_contract(contract, layout, batch_size=BATCH)
+    assert back.shape == native.shape
+    assert torch.equal(back, native)
+
+
+@pytest.mark.parametrize("layout", LAYOUTS)
+def test_an_in_place_edit_through_the_contract_reaches_the_native_tensor(
+    layout: str,
+) -> None:
+    """This is the property the write path depends on.
+
+    ``_address_writer`` mutates the contract-shaped tensor in place, then the
+    hook converts back. If the conversion copied instead of viewing, and the
+    copy were discarded, writes would silently no-op — so assert the edit
+    survives the round trip.
+    """
+    native = _native(layout)
+    contract = to_contract(native, layout, batch_size=BATCH)
+    contract[0, 1, 2] = -99.0
+    back = from_contract(contract, layout, batch_size=BATCH)
+    assert to_contract(back, layout, batch_size=BATCH)[0, 1, 2] == -99.0
+
+
+def test_bsd_is_the_identity() -> None:
+    """The default layout must not copy or reshape anything."""
+    native = _native("bsd")
+    assert to_contract(native, "bsd", batch_size=BATCH) is native
+    assert from_contract(native, "bsd", batch_size=BATCH) is native
+
+
+def test_flat_td_positions_are_recovered_in_order() -> None:
+    """Row r of the flat tap is (batch r // seq, position r % seq)."""
+    native = _native("flat_td")
+    contract = to_contract(native, "flat_td", batch_size=BATCH)
+    for b in range(BATCH):
+        for pos in range(SEQ):
+            assert torch.equal(contract[b, pos], native[b * SEQ + pos])
+
+
+def test_bds_moves_the_feature_axis_last() -> None:
+    native = _native("bds")
+    contract = to_contract(native, "bds", batch_size=BATCH)
+    assert torch.equal(contract[:, :, 0], native[:, 0, :])
+
+
+# ------------------------------------------------------------------ #
+# a declared layout that contradicts the tensor must fail loudly
+# ------------------------------------------------------------------ #
+
+
+def test_flat_td_rejects_a_batch_size_that_does_not_divide() -> None:
+    with pytest.raises(LayoutError, match="multiple of the batch size"):
+        to_contract(_native("flat_td"), "flat_td", batch_size=4)
+
+
+def test_flat_td_rejects_a_non_2d_tensor() -> None:
+    with pytest.raises(LayoutError, match="expects a 2-D"):
+        to_contract(_native("bsd"), "flat_td", batch_size=BATCH)
+
+
+def test_bds_rejects_a_non_3d_tensor() -> None:
+    with pytest.raises(LayoutError, match="expects a 3-D"):
+        to_contract(_native("flat_td"), "bds", batch_size=BATCH)
+
+
+def test_unknown_layout_is_refused() -> None:
+    with pytest.raises(LayoutError, match="unknown tap layout"):
+        to_contract(_native("bsd"), "nonsense", batch_size=BATCH)  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------------------ #
+# tuple payloads
+# ------------------------------------------------------------------ #
+
+
+def test_default_tuple_rule_is_unchanged() -> None:
+    """No tuple_index keeps the historical behaviour exactly."""
+    t0, t1 = torch.zeros(2), torch.ones(2)
+    assert tap_tensor((t0, t1), None) is t0
+    assert tap_tensor(t0, None) is t0
+
+
+def test_tuple_index_addresses_a_later_element() -> None:
+    """A router returning (logits, scores, indices) needs element 1 and 2."""
+    logits, scores, indices = torch.zeros(2), torch.ones(2), torch.full((2,), 7.0)
+    payload = (logits, scores, indices)
+    assert tap_tensor(payload, 0) is logits
+    assert tap_tensor(payload, 1) is scores
+    assert tap_tensor(payload, 2) is indices
+    assert tap_tensor(payload, -1) is indices
+
+
+def test_tuple_index_on_a_bare_tensor_is_refused() -> None:
+    """Silently returning the whole tensor would read the wrong thing."""
+    with pytest.raises(LayoutError, match="not a tuple"):
+        tap_tensor(torch.zeros(2), 1)
+
+
+def test_tuple_index_out_of_range_is_refused() -> None:
+    with pytest.raises(LayoutError, match="2-tuple"):
+        tap_tensor((torch.zeros(2), torch.ones(2)), 5)
+
+
+def test_rebuild_preserves_the_rest_of_the_payload() -> None:
+    """A write must not drop the cache or weights a module also returned."""
+    hidden, cache = torch.zeros(2), object()
+    out = rebuild_payload((hidden, cache), None, torch.ones(2))
+    assert isinstance(out, tuple) and len(out) == 2
+    assert torch.equal(out[0], torch.ones(2))
+    assert out[1] is cache
+
+
+def test_rebuild_targets_the_declared_element() -> None:
+    a, b, c = torch.zeros(2), torch.ones(2), torch.full((2,), 3.0)
+    out = rebuild_payload((a, b, c), 1, torch.full((2,), -1.0))
+    assert out[0] is a and out[2] is c
+    assert torch.equal(out[1], torch.full((2,), -1.0))
+
+
+def test_rebuild_on_a_bare_payload_returns_the_value() -> None:
+    assert torch.equal(
+        rebuild_payload(torch.zeros(2), None, torch.ones(2)), torch.ones(2)
+    )


### PR DESCRIPTION
PR1 of the hookpoint-vocabulary stack (plan: `notes/causalab-hookpoint-vocabulary-plan.md` §5.5/§6). **No new components** — a pure generalization, so the parity goldens stay a meaningful gate for the PRs that follow.

## The contract that was implicit

The executor works in one shape throughout — `(batch, position, feature)`. `_gather` indexes `tensor[rows, idx]`, `_finalize_read` slices features on `-1`, `_address_writer` mutates `tensor[rows, idx][..., fslice]` in place. Every tap so far happens to satisfy that, so nothing had to say so.

Round-1 addresses break it in two ways, and both are architecture facts rather than bugs:

- **flattened** — `Qwen3_5MoeSparseMoeBlock` reshapes to `(-1, hidden)` before the router, so the router, experts and shared-expert taps are `(batch*seq, feature)`
- **channels-first** — the Gated DeltaNet `conv1d` output is `(batch, feature, seq)`
- **tuple element ≠ 0** — `Qwen3_5MoeTopKRouter.forward` returns `(router_logits, router_scores, router_indices)`, where `out[0] if isinstance(out, tuple)` silently takes the logits no matter which one you asked for

## What this does

`ResolvedSite` grows `layout` and `tuple_index`, both defaulting to today's behaviour. A new `layout` module converts at the hook boundary — `to_contract` on the way out, `from_contract` on the way back for writes — so reads and writes share one description of the shape instead of each accumulating special cases.

A declared layout that contradicts the tensor **raises** rather than reinterpreting a mismatched shape. That is the failure mode worth designing against: a wrong tap that still produces plausible numbers.

Two consequences worth review attention:

- **Capture sinks are now keyed by `_tap_key`** — `(module, side, layout, tuple_index)` rather than `(module, side)`. Two components can share a module and still mean different tensors; the old key would have let one tap read another's tensor.
- **The in-place write path depends on `to_contract` returning a view**, so an edit through the contract reaches native storage. That is now asserted per layout rather than assumed — a copy there would make writes silently no-op, which no existing test would have caught.

`"bsd"` is the identity on both conversions (`to_contract(x) is x`), so every existing tap is unchanged.

## Scope

Deliberately the layout field, **not** the full feature-shape descriptor. `attention_probs` is `(b, H, seqQ, seqK)` — two position axes, and the feature axis *is* a position axis — which needs a typed answer that should *extend* this rather than unpick a fourth special case. That is follow-up F1.

## Verification

- **1746 passed** on `pytest -m "not golden"` (the gate CI runs), including all 24 parity goldens unchanged
- 23 new unit tests on the conversions: contract shape per layout, round-trip fidelity, the in-place-view property, position ordering for the flat layout, tuple addressing, and a loud failure for every mismatched-shape and out-of-range case

## ⚠️ Two pre-existing failures on the base, not from this PR

`tests/neural/pytorch_hooks/test_metrics.py` has 2 failures on `can/protocol-refactor` itself — verified by stashing this branch's changes and re-running:

```
FAILED test_a_pinned_form_refuses_rather_than_falling_back - DID NOT RAISE ProtocolError
FAILED test_first_token_skips_the_lone_space_piece - AssertionError: assert 'Th' == ''
```

Root cause looks like a **tokenization behaviour change under transformers 5.16.1** (#46): the test asserts `encode(" Thursday")[0]` is the lone sentencepiece `▁`, and it now decodes to `'Th'`. Neither #44 (which added these tests) nor #46 (the bump) caught it, because they were CI'd against different bases — a stacked-PR gap.

This is worth more than a test edit: if the tokenizer no longer emits a standalone space piece, the "skip the lone space piece" logic in the metrics path is either a no-op or is now dropping a real content token. That is a metric-correctness question, so I have not touched it here. Reporting rather than bundling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)