### PR TITLE
PR0.5 — make the stack's base green: the tokenizer witness, and #45's unfinished metric-table migration

### DIFF
--- a/causalab/neural/pytorch_hooks/metrics.py
+++ b/causalab/neural/pytorch_hooks/metrics.py
@@ -22,6 +22,14 @@ form instead of letting the tokenizer's vocabulary decide. Under ``auto``,
 tokens and disagree — exactly the condition under which it can be silently
 wrong.
 
+📐 One limit of that warning, introduced by the transformers 5 bump: a
+sentencepiece family that has dropped the legacy dummy prefix encodes ``" X"``
+and ``"X"`` to the *same* id, so the two forms can never disagree there. On such
+a tokenizer ``token_form`` has only one row to name, the warning is structurally
+dark, and neither is a defect — but it does mean the punctuation trap above is a
+BPE-family hazard, and a document cannot be checked against it by pinning
+``token_form`` on a sentencepiece model.
+
 ``match`` is the one kind that can be told otherwise, and only explicitly
 (§2.10): its ``expected`` column may hold a **list** of equivalent surface
 forms (synonyms, casings), and ``"mode": "first_token"`` credits a form's
@@ -159,12 +167,23 @@ def column_first_token_id(
 
     A single-token value resolves exactly as :func:`column_token_id` does, so
     ``first_token`` is a strict generalization of ``exact``. A multi-token
-    value resolves to the first piece that carries text: sentencepiece
-    families encode a leading space as its own ``▁`` piece, and crediting
-    *that* would score every space-prefixed answer alike — the first piece an
-    argmax can distinguish is the one after it (``" Thursday"`` →
-    ``▁ Th urs day`` → ``Th``, which is also what the model emits in
-    context).
+    value resolves to the first piece that carries text: a sentencepiece family
+    can encode a leading space as its own ``▁`` piece, and crediting *that*
+    would score every space-prefixed answer alike — the first piece an argmax
+    can distinguish is the one after it, which is also what the model emits in
+    context.
+
+    📐 Which values trigger that is tokenizer- *and* version-dependent, so the
+    skip is written as a property of the piece (does it decode to text?) rather
+    than of a known value. Under transformers 4.x the tiny Llama tokenizer
+    emitted the lone ``▁`` for any space-prefixed word (``" Thursday"`` →
+    ``▁ Th urs day``); 5.16.1 dropped that legacy dummy prefix, so
+    ``" Thursday"`` is now ``Th urs day`` — and the skip is what makes this
+    function return the same id, ``Th``, across the bump. It is not dead code:
+    5.16.1 still emits the lone ``▁`` whenever the first character has no
+    merged ``▁X`` piece — digits, non-Latin scripts, emoji, ligatures
+    (``" 3.14"`` → ``▁ 3 . 1 4``) — and byte-level BPE families still split a
+    whitespace run off the front (gpt2 ``"  ?"`` → ``' '`` + ``' ?'``).
 
     What this cannot know is whether the table's answer space is
     first-token-distinct — two answers sharing a first piece would both score.

--- a/tests/neural/pytorch_hooks/test_generate_metrics.py
+++ b/tests/neural/pytorch_hooks/test_generate_metrics.py
@@ -58,7 +58,7 @@ def _doc(metric: dict[str, Any], *, anchor: dict[str, Any]) -> dict[str, Any]:
                 "value": "scored",
                 "model": "original",
                 "input": "base",
-                "file_path": "scored.parquet",
+                "file_path": "scored.json",
             }
         ],
     }
@@ -240,7 +240,7 @@ def test_kl_across_different_widths_refuses(llama_bundle):
                     "value": "d",
                     "model": "original",
                     "input": "base",
-                    "file_path": "d.parquet",
+                    "file_path": "d.json",
                 }
             ],
         }

--- a/tests/neural/pytorch_hooks/test_metrics.py
+++ b/tests/neural/pytorch_hooks/test_metrics.py
@@ -36,7 +36,14 @@ def _logits(tokenizer, favored: str, disfavored: str) -> torch.Tensor:
 
 
 def test_space_prefixed_first_resolution(tokenizer):
-    # sentencepiece: " Monday" is two pieces, "Monday" is the ▁Monday piece
+    # 📐 transformers 5.16.1: this sentencepiece tokenizer dropped the legacy
+    # dummy prefix, so " Monday" and "Monday" BOTH encode to the single ▁Monday
+    # piece. The two forms agree because they are now the same id — not, as
+    # under transformers 4.x, because the spaced form was ▁+▁Monday and `auto`
+    # fell back. Pinned so the reason cannot drift silently again.
+    assert tokenizer.encode(" Monday", add_special_tokens=False) == tokenizer.encode(
+        "Monday", add_special_tokens=False
+    )
     assert column_token_id(tokenizer, " Monday") == column_token_id(tokenizer, "Monday")
     with pytest.raises(ProtocolError):
         column_token_id(tokenizer, " Tuesday")  # 3 pieces either way — refuse
@@ -165,11 +172,39 @@ def test_space_prefixed_form_is_pinnable(gpt2_tokenizer):
     )
 
 
-def test_a_pinned_form_refuses_rather_than_falling_back(tokenizer):
-    """Pinning a form means it: sentencepiece makes " Monday" two pieces, and
-    `space_prefixed` must refuse instead of quietly using the bare piece."""
+def test_a_pinned_form_refuses_rather_than_falling_back(gpt2_tokenizer):
+    """Pinning a form means it: `space_prefixed` must refuse rather than quietly
+    hand back the bare row it was told not to use.
+
+    The witness moved to gpt2 in the transformers 5 bump. This contract needs a
+    value whose bare form is ONE token while its space-prefixed form is several
+    — 📐 under 5.16.1 the sentencepiece tokenizer no longer has one, because it
+    dropped the legacy dummy prefix and now encodes both forms identically (see
+    ``test_the_two_forms_collapse_on_sentencepiece``). gpt2's byte-level BPE
+    still separates them and is unchanged across the bump: "haus" is [30404],
+    " haus" is [387, 385]."""
+    assert len(gpt2_tokenizer.encode("haus", add_special_tokens=False)) == 1
+    assert len(gpt2_tokenizer.encode(" haus", add_special_tokens=False)) == 2
+
     with pytest.raises(ProtocolError):
-        column_token_id(tokenizer, "Monday", token_form="space_prefixed")
+        column_token_id(gpt2_tokenizer, "haus", token_form="space_prefixed")
+    # and the bare row it refused to fall back to is genuinely resolvable
+    assert column_token_id(gpt2_tokenizer, "haus", token_form="bare") == 30404
+
+
+def test_the_two_forms_collapse_on_sentencepiece(tokenizer):
+    """📐 The hazard the transformers 5 bump introduced, recorded as a test.
+
+    Dropping the legacy dummy prefix means " X" and "X" encode identically on
+    this family, so `token_form` cannot separate the two rows here and
+    `_ambiguous_under_auto` can never fire — the once-per-column warning that
+    exists because a punctuation `match` read a flat 0.000 across all 48 layers
+    of a gpt2-xl scan is structurally dark on sentencepiece. Nothing to fix in
+    the resolver (there is only one row to name); pinned so that the day a
+    tokenizer separates them again, this test says so out loud."""
+    assert column_token_id(tokenizer, "Monday", token_form="bare") == column_token_id(
+        tokenizer, "Monday", token_form="space_prefixed"
+    )
 
 
 def test_match_scores_a_punctuation_answer_only_under_bare(gpt2_tokenizer):
@@ -194,8 +229,10 @@ def test_auto_warns_once_per_column_when_the_forms_disagree(gpt2_tokenizer):
 
 
 def test_auto_is_silent_when_there_is_nothing_to_disambiguate(tokenizer, recwarn):
-    """Sentencepiece " Monday" is two pieces, so only the bare form resolves —
-    no choice was made and no warning is owed."""
+    """📐 Under transformers 5.16.1 this tokenizer encodes " Monday" and "Monday"
+    to the SAME id, so the two forms cannot disagree — no choice was made and no
+    warning is owed. (Under 4.x the same silence held for the opposite reason:
+    the spaced form was two pieces, so only the bare form resolved.)"""
     column_token_ids(tokenizer, [" Monday", "Monday"])
     assert [w for w in recwarn if issubclass(w.category, UserWarning)] == []
 
@@ -256,17 +293,49 @@ def test_first_token_mode_credits_a_multi_token_answer(tokenizer):
     assert compute_metric(first, logits, [{"ans": " Thursday"}], tokenizer) == [1.0]
 
 
-def test_first_token_skips_the_lone_space_piece(tokenizer):
-    """The sentencepiece trap: " Thursday" encodes as ▁ + Th + urs + day, so
-    crediting the *first* id would credit the bare-space piece — which every
-    space-prefixed answer shares, making every answer match."""
-    space_piece = tokenizer.encode(" Thursday", add_special_tokens=False)[0]
-    assert tokenizer.decode([space_piece]).strip() == ""
-    assert column_first_token_id(tokenizer, " Thursday") != space_piece
-    assert (
-        column_first_token_id(tokenizer, " Thursday")
-        == tokenizer.encode("Thursday", add_special_tokens=False)[0]
+class _LoneSpacePieceTokenizer:
+    """A tokenizer whose leading space is its own piece — the trap, distilled.
+
+    Which *values* trigger the trap is a property of a released tokenizer and it
+    moved under transformers 5; the rule that `first_token` must never credit a
+    whitespace-only piece is a property of :func:`column_first_token_id`. Pinning
+    the rule against a stub keeps it honest across bumps, and
+    :func:`test_first_token_skips_a_real_lone_space_piece` keeps a live witness."""
+
+    _PIECES = {0: " ", 1: "Th", 2: "urs", 3: "day"}
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+        return [0, 1, 2, 3] if text.startswith(" ") else [1, 2, 3]
+
+    def decode(self, ids) -> str:
+        return "".join(self._PIECES[int(i)] for i in ids)
+
+
+def test_first_token_skips_the_lone_space_piece():
+    """The trap: crediting the *first* id would credit the bare-space piece —
+    which every space-prefixed answer shares, making every answer match."""
+    tok = _LoneSpacePieceTokenizer()
+    assert tok.decode([tok.encode(" Thursday")[0]]).strip() == ""  # the premise
+    assert column_first_token_id(tok, " Thursday") == 1  # "Th", not the space
+
+
+def test_first_token_skips_a_real_lone_space_piece(tokenizer):
+    """The live witness on a real sentencepiece tokenizer.
+
+    📐 Under transformers 5.16.1 this tokenizer stopped emitting a lone ▁ for an
+    ordinary space-prefixed word — " Thursday" is now [Th, urs, day] — but still
+    emits one whenever the first character has no merged ▁X piece: digits,
+    non-Latin scripts, emoji, ligatures. Measured: encode(" 3.14") is
+    [29871, 29941, 29889, 29896, 29946] and 29871 decodes to "". So the skip is
+    load-bearing, not dead code. A failure of the premise below means the
+    witness moved, not that the behaviour broke — the behaviour is pinned in
+    :func:`test_first_token_skips_the_lone_space_piece`."""
+    ids = tokenizer.encode(" 3.14", add_special_tokens=False)
+    assert len(ids) > 1, "witness moved: ' 3.14' is a single token now"
+    assert tokenizer.decode([ids[0]]).strip() == "", (
+        "witness moved: ' 3.14' no longer leads with a whitespace-only piece"
     )
+    assert column_first_token_id(tokenizer, "3.14") == ids[1]
 
 
 def test_first_token_agrees_with_exact_on_single_token_answers(tokenizer):

--- a/tests/neural/pytorch_hooks/test_run_corpus.py
+++ b/tests/neural/pytorch_hooks/test_run_corpus.py
@@ -283,13 +283,13 @@ def test_12_probe_variable_scores_every_step_and_reports_what_was_said(roots, tm
     code = _run("12_probe_variable_im.json", roots, tmp_path, "sites.target.layer=1")
     assert code == 0
 
-    per_step = pd.read_parquet(tmp_path / "per_step.parquet")
+    per_step = table_frame(tmp_path / "per_step.json")
     examples = per_step["example"].nunique()
     assert len(per_step) == examples * 8  # one row per (example, decode step)
     assert sorted(per_step["step"].unique()) == list(range(8))
     assert per_step["matched"].all()
 
-    said = pd.read_parquet(tmp_path / "said.parquet")
+    said = table_frame(tmp_path / "said.json")
     assert len(said) == examples  # decode reduces the window to one string
     assert said["step"].isna().all()  # no single step owns a joined string
     assert said["value"].notna().all()

--- a/tests/protocol/corpus_digests.json
+++ b/tests/protocol/corpus_digests.json
@@ -137,9 +137,9 @@
     ]
   },
   "12_probe_variable_im.json": {
-    "document": "0e896ba580e777685fb6f52fe65a2c6799d0df81e590cc85f472aefb06182d5b",
+    "document": "d61509d25bcd8e977afe254d1448df5c7b8fe016e88e3f68c1d866f08b72fc18",
     "points": [
-      "0e896ba580e777685fb6f52fe65a2c6799d0df81e590cc85f472aefb06182d5b"
+      "d61509d25bcd8e977afe254d1448df5c7b8fe016e88e3f68c1d866f08b72fc18"
     ]
   }
 }

--- a/tests/protocol/test_generate_plan.py
+++ b/tests/protocol/test_generate_plan.py
@@ -141,7 +141,7 @@ def _decode_metric(raw: dict[str, Any]) -> dict[str, Any]:
             "value": "said",
             "model": "patched",
             "input": "base",
-            "file_path": "said.parquet",
+            "file_path": "said.json",
         }
     ]
     return in_order(raw)

--- a/tests/protocol/test_validation_rules.py
+++ b/tests/protocol/test_validation_rules.py
@@ -676,7 +676,7 @@ def test_rule_4_decode_over_a_prompt_frame_read():
             "value": "said",
             "model": "patched",
             "input": "base",
-            "file_path": "said.parquet",
+            "file_path": "said.json",
         }
     ]
     err = expect_rule(4, doc)
@@ -691,7 +691,7 @@ def test_decode_over_a_continuation_read_is_legal():
             "value": "said",
             "model": "patched",
             "input": "base",
-            "file_path": "said.parquet",
+            "file_path": "said.json",
         }
     ]
     parse_and_validate(doc)

--- a/tests/protocols/12_probe_variable_im.json
+++ b/tests/protocols/12_probe_variable_im.json
@@ -22,8 +22,8 @@
     "said": {"kind": "decode", "of": "steps"}
   },
   "save": [
-    {"value": "per_step", "model": "original", "input": "base", "file_path": "per_step.parquet"},
-    {"value": "said", "model": "original", "input": "base", "file_path": "said.parquet"},
+    {"value": "per_step", "model": "original", "input": "base", "file_path": "per_step.json"},
+    {"value": "said", "model": "original", "input": "base", "file_path": "said.json"},
     {"value": "where", "model": "original", "input": "base", "file_path": "where.safetensors"}
   ]
 }


### PR DESCRIPTION
`can/protocol-refactor` — the base the Qwen3.6 hookpoint stack (#46 merged, #47, #48) builds on — was red by **17** tests, not the 2 recorded in the plan note. Two unrelated regressions, one commit each. `pytest -m "not golden"` is now **1740 passed, 8 deselected, 0 failed**.

## 1. The transformers 5.16.1 bump moved a tokenizer witness (2 tests)

`#46` floored transformers at 5.16.1. That changed *tokenization*, which the parity goldens do not cover — 5.16.1 drops sentencepiece's legacy dummy prefix, so on the tiny Llama tokenizer `encode(" Thursday")` is now `[Th, urs, day]`, not `[▁, Th, urs, day]`.

The question was whether `column_first_token_id`'s "skip the piece that decodes to whitespace" filter is now a no-op to delete, or is silently eating a real content token. **Measured: neither — it is load-bearing.** The lone `▁` still appears whenever the first character has no merged `▁X` piece (digits, non-Latin scripts, emoji, ligatures — `encode(" 3.14")` is still `[29871, 29941, 29889, 29896, 29946]`), and byte-level BPE still splits a whitespace run off the front (gpt2 `"  ?"` → `' '` + `' ?'`). It fires on 20/25 probe values on tiny Llama, 5/25 on the Qwen MoE fixture, 2/25 on gpt2, and only ever skips a piece whose decode is empty-or-whitespace — which no content piece is.

Verified by mutation: with the filter removed, `first_token` credits `▁` (29871) instead of `"3"` (29941), and both tests below catch it.

So the code stays and the tests change:

- the lone-space **contract** is pinned against a stub tokenizer that cannot drift, because *which values* trigger it is a released-tokenizer property that just moved. A second test keeps a live witness (`" 3.14"`) and reports "witness moved" rather than "behaviour broke" if it shifts again.
- the **non-fallback** contract needs a value whose bare form is one token while its space-prefixed form is several. 5.16.1 leaves no such value on sentencepiece, so the witness moves to gpt2, whose byte-level BPE is byte-identical across the bump (`"haus"` is `[30404]`, `" haus"` is `[387, 385]`).

**One finding worth flagging.** On a sentencepiece family that has dropped the dummy prefix, `" X"` and `"X"` now encode to the *same* id — so `token_form` has one row to name there and `_ambiguous_under_auto` can never fire. The once-per-column warning exists because a punctuation `match` read a flat 0.000 across all 48 layers of a real gpt2-xl scan; that detector is now structurally dark on sentencepiece. Nothing to fix in the resolver, but it means the punctuation trap is a **BPE-family hazard** and a document cannot be checked against it by pinning `token_form` on a sentencepiece model. Recorded as a test plus a note in the module docstring.

Also corrects two docstrings that had inverted into passing for the opposite reason they state, with the reason now pinned so they cannot lie again silently.

## 2. #45 left its metric-table migration unfinished (15 tests)

Bisected: these pass at `f55efa8` (the #46 merge) and fail at `6e467ea` (after #45), so they arrived with **#45 (workflow-v2)**, not the bump. #45 tightened §2.12 to "JSON and safetensors are the only two formats" and changed the validator — `expected_ext = ".json" if is_metric else ".safetensors"`, was `".parquet"` — but left the call sites declaring `.parquet` behind.

Nothing in production needed changing, which is the reassuring part: `write_outputs` → `write_table` already emits JSON unconditionally, so the declared extension was the only thing out of step. That also means `test_run_corpus`'s two `pd.read_parquet` read-backs could never have run — `pd` is not imported in that module — so they move to `table_frame`, the JSON-table reader the rest of that file already uses.

Corpus digest pins regenerated with `update_corpus_digests.py`; the diff is confined to `12_probe_variable_im.json` (2 lines, its save block changed) and the other 11 documents' pins are byte-identical.

## Gates

- `pytest -m "not golden"` — **1740 passed, 8 deselected** (the GPU-only golden tier), 0 failed
- `pre-commit run --all-files` — passes repo-wide (ruff 0.14.5 pinned)
- the parity goldens are untouched

Plan note: `notes/causalab-hookpoint-vocabulary-plan.md` §6.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)