### PR TITLE
PR2 — round-1 block components, and make the mixer a per-layer fact

### DIFF
--- a/causalab/neural/pytorch_hooks/executor.py
+++ b/causalab/neural/pytorch_hooks/executor.py
@@ -589,15 +589,19 @@ class PointExecutor:
     def _read_stack(
         self, read: ReadSpec | WriteSpec, site: ResolvedSite
     ) -> FeaturizerStack:
-        width = (
-            (site.feature_slice.stop - site.feature_slice.start)
-            if site.feature_slice is not None
-            else component_width(
-                self.bundle.info,
-                site.component,
-                head=None,
-            )
-        )
+        # Lazily: `build_stack` ignores the width entirely when no featurizer is
+        # referenced (it returns an Identity stack), and some components have no
+        # width to give — `input_ids` carries integer ids on a position axis and
+        # `expert_idx` a routing table, so both refuse rather than invent one
+        # (§5.4). Asking for the width up front made an unfeaturized read of
+        # those impossible, which is not what the refusal is for: it exists to
+        # reject a *featurizer*, not a read.
+        if read.featurizer is None:
+            width = 0
+        elif site.feature_slice is not None:
+            width = site.feature_slice.stop - site.feature_slice.start
+        else:
+            width = component_width(self.bundle.info, site.component, head=None)
         return build_stack(
             read.featurizer,
             dict(self.doc.featurizers),

--- a/causalab/neural/pytorch_hooks/layout.py
+++ b/causalab/neural/pytorch_hooks/layout.py
@@ -19,6 +19,8 @@ layout               native shape                where it shows up
                                                   and shared-expert taps are flat
 ``"bds"``            ``(batch, feature, seq)``    channels-first — the Gated DeltaNet
                                                   ``conv1d`` output
+``"bs"``             ``(batch, seq)``             no feature axis at all — ``input_ids``,
+                                                  one integer token id per position
 ===================  ==========================  ====================================
 
 A tap declares its layout on :class:`~causalab.neural.pytorch_hooks.sites.ResolvedSite`
@@ -43,7 +45,14 @@ from typing import Any, Literal, get_args
 import torch
 
 #: The layouts a tap may declare. ``"bsd"`` is the executor's contract.
-Layout = Literal["bsd", "flat_td", "bds"]
+#:
+#: ``"bs"`` is the degenerate case and is deliberately *here* rather than
+#: special-cased in the executor: a tensor with no feature axis still has a
+#: native shape that differs from the contract, which is exactly what this
+#: module exists to reconcile. It is not the typed feature-shape descriptor that
+#: ``attention_probs`` needs (whose feature axis *is* a position axis) — there is
+#: no feature-axis ambiguity to describe, only an absent axis to add.
+Layout = Literal["bsd", "flat_td", "bds", "bs"]
 
 #: Every valid layout string, for validation and error messages.
 LAYOUTS: tuple[str, ...] = get_args(Layout)
@@ -121,6 +130,15 @@ def to_contract(
                 f"shape {tuple(tensor.shape)}"
             )
         return tensor.transpose(1, 2)
+    if layout == "bs":
+        if tensor.dim() != 2:
+            raise LayoutError(
+                f"layout 'bs' expects a 2-D (batch, seq) tensor, got shape "
+                f"{tuple(tensor.shape)}"
+            )
+        # unsqueeze, not reshape: a view, so the aliasing the write path relies
+        # on survives (even though the only 'bs' tap today is read-only)
+        return tensor.unsqueeze(-1)
     raise LayoutError(f"unknown tap layout {layout!r}; expected one of {LAYOUTS}")
 
 
@@ -149,6 +167,13 @@ def from_contract(
                 f"{tuple(tensor.shape)}"
             )
         return tensor.transpose(1, 2)
+    if layout == "bs":
+        if tensor.dim() != 3 or tensor.shape[-1] != 1:
+            raise LayoutError(
+                f"layout 'bs' expects a 3-D contract tensor of width 1 to drop "
+                f"back to (batch, seq), got shape {tuple(tensor.shape)}"
+            )
+        return tensor.squeeze(-1)
     raise LayoutError(f"unknown tap layout {layout!r}; expected one of {LAYOUTS}")
 
 

--- a/causalab/neural/pytorch_hooks/loading.py
+++ b/causalab/neural/pytorch_hooks/loading.py
@@ -49,6 +49,54 @@ class ModelBundle:
             self.model.transformer, "h"
         )
 
+    @property
+    def blocks(self) -> Any:
+        """The decoder-layer ModuleList, whichever tree this family uses."""
+        return (
+            self.model.transformer.h if self.is_gpt2_family else self.model.model.layers
+        )
+
+    def stream_at(self, layer: int) -> str:
+        """Which mixer stream ``layer`` actually carries.
+
+        A hybrid architecture varies this *per layer*: 📐 on
+        ``tiny-random/qwen3.5-moe`` the text tower is
+        ``['linear_attention', 'linear_attention', 'linear_attention',
+        'full_attention']`` — three Gated DeltaNet blocks and one gated full
+        attention. So a boolean family flag cannot answer this, and neither can
+        the config alone: it is read off the module that is really there, which
+        is what a hook has to attach to.
+
+        Returns one of ``"full_attention"`` (a ``self_attn``/``attn`` child) or
+        ``"linear_attention"`` (a ``linear_attn`` child).
+        """
+        block = self.blocks[layer]
+        if hasattr(block, "self_attn") or hasattr(block, "attn"):
+            return "full_attention"
+        if hasattr(block, "linear_attn"):
+            return "linear_attention"
+        raise ProtocolError(
+            "P4",
+            f"layer {layer} of {self.key!r} has no recognised mixer child "
+            f"(children={sorted(name for name, _ in block.named_children())}) — "
+            "extend the stream table in pytorch_hooks/loading.py",
+        )
+
+    def mixer_at(self, layer: int) -> Any:
+        """The attention/mixer module at ``layer``, whichever stream it is."""
+        block = self.blocks[layer]
+        for name in ("attn", "self_attn", "linear_attn"):
+            child = getattr(block, name, None)
+            if child is not None:
+                return child
+        self.stream_at(layer)  # raises with the useful message
+        raise AssertionError("unreachable")
+
+    @property
+    def streams(self) -> tuple[str, ...]:
+        """``stream_at`` for every layer — the whole tower's shape at a glance."""
+        return tuple(self.stream_at(i) for i in range(len(self.blocks)))
+
 
 @functools.lru_cache(maxsize=4)
 def load_model(

--- a/causalab/neural/pytorch_hooks/loading.py
+++ b/causalab/neural/pytorch_hooks/loading.py
@@ -31,6 +31,14 @@ __all__ = ["BundlePoint", "ModelBundle", "TensorBundle", "load_model"]
 _DTYPES = {"fp32": torch.float32, "bf16": torch.bfloat16, "fp16": torch.float16}
 
 
+#: The mixer children that mean a layer runs full (softmax) attention, and the
+#: ones that mean it runs a linear-attention kernel. Named here so
+#: :meth:`ModelBundle.stream_at` and :meth:`ModelBundle.mixer_at` read the same
+#: table instead of each carrying its own probe order.
+_FULL_ATTENTION_CHILDREN: tuple[str, ...] = ("self_attn", "attn")
+_LINEAR_ATTENTION_CHILDREN: tuple[str, ...] = ("linear_attn",)
+
+
 @dataclasses.dataclass(frozen=True)
 class ModelBundle:
     """One loaded model with everything the executor needs."""
@@ -69,11 +77,31 @@ class ModelBundle:
 
         Returns one of ``"full_attention"`` (a ``self_attn``/``attn`` child) or
         ``"linear_attention"`` (a ``linear_attn`` child).
+
+        Raises:
+            ProtocolError: the block has no recognised mixer child, or has
+                children of *both* kinds. The second case is hypothetical — no
+                family in the round-1 box map ships it — but probing in a fixed
+                order would answer "full_attention" for it silently, and every
+                per-layer tap downstream would then attach to the wrong module
+                and still produce plausible numbers. A named refusal is the
+                same trade this module makes everywhere else.
         """
         block = self.blocks[layer]
-        if hasattr(block, "self_attn") or hasattr(block, "attn"):
+        full = [name for name in _FULL_ATTENTION_CHILDREN if hasattr(block, name)]
+        linear = [name for name in _LINEAR_ATTENTION_CHILDREN if hasattr(block, name)]
+        if full and linear:
+            raise ProtocolError(
+                "P4",
+                f"layer {layer} of {self.key!r} carries both a full-attention "
+                f"child ({', '.join(full)}) and a linear-attention child "
+                f"({', '.join(linear)}) — the stream of a layer must be one or "
+                "the other, so extend the stream table in "
+                "pytorch_hooks/loading.py to say which this family means",
+            )
+        if full:
             return "full_attention"
-        if hasattr(block, "linear_attn"):
+        if linear:
             return "linear_attention"
         raise ProtocolError(
             "P4",
@@ -83,14 +111,22 @@ class ModelBundle:
         )
 
     def mixer_at(self, layer: int) -> Any:
-        """The attention/mixer module at ``layer``, whichever stream it is."""
+        """The attention/mixer module at ``layer``, whichever stream it is.
+
+        Resolved *through* :meth:`stream_at` rather than by its own probe, so
+        the two can never disagree about a block: one answer, one place.
+        """
         block = self.blocks[layer]
-        for name in ("attn", "self_attn", "linear_attn"):
+        names = (
+            _FULL_ATTENTION_CHILDREN
+            if self.stream_at(layer) == "full_attention"
+            else _LINEAR_ATTENTION_CHILDREN
+        )
+        for name in names:
             child = getattr(block, name, None)
             if child is not None:
                 return child
-        self.stream_at(layer)  # raises with the useful message
-        raise AssertionError("unreachable")
+        raise AssertionError("unreachable")  # stream_at only answers if one exists
 
     @property
     def streams(self) -> tuple[str, ...]:

--- a/causalab/neural/pytorch_hooks/sites.py
+++ b/causalab/neural/pytorch_hooks/sites.py
@@ -94,8 +94,13 @@ def _blocks(bundle: ModelBundle) -> Any:
 
 
 def _attn(bundle: ModelBundle, layer: int) -> Any:
-    block = _blocks(bundle)[layer]
-    return block.attn if bundle.is_gpt2_family else block.self_attn
+    """The mixer at ``layer`` — ``self_attn``, ``attn`` or ``linear_attn``.
+
+    Was ``block.self_attn`` for every non-GPT-2 model, which AttributeErrors on
+    a hybrid tower: 📐 on ``tiny-random/qwen3.5-moe`` three of four layers carry
+    ``linear_attn`` (Gated DeltaNet) and only one carries ``self_attn``. The
+    per-layer answer lives on the bundle (§5.2)."""
+    return bundle.mixer_at(layer)
 
 
 def _o_proj(bundle: ModelBundle, layer: int) -> Any:
@@ -107,6 +112,45 @@ def _head_dim(bundle: ModelBundle) -> int:
     return bundle.info.head_dim
 
 
+#: Components that only exist on a full-attention mixer. A Gated DeltaNet layer
+#: has no attention matrix at all — there is nothing to read and nothing to
+#: write — so naming one at such a layer is an error about the *architecture*,
+#: not a missing feature (§5.3).
+_FULL_ATTENTION_ONLY: frozenset[str] = frozenset({"attention_probs"})
+
+
+def _check_stream(
+    bundle: ModelBundle, component: str, spec: SiteSpec, layer: int
+) -> None:
+    """Refuse a site whose stream the layer does not carry, before hooking.
+
+    Two ways to get this wrong, and both are caught here rather than as an
+    AttributeError from inside a hook:
+
+    * the site *declares* a ``stream`` the layer does not have — ``stream`` has
+      parsed since ``schema.py`` gained it and nothing read it until now (§5.2);
+    * the site names a full-attention-only component at a linear-attention
+      layer, which no ``stream`` spelling can make true (§5.3).
+    """
+    actual = bundle.stream_at(layer)
+    declared = spec.stream if isinstance(spec.stream, str) else None
+    if declared is not None and declared != actual:
+        raise ProtocolError(
+            "P4",
+            f"site names stream {declared!r} at layer {layer}, but that layer "
+            f"carries {actual!r} — this is a hybrid tower ({', '.join(bundle.streams)}), "
+            "so the stream is a per-layer fact, not a model-wide one",
+        )
+    if component in _FULL_ATTENTION_ONLY and actual != "full_attention":
+        raise ProtocolError(
+            "P4",
+            f"component {component!r} needs a full-attention mixer, but layer "
+            f"{layer} of {bundle.key!r} carries {actual!r} — a Gated DeltaNet "
+            "block computes no attention matrix, so there is no such tensor at "
+            f"this layer. This tower is ({', '.join(bundle.streams)}).",
+        )
+
+
 def resolve_site(bundle: ModelBundle, spec: SiteSpec) -> ResolvedSite:
     """Resolve one site record to its tap. Refuses honestly on components
     this backend does not implement yet."""
@@ -116,6 +160,19 @@ def resolve_site(bundle: ModelBundle, spec: SiteSpec) -> ResolvedSite:
     layer = spec.layer if isinstance(spec.layer, int) else 0
     head = spec.head if isinstance(spec.head, int) else None
 
+    if component == "input_ids":
+        # the ids themselves, taken as the embedding's INPUT: that is the one
+        # module boundary they cross, and a forward pre-hook already exists for
+        # the "in" side. Read-only and layer-less (§5.4); `bs` layout because
+        # there is no feature axis, only one integer per position.
+        module = (
+            bundle.model.transformer.wte
+            if bundle.is_gpt2_family
+            else bundle.model.model.embed_tokens
+        )
+        return ResolvedSite(
+            module=module, kind="in", layer=0, component=component, layout="bs"
+        )
     if component == "embeddings":
         module = (
             bundle.model.transformer.wte
@@ -135,6 +192,13 @@ def resolve_site(bundle: ModelBundle, spec: SiteSpec) -> ResolvedSite:
         )
         return ResolvedSite(module=module, kind="out", layer=layer, component=component)
 
+    # Order matters: the stream check runs FIRST so that a full-attention-only
+    # component at a Gated DeltaNet layer refuses with the architectural reason
+    # ("there is no attention matrix here") rather than the temporary one ("this
+    # backend has not implemented it yet"). The first is permanent and true even
+    # after PR4 lands attention_probs; the second is a roadmap statement.
+    _check_stream(bundle, component, spec, layer)
+
     if component in ("attention_probs", "router_logits", "expert_output"):
         raise NotImplementedError(
             f"the pytorch_hooks backend has no tap for {component!r} yet — "
@@ -144,6 +208,28 @@ def resolve_site(bundle: ModelBundle, spec: SiteSpec) -> ResolvedSite:
         )
 
     block = _blocks(bundle)[layer]
+    if component == "attention_input_norm":
+        # input_layernorm's OUTPUT: what the mixer actually consumes
+        return ResolvedSite(
+            module=block.input_layernorm, kind="out", layer=layer, component=component
+        )
+    if component == "block_mid":
+        # post_attention_layernorm's INPUT is resid_mid — the residual stream
+        # after the mixer has been added and before the MLP branch
+        return ResolvedSite(
+            module=block.post_attention_layernorm,
+            kind="in",
+            layer=layer,
+            component=component,
+        )
+    if component == "mlp_input_norm":
+        # ...and its OUTPUT is what the MoE block consumes
+        return ResolvedSite(
+            module=block.post_attention_layernorm,
+            kind="out",
+            layer=layer,
+            component=component,
+        )
     if component == "block_output":
         return ResolvedSite(module=block, kind="out", layer=layer, component=component)
     if component == "block_input":

--- a/causalab/protocol/plan.py
+++ b/causalab/protocol/plan.py
@@ -42,11 +42,17 @@ __all__ = [
 #: data used only to find a group's deepest tap (elision, §4). ``ln_final``
 #: and ``lm_head`` sort after every block.
 COMPONENT_RANK: dict[str, int] = {
+    "input_ids": -1,  # the model's input: before every activation
     "embeddings": 0,
     "block_input": 10,
+    "attention_input_norm": 15,  # input_layernorm, between resid_pre and the mixer
     "attention_probs": 20,
     "attention_value": 30,
     "attention_output": 40,
+    # resid_mid is post_attention_layernorm's INPUT and mlp_input_norm its
+    # OUTPUT, so the two straddle that one module in this order
+    "block_mid": 45,
+    "mlp_input_norm": 47,
     "mlp_input": 50,
     "mlp_activation": 60,
     "mlp_output": 70,

--- a/causalab/protocol/registry.py
+++ b/causalab/protocol/registry.py
@@ -14,8 +14,10 @@ Widths per component (the ``(model, site) → d`` rule of §2.5):
 component          feature width
 =================  =======================================================
 ``embeddings``, ``block_input``, ``block_output``, ``attention_output``,
-``mlp_input``, ``mlp_output``, ``ln_final``, ``expert_output``
-                   ``hidden_size``
+``mlp_input``, ``mlp_output``, ``ln_final``, ``expert_output``,
+``attention_input_norm``, ``block_mid``, ``mlp_input_norm``
+                   ``hidden_size`` — the three norm taps are residual-stream
+                   shaped, being an RMSNorm's input or output
 ``mlp_activation`` ``intermediate_size`` (the family caveat of what tensor
                    this names lives in the backend, not here)
 ``attention_value``
@@ -26,6 +28,8 @@ component          feature width
 ``attention_probs``
                    no static width — sequence-shaped; featurizers are
                    refused on it
+``input_ids``      no static width — token ids are not a feature space at all
+                   (§5.4): no featurizer, no gradient, read-only
 =================  =======================================================
 """
 
@@ -133,6 +137,11 @@ def component_width(info: ModelInfo, component: str, *, head: int | None = None)
         "mlp_output",
         "ln_final",
         "expert_output",
+        # the three norm taps: an RMSNorm maps the residual stream to itself,
+        # so both its sides are hidden_size-wide
+        "attention_input_norm",
+        "block_mid",
+        "mlp_input_norm",
     ):
         return info.hidden_size
     if component == "mlp_activation":
@@ -149,6 +158,15 @@ def component_width(info: ModelInfo, component: str, *, head: int | None = None)
                 4, f"model {info.key!r} declares no experts; router_logits has no width"
             )
         return info.num_experts
+    if component == "input_ids":
+        raise ValidationError(
+            4,
+            "component 'input_ids' is the model's token input, not a feature "
+            "space (§5.4): it carries integer ids on a position axis, so it has "
+            "no width for a featurizer to match, no gradient to train through, "
+            "and no meaningful subspace. Read it directly, or read 'embeddings' "
+            "if you want the vector the ids look up.",
+        )
     raise ValidationError(
         4,
         f"component {component!r} has no static feature width — featurizers "

--- a/causalab/protocol/schema.py
+++ b/causalab/protocol/schema.py
@@ -85,17 +85,21 @@ __all__ = [
 # --------------------------------------------------------------------------- #
 
 Component = Literal[
+    "input_ids",
     "embeddings",
     "block_input",
-    "block_output",
+    "attention_input_norm",
     "attention_output",
     "attention_value",
     "attention_probs",
+    "block_mid",
+    "mlp_input_norm",
     "mlp_input",
     "mlp_output",
     "mlp_activation",
     "router_logits",
     "expert_output",
+    "block_output",
     "ln_final",
     "lm_head",
 ]
@@ -104,7 +108,11 @@ Component = Literal[
 COMPONENTS: tuple[Component, ...] = get_args(Component)
 
 #: Components that carry no ``layer`` field.
-LAYERLESS_COMPONENTS: frozenset[str] = frozenset({"embeddings", "ln_final", "lm_head"})
+#: ``input_ids`` joins these because it is the model's *input* (§5.4), not an
+#: activation inside a block — there is no layer at which to read it.
+LAYERLESS_COMPONENTS: frozenset[str] = frozenset(
+    {"input_ids", "embeddings", "ln_final", "lm_head"}
+)
 
 FeaturizerKind = Literal["identity", "subspace", "pca", "sae", "standardize", "gate"]
 FEATURIZER_KINDS: tuple[FeaturizerKind, ...] = get_args(FeaturizerKind)

--- a/docs/intervention_protocol.md
+++ b/docs/intervention_protocol.md
@@ -168,17 +168,36 @@ the model said the row's value for `x`.
 |---|---|
 | `component` | one of the vocabulary below |
 | `layer` | depth index (where the component has one) |
-| `head` / `expert` / `stream` | optional sub-axes: attention head, MoE expert, residual-stream index |
+| `head` / `expert` / `stream` | optional sub-axes: attention head, MoE expert, **mixer stream** |
 
-Component vocabulary (per-backend `SiteResolver` maps each to a tap):
+Component vocabulary (per-backend `SiteResolver` maps each to a tap), in
+execution order:
 
-`embeddings` · `block_input` · `block_output` · `attention_output` ·
-`attention_value` · `attention_probs` · `mlp_input` · `mlp_output` ·
-`mlp_activation` · `router_logits` · `expert_output` · `ln_final` · `lm_head`
+`input_ids` · `embeddings` · `block_input` · `attention_input_norm` ·
+`attention_output` · `attention_value` · `attention_probs` · `block_mid` ·
+`mlp_input_norm` · `mlp_input` · `mlp_output` · `mlp_activation` ·
+`router_logits` · `expert_output` · `block_output` · `ln_final` · `lm_head`
 
 - **`sites` is the complete inventory**: every site a read or write references
   must be declared here, including `lm_head` (`{"component": "lm_head"}`).
   There are no implicit site names.
+- **The three norm taps** name the two RMSNorms every block carries:
+  `attention_input_norm` is `input_layernorm`'s **output** (what the mixer
+  consumes), `block_mid` is `post_attention_layernorm`'s **input** (the residual
+  stream after the mixer is added), and `mlp_input_norm` is that same module's
+  **output**. So a block satisfies
+  `block_mid = block_input + attention_output` and
+  `block_output = block_mid + mlp_output`.
+- **`input_ids` is the model's token input, not an activation.** It is
+  layer-less, **read-only**, and *not a feature space*: it carries integer ids
+  on a position axis, so no featurizer may attach to it and it has no width.
+  Read `embeddings` for the vector the ids look up.
+- **`stream` names a mixer stream, and it is a per-layer fact.** A hybrid tower
+  carries a different mixer at different depths (Qwen3.6's text tower alternates
+  Gated DeltaNet with gated full attention), so a site whose declared `stream`
+  contradicts the layer it names is refused at load. `attention_probs` requires
+  a full-attention layer: a linear-attention block computes no attention matrix,
+  so the refusal there is about the architecture and is permanent.
 - Sites are pure data — no behavior, no model handles.
 
 ### 2.5 `featurizers`

--- a/tests/neural/pytorch_hooks/conftest.py
+++ b/tests/neural/pytorch_hooks/conftest.py
@@ -18,9 +18,10 @@ TINY_LLAMA = "hf-internal-testing/tiny-random-LlamaForCausalLM"
 TINY_GPT2 = "hf-internal-testing/tiny-random-gpt2"
 #: The hookpoint-vocabulary target architecture in miniature: a real hybrid
 #: stack (layers 0-2 Gated DeltaNet, layer 3 full attention) with a sparse MoE
-#: in every layer. Deliberately *not* in the parametrized ``bundle`` fixture —
-#: the site resolver cannot address a DeltaNet layer yet, so the oracle suites
-#: would fail on it. Ask for ``qwen35moe_bundle`` explicitly.
+#: in every layer. Deliberately *not* in the parametrized ``bundle`` fixture:
+#: the oracle suites pin family-specific tensors the oracle has no MoE/DeltaNet
+#: entry for. The site resolver *can* address a DeltaNet layer as of PR2 (the
+#: mixer is resolved per layer), so ask for ``qwen35moe_bundle`` explicitly.
 TINY_QWEN35_MOE = "tiny-random/qwen3.5-moe"
 
 BASE_TEXT = "the quick brown fox jumps"

--- a/tests/neural/pytorch_hooks/test_layout.py
+++ b/tests/neural/pytorch_hooks/test_layout.py
@@ -26,6 +26,15 @@ pytestmark = pytest.mark.unit
 BATCH, SEQ, FEATURE = 2, 3, 5
 
 
+def _feature(layout: str) -> int:
+    """The feature width the contract has for this layout.
+
+    ``"bs"`` has no native feature axis, so its contract width is 1 by
+    definition rather than by choice — the generic assertions below are
+    parametrized on this instead of on the module-level ``FEATURE``."""
+    return 1 if layout == "bs" else FEATURE
+
+
 def _native(layout: str) -> torch.Tensor:
     if layout == "bsd":
         return torch.arange(BATCH * SEQ * FEATURE, dtype=torch.float32).reshape(
@@ -39,6 +48,8 @@ def _native(layout: str) -> torch.Tensor:
         return torch.arange(BATCH * FEATURE * SEQ, dtype=torch.float32).reshape(
             BATCH, FEATURE, SEQ
         )
+    if layout == "bs":
+        return torch.arange(BATCH * SEQ, dtype=torch.float32).reshape(BATCH, SEQ)
     raise AssertionError(layout)
 
 
@@ -46,7 +57,7 @@ def _native(layout: str) -> torch.Tensor:
 def test_to_contract_yields_the_executor_shape(layout: str) -> None:
     """Whatever the tap's native shape, the executor sees (batch, pos, feature)."""
     got = to_contract(_native(layout), layout, batch_size=BATCH)
-    assert got.shape == (BATCH, SEQ, FEATURE)
+    assert got.shape == (BATCH, SEQ, _feature(layout))
 
 
 @pytest.mark.parametrize("layout", LAYOUTS)
@@ -72,9 +83,10 @@ def test_an_in_place_edit_through_the_contract_reaches_the_native_tensor(
     """
     native = _native(layout)
     contract = to_contract(native, layout, batch_size=BATCH)
-    contract[0, 1, 2] = -99.0
+    cell = (0, 1, _feature(layout) - 1)
+    contract[cell] = -99.0
     back = from_contract(contract, layout, batch_size=BATCH)
-    assert to_contract(back, layout, batch_size=BATCH)[0, 1, 2] == -99.0
+    assert to_contract(back, layout, batch_size=BATCH)[cell] == -99.0
 
 
 def test_bsd_is_the_identity() -> None:

--- a/tests/neural/pytorch_hooks/test_sites_round1_block.py
+++ b/tests/neural/pytorch_hooks/test_sites_round1_block.py
@@ -192,6 +192,63 @@ def test_a_site_naming_the_right_stream_resolves(qwen35moe_bundle):
         assert site.module is qwen35moe_bundle.mixer_at(layer)
 
 
+def test_a_block_carrying_both_mixer_kinds_refuses_instead_of_guessing(
+    qwen35moe_bundle,
+):
+    """A hypothetical block with both children must not resolve silently.
+
+    No family in the round-1 box map ships one, so this is a guard rather than
+    a regression — but `stream_at` answers by probing children, and a fixed
+    probe order would call such a block "full_attention" without a word. Every
+    per-layer tap would then attach to one of its two mixers and go on
+    producing plausible numbers, which is the failure mode the whole
+    stream-per-layer fix exists to remove.
+
+    Built by grafting a `linear_attn` child onto the fixture's one real
+    full-attention layer, so the block is a genuine torch module in both
+    respects and not a stub that only looks like one.
+    """
+    full_layer = qwen35moe_bundle.streams.index("full_attention")
+    linear_layer = qwen35moe_bundle.streams.index("linear_attention")
+    block = qwen35moe_bundle.blocks[full_layer]
+    donor = qwen35moe_bundle.blocks[linear_layer].linear_attn
+
+    block.add_module("linear_attn", donor)
+    try:
+        with pytest.raises(ProtocolError) as excinfo:
+            qwen35moe_bundle.stream_at(full_layer)
+        message = str(excinfo.value)
+        assert "self_attn" in message and "linear_attn" in message
+        # and mixer_at must not answer either, since it resolves through stream_at
+        with pytest.raises(ProtocolError):
+            qwen35moe_bundle.mixer_at(full_layer)
+    finally:
+        del block._modules["linear_attn"]
+
+    # the fixture is intact again — the graft must not leak into later tests
+    assert qwen35moe_bundle.stream_at(full_layer) == "full_attention"
+
+
+def test_mixer_at_and_stream_at_never_disagree(qwen35moe_bundle, llama_bundle):
+    """`mixer_at` picks the child that matches the stream `stream_at` named.
+
+    They used to probe independently, in different orders (`attn` before
+    `self_attn` in one, the reverse in the other) — harmless for every family
+    here, and exactly the kind of duplicated table that stops being harmless
+    once a family has both names.
+    """
+    for bundle in (qwen35moe_bundle, llama_bundle):
+        for layer, stream in enumerate(bundle.streams):
+            block = bundle.blocks[layer]
+            mixer = bundle.mixer_at(layer)
+            if stream == "full_attention":
+                assert mixer is getattr(block, "self_attn", None) or mixer is getattr(
+                    block, "attn", None
+                )
+            else:
+                assert mixer is block.linear_attn
+
+
 # --------------------------------------------------------------------------- #
 # §5.3 — refuse for the permanent reason before the temporary one
 # --------------------------------------------------------------------------- #

--- a/tests/neural/pytorch_hooks/test_sites_round1_block.py
+++ b/tests/neural/pytorch_hooks/test_sites_round1_block.py
@@ -1,0 +1,406 @@
+"""Round-1 block components: the four new taps, and per-layer stream dispatch.
+
+PR2 of the hookpoint-vocabulary stack. Four components join the vocabulary —
+``input_ids``, ``attention_input_norm``, ``block_mid``, ``mlp_input_norm`` — and
+``attention_output`` learns that the mixer is a *per-layer* fact.
+
+The shape assertions here are measurements against a real ``qwen3_5_moe``
+checkpoint, so a mismatch is a finding rather than a stale expectation. The
+identity assertions are stronger than shapes: they pin that each tap names the
+tensor its *name* claims, by reproducing the decoder layer's residual algebra
+from the taps alone.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from causalab.neural.pytorch_hooks.layout import (
+    LayoutError,
+    from_contract,
+    tap_tensor,
+    to_contract,
+)
+from causalab.neural.pytorch_hooks.loading import ModelBundle, load_model
+from causalab.neural.pytorch_hooks.sites import resolve_site
+from causalab.protocol.errors import ProtocolError, ValidationError
+from causalab.protocol.plan import COMPONENT_RANK
+from causalab.protocol.registry import component_width
+from causalab.protocol.schema import COMPONENTS, LAYERLESS_COMPONENTS, SiteSpec
+
+from .conftest import TINY_LLAMA, TINY_QWEN35_MOE
+
+pytestmark = pytest.mark.smoke
+
+#: The four new components, plus the one whose resolution changed.
+NEW_COMPONENTS = ("input_ids", "attention_input_norm", "block_mid", "mlp_input_norm")
+PR2_COMPONENTS = NEW_COMPONENTS + ("attention_output",)
+
+TEXT = "the quick brown fox jumps"
+
+
+def _spec(component: str, layer: int | None = None, **kw: object) -> SiteSpec:
+    if component in LAYERLESS_COMPONENTS:
+        return SiteSpec(component=component, **kw)
+    return SiteSpec(component=component, layer=0 if layer is None else layer, **kw)
+
+
+def _capture(
+    bundle: ModelBundle, specs: dict[str, SiteSpec]
+) -> dict[str, torch.Tensor]:
+    """Read many sites in one forward pass, each in contract shape."""
+    encoded = bundle.tokenizer(TEXT, return_tensors="pt")
+    batch = encoded["input_ids"].shape[0]
+    out: dict[str, torch.Tensor] = {}
+    handles = []
+    for name, spec in specs.items():
+        site = resolve_site(bundle, spec)
+
+        def hook(_mod, inp, output=None, *, _name=name, _site=site):
+            payload = inp if output is None else output
+            if output is None and isinstance(payload, tuple) and len(payload) == 1:
+                payload = payload[0]
+            tensor = tap_tensor(payload, _site.tuple_index)
+            out[_name] = (
+                to_contract(tensor, _site.layout, batch_size=batch).detach().clone()
+            )
+
+        handles.append(
+            site.module.register_forward_pre_hook(hook)
+            if site.kind == "in"
+            else site.module.register_forward_hook(hook)
+        )
+    try:
+        with torch.no_grad():
+            bundle.model(**encoded)
+    finally:
+        for handle in handles:
+            handle.remove()
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# the vocabulary itself
+# --------------------------------------------------------------------------- #
+
+
+def test_the_four_components_joined_the_closed_vocabulary():
+    for component in NEW_COMPONENTS:
+        assert component in COMPONENTS, f"{component} missing from Component"
+
+
+def test_input_ids_is_layerless_and_the_others_are_not():
+    """``input_ids`` is the model's *input* (§5.4) — there is no layer at which
+    to read it, and naming one is a parse error."""
+    assert "input_ids" in LAYERLESS_COMPONENTS
+    for component in ("attention_input_norm", "block_mid", "mlp_input_norm"):
+        assert component not in LAYERLESS_COMPONENTS
+
+
+def test_the_new_ranks_order_the_block_as_the_forward_pass_runs():
+    """Group elision (§4) picks a group's deepest tap, so the ranks must follow
+    the decoder layer's actual order — the same order the identities below
+    reproduce."""
+    order = [
+        "input_ids",
+        "embeddings",
+        "block_input",
+        "attention_input_norm",
+        "attention_output",
+        "block_mid",
+        "mlp_input_norm",
+        "mlp_input",
+        "mlp_output",
+        "block_output",
+    ]
+    ranks = [COMPONENT_RANK[c] for c in order]
+    assert ranks == sorted(ranks), dict(zip(order, ranks))
+
+
+# --------------------------------------------------------------------------- #
+# widths: three are residual-shaped, one is not a feature space at all
+# --------------------------------------------------------------------------- #
+
+
+def test_the_three_norm_taps_are_residual_width(qwen35moe_bundle):
+    hidden = qwen35moe_bundle.info.hidden_size
+    for component in ("attention_input_norm", "block_mid", "mlp_input_norm"):
+        assert component_width(qwen35moe_bundle.info, component) == hidden
+
+
+def test_input_ids_refuses_a_width_because_it_is_not_a_feature_space(qwen35moe_bundle):
+    """§5.4: integer ids on a position axis. No featurizer can attach, and the
+    refusal must say *why* rather than read as a missing table entry."""
+    with pytest.raises(ValidationError) as excinfo:
+        component_width(qwen35moe_bundle.info, "input_ids")
+    assert "not a feature space" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------- #
+# §5.2 — the mixer is a per-layer fact
+# --------------------------------------------------------------------------- #
+
+
+def test_the_fixture_tower_really_is_hybrid(qwen35moe_bundle):
+    """📐 The premise every assertion below rests on."""
+    assert qwen35moe_bundle.streams == (
+        "linear_attention",
+        "linear_attention",
+        "linear_attention",
+        "full_attention",
+    )
+
+
+def test_attention_output_follows_the_stream_per_layer(qwen35moe_bundle):
+    """The §5.2 fix. ``block.self_attn`` for every non-GPT-2 model raised
+    AttributeError on 3 of these 4 layers — the tap now asks the layer."""
+    for layer, stream in enumerate(qwen35moe_bundle.streams):
+        site = resolve_site(qwen35moe_bundle, _spec("attention_output", layer))
+        block = qwen35moe_bundle.blocks[layer]
+        if stream == "full_attention":
+            assert site.module is block.self_attn
+        else:
+            assert site.module is block.linear_attn
+            # and the regression this replaces: there is no self_attn to reach
+            assert not hasattr(block, "self_attn")
+
+
+def test_a_site_naming_the_wrong_stream_refuses(qwen35moe_bundle):
+    """``stream`` has parsed since schema.py gained it and nothing read it
+    (§5.2). It reads it now, and a contradiction is an error."""
+    with pytest.raises(ProtocolError) as excinfo:
+        resolve_site(
+            qwen35moe_bundle,
+            _spec("attention_output", 0, stream="full_attention"),
+        )
+    assert "layer 0" in str(excinfo.value)
+
+    with pytest.raises(ProtocolError):
+        resolve_site(
+            qwen35moe_bundle,
+            _spec("attention_output", 3, stream="linear_attention"),
+        )
+
+
+def test_a_site_naming_the_right_stream_resolves(qwen35moe_bundle):
+    for layer, stream in enumerate(qwen35moe_bundle.streams):
+        site = resolve_site(
+            qwen35moe_bundle, _spec("attention_output", layer, stream=stream)
+        )
+        assert site.module is qwen35moe_bundle.mixer_at(layer)
+
+
+# --------------------------------------------------------------------------- #
+# §5.3 — refuse for the permanent reason before the temporary one
+# --------------------------------------------------------------------------- #
+
+
+def test_attention_probs_at_a_deltanet_layer_refuses_on_the_architecture(
+    qwen35moe_bundle,
+):
+    """A Gated DeltaNet block computes no attention matrix, so this is not a
+    missing feature — it stays false after PR4 lands ``attention_probs``."""
+    with pytest.raises(ProtocolError) as excinfo:
+        resolve_site(qwen35moe_bundle, _spec("attention_probs", 0))
+    message = str(excinfo.value)
+    assert "full-attention mixer" in message
+    assert "linear_attention" in message
+
+
+def test_attention_probs_at_a_full_attention_layer_is_merely_unimplemented(
+    qwen35moe_bundle,
+):
+    """The other half of the ordering: at layer 3 the tensor exists, and the
+    refusal is a roadmap statement (PR4), not an architectural one."""
+    with pytest.raises(NotImplementedError):
+        resolve_site(qwen35moe_bundle, _spec("attention_probs", 3))
+
+
+# --------------------------------------------------------------------------- #
+# the taps name what they claim: the decoder layer's residual algebra
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("layer", [0, 3], ids=["deltanet", "full_attention"])
+def test_the_taps_reproduce_the_residual_algebra(qwen35moe_bundle, layer):
+    """The sanity check that shapes cannot give.
+
+    A Qwen3.5-MoE decoder layer runs::
+
+        h = input_layernorm(resid_pre)      -> attention_input_norm
+        h = mixer(h)                        -> attention_output
+        resid_mid = resid_pre + h           -> block_mid
+        h = post_attention_layernorm(resid_mid) -> mlp_input_norm
+        h = mlp(h)                          -> mlp_output
+        resid_post = resid_mid + h          -> block_output
+
+    So the three new taps are pinned by identities against taps that already
+    existed. If ``block_mid`` were accidentally the layernorm's *output* rather
+    than its input (the one-character mistake available here), the second
+    identity fails.
+    """
+    block = qwen35moe_bundle.blocks[layer]
+    got = _capture(
+        qwen35moe_bundle,
+        {
+            name: _spec(name, layer)
+            for name in (
+                "block_input",
+                "attention_input_norm",
+                "attention_output",
+                "block_mid",
+                "mlp_input_norm",
+                "mlp_output",
+                "block_output",
+            )
+        },
+    )
+
+    torch.testing.assert_close(
+        got["attention_input_norm"], block.input_layernorm(got["block_input"])
+    )
+    torch.testing.assert_close(
+        got["block_mid"], got["block_input"] + got["attention_output"]
+    )
+    torch.testing.assert_close(
+        got["mlp_input_norm"], block.post_attention_layernorm(got["block_mid"])
+    )
+    torch.testing.assert_close(
+        got["block_output"], got["block_mid"] + got["mlp_output"]
+    )
+
+
+@pytest.mark.parametrize("layer", [0, 3], ids=["deltanet", "full_attention"])
+def test_every_new_block_tap_is_residual_shaped(qwen35moe_bundle, layer):
+    """📐 §3 panel 2: every box in the DecoderLayer panel is ``(1, 6, 8)`` on
+    this fixture — 6 positions of hidden size 8."""
+    got = _capture(
+        qwen35moe_bundle,
+        {
+            n: _spec(n, layer)
+            for n in ("attention_input_norm", "block_mid", "mlp_input_norm")
+        },
+    )
+    hidden = qwen35moe_bundle.info.hidden_size
+    for name, tensor in got.items():
+        assert tensor.dim() == 3, name
+        assert tensor.shape[0] == 1 and tensor.shape[-1] == hidden, (name, tensor.shape)
+
+
+def test_the_three_norm_taps_are_three_different_tensors(qwen35moe_bundle):
+    """Two of them share a module and differ only by side, so a copy-paste slip
+    would make them alias — the failure a shape assertion cannot see."""
+    got = _capture(
+        qwen35moe_bundle,
+        {
+            n: _spec(n, 0)
+            for n in ("attention_input_norm", "block_mid", "mlp_input_norm")
+        },
+    )
+    values = list(got.values())
+    for i, first in enumerate(values):
+        for second in values[i + 1 :]:
+            assert not torch.equal(first, second)
+
+
+# --------------------------------------------------------------------------- #
+# input_ids
+# --------------------------------------------------------------------------- #
+
+
+def test_input_ids_reads_the_ids_the_tokenizer_produced(qwen35moe_bundle):
+    encoded = qwen35moe_bundle.tokenizer(TEXT, return_tensors="pt")
+    got = _capture(qwen35moe_bundle, {"input_ids": _spec("input_ids")})["input_ids"]
+    # contract shape: the degenerate feature axis of width 1
+    assert got.shape == (*encoded["input_ids"].shape, 1)
+    assert not got.dtype.is_floating_point, "token ids are integers"
+    torch.testing.assert_close(got.squeeze(-1), encoded["input_ids"])
+
+
+def test_input_ids_taps_the_embedding_input_on_both_families():
+    """The ids cross exactly one module boundary, and it differs by family."""
+    for key, attr in (
+        (TINY_QWEN35_MOE, "embed_tokens"),
+        (TINY_LLAMA, "embed_tokens"),
+    ):
+        bundle = load_model(key)
+        site = resolve_site(bundle, _spec("input_ids"))
+        assert site.module is getattr(bundle.model.model, attr)
+        assert site.kind == "in"
+        assert site.layout == "bs"
+
+
+# --------------------------------------------------------------------------- #
+# the "bs" layout
+# --------------------------------------------------------------------------- #
+
+
+def test_bs_layout_round_trips_and_returns_a_view():
+    """§6.2 review point 2: ``to_contract`` must return a view, so an in-place
+    edit reaches native storage. ``unsqueeze`` does; ``reshape`` might not."""
+    native = torch.arange(12).reshape(3, 4)
+    contract = to_contract(native, "bs", batch_size=3)
+    assert contract.shape == (3, 4, 1)
+    assert contract._base is native or contract.data_ptr() == native.data_ptr()
+    torch.testing.assert_close(from_contract(contract, "bs", batch_size=3), native)
+
+
+@pytest.mark.parametrize(
+    "bad", [torch.zeros(3), torch.zeros(2, 3, 4)], ids=["1d", "3d"]
+)
+def test_bs_layout_refuses_a_shape_it_cannot_mean(bad):
+    """A declared layout that contradicts the tensor raises rather than
+    reinterpreting — the wrong-tap-with-plausible-numbers failure."""
+    with pytest.raises(LayoutError):
+        to_contract(bad, "bs", batch_size=2)
+
+
+# --------------------------------------------------------------------------- #
+# family parity: the gate says all five read on tiny-llama too
+# --------------------------------------------------------------------------- #
+
+
+def test_all_five_components_resolve_on_a_non_hybrid_family(llama_bundle):
+    assert set(llama_bundle.streams) == {"full_attention"}
+    for component in PR2_COMPONENTS:
+        site = resolve_site(llama_bundle, _spec(component))
+        assert site.module is not None
+
+
+def test_all_five_components_read_on_a_non_hybrid_family(llama_bundle):
+    got = _capture(llama_bundle, {n: _spec(n) for n in PR2_COMPONENTS})
+    assert set(got) == set(PR2_COMPONENTS)
+    hidden = llama_bundle.info.hidden_size
+    for name, tensor in got.items():
+        width = 1 if name == "input_ids" else hidden
+        assert tensor.shape[-1] == width, (name, tensor.shape)
+
+
+def test_the_llama_residual_algebra_holds_too(llama_bundle):
+    """The identities are architecture-independent — same algebra, other family."""
+    block = llama_bundle.blocks[0]
+    got = _capture(
+        llama_bundle,
+        {
+            n: _spec(n, 0)
+            for n in (
+                "block_input",
+                "attention_input_norm",
+                "attention_output",
+                "block_mid",
+                "mlp_input_norm",
+                "mlp_output",
+                "block_output",
+            )
+        },
+    )
+    torch.testing.assert_close(
+        got["attention_input_norm"], block.input_layernorm(got["block_input"])
+    )
+    torch.testing.assert_close(
+        got["block_mid"], got["block_input"] + got["attention_output"]
+    )
+    torch.testing.assert_close(
+        got["mlp_input_norm"], block.post_attention_layernorm(got["block_mid"])
+    )

--- a/tests/neural/pytorch_hooks/test_sites_round1_block.py
+++ b/tests/neural/pytorch_hooks/test_sites_round1_block.py
@@ -29,6 +29,7 @@ from causalab.protocol.plan import COMPONENT_RANK
 from causalab.protocol.registry import component_width
 from causalab.protocol.schema import COMPONENTS, LAYERLESS_COMPONENTS, SiteSpec
 
+from ._drive import base_data_section, executor_for
 from .conftest import TINY_LLAMA, TINY_QWEN35_MOE
 
 pytestmark = pytest.mark.smoke
@@ -404,3 +405,82 @@ def test_the_llama_residual_algebra_holds_too(llama_bundle):
     torch.testing.assert_close(
         got["mlp_input_norm"], block.post_attention_layernorm(got["block_mid"])
     )
+
+
+# --------------------------------------------------------------------------- #
+# end to end through the executor — the path raw hooks do not exercise
+# --------------------------------------------------------------------------- #
+
+
+def _read_doc(component: str, layer: int | None = None, featurizer: bool = False):
+    site: dict = {"component": component}
+    if layer is not None:
+        site["layer"] = layer
+    read: dict = {
+        "site": "tap",
+        "pos": {"index": 1},
+        "model": "original",
+        "input": "base",
+    }
+    doc: dict = {
+        "version": "1",
+        "model": {"key": "test", "revision": "main"},
+        "data": base_data_section(with_counterfactual=False),
+        "sites": {"tap": site},
+        "reads": {"r": read},
+        "save": [
+            {
+                "value": "r",
+                "model": "original",
+                "input": "base",
+                "file_path": "a.safetensors",
+            }
+        ],
+    }
+    if featurizer:
+        doc["featurizers"] = {"f": {"kind": "subspace", "k": 1}}
+        read["featurizer"] = "f"
+    return doc
+
+
+@pytest.mark.parametrize(
+    "component", ["attention_input_norm", "block_mid", "mlp_input_norm"]
+)
+def test_a_document_reads_each_new_norm_component(llama_bundle, component: str):
+    """The §6 gate: a real document, parsed and validated, reads the component."""
+    executor = executor_for(_read_doc(component, 0), llama_bundle, base_texts=[TEXT])
+    value = executor.read_value("r")
+    assert value.shape == (1, 1, llama_bundle.info.hidden_size)
+
+
+def test_a_document_reads_input_ids_even_though_it_has_no_width(llama_bundle):
+    """The refusal in ``component_width`` must not make reading impossible.
+
+    A read with no featurizer needs no width — ``build_stack`` returns an
+    Identity stack and ignores it — so the executor asks for the width lazily.
+    Eagerly asking made a plain ``input_ids`` read raise the "not a feature
+    space" error, which is not what that refusal is for: it exists to reject a
+    *featurizer*, not a read.
+    """
+    executor = executor_for(_read_doc("input_ids"), llama_bundle, base_texts=[TEXT])
+    value = executor.read_value("r")
+    assert value.shape == (1, 1, 1)
+    assert not value.dtype.is_floating_point
+
+
+def test_a_featurizer_on_input_ids_still_refuses(llama_bundle):
+    """The other half: §5.4's rule survives the laziness above."""
+    with pytest.raises(ValidationError) as excinfo:
+        executor_for(
+            _read_doc("input_ids", featurizer=True), llama_bundle, base_texts=[TEXT]
+        ).read_value("r")
+    assert "not a feature space" in str(excinfo.value)
+
+
+def test_a_featurizer_on_a_norm_component_is_fine(llama_bundle):
+    """Anti-vacuity for the test above: the refusal is about the component, not
+    about featurizers being broken here."""
+    executor = executor_for(
+        _read_doc("block_mid", 0, featurizer=True), llama_bundle, base_texts=[TEXT]
+    )
+    assert executor.read_value("r").shape == (1, 1, 1)


### PR DESCRIPTION
PR2 of the Qwen3.6 hookpoint-vocabulary stack (§5.2, §5.3, §5.4 of the plan note). Four components join the closed vocabulary, and one existing component stops assuming the tower is homogeneous.

**Stacked on #48** (needs `layout.py`), with **#49 merged in** so CI reflects PR2 rather than the 17 failures the base carried. Review #48 and #49 first; this PR's own diff is 9 files / +241.

## The bug this fixes first

`_attn()` was `block.self_attn` for every non-GPT-2 model. 📐 On `tiny-random/qwen3.5-moe` the tower is `(linear_attention, linear_attention, linear_attention, full_attention)` — so **three of four layers have no `self_attn` at all**, and `attention_output` raised `AttributeError` from inside the hook. The mixer is now resolved per layer, off the module that is actually there rather than a config field or a boolean family flag. `ModelBundle` grows `blocks`, `stream_at`, `mixer_at`, `streams`.

## `stream` finally does something

It has parsed since `schema.py` gained it and **nothing read it** (§5.2). A site whose declared `stream` contradicts the layer it names is now refused, with the tower's actual shape in the message.

## Refusal order matters (§5.3)

The stream check runs **before** the "unimplemented" branch, so:

| site | refusal |
|---|---|
| `attention_probs` @ layer 0 (DeltaNet) | `ProtocolError` — *there is no attention matrix here*, and there still won't be after PR4 |
| `attention_probs` @ layer 3 (full attention) | `NotImplementedError` — merely unimplemented, PR4's job |

One is permanent and one is a roadmap statement; they should not read alike.

## The three norm taps

`attention_input_norm` = `input_layernorm`'s **output**; `block_mid` = `post_attention_layernorm`'s **input**; `mlp_input_norm` = that same module's **output**.

Two of them share a module and differ only by side — a one-character mistake waiting to happen, and one that no shape assertion can catch. So they are pinned by **identities**: the tests reproduce the decoder layer's residual algebra from the taps alone —

```
block_mid       == block_input + attention_output
mlp_input_norm  == post_attention_layernorm(block_mid)
block_output    == block_mid + mlp_output
attention_input_norm == input_layernorm(block_input)
```

— on a DeltaNet layer, on a full-attention layer, and on tiny-llama. Plus a test that the three are three *different* tensors.

## `input_ids` (§5.4)

The model's input, not an activation: **layer-less**, **read-only**, and **not a feature space**. `component_width` refuses it with a message saying *why* rather than reading as a missing table entry, so an author who attaches a featurizer learns it is a category error, not a typo. Its tap is the embedding's `in` side — the one module boundary the ids cross.

It needs a shape no layout covered, `(batch, seq)` with no feature axis, so `layout.py` gains **`"bs"`**. That belongs there rather than as a reshape in the executor: an absent axis is still a native-shape mismatch, which is exactly what that module reconciles, and `unsqueeze` keeps it a **view** so #48's aliasing property (review point 2) holds. It is deliberately *not* the typed feature-shape descriptor `attention_probs` needs (F1) — there is no feature-axis ambiguity here, only a missing axis, so this does not pre-empt that design.

#48's layout suite is exhaustive over `LAYOUTS`, so `"bs"` enrolled itself and the helpers needed a per-layout feature width — nice property to have inherited.

## Gates

- `pytest -m "not golden"` — **1790 passed, 8 deselected** (GPU-only golden tier), 0 failed
- `pre-commit run --all-files` — green repo-wide (ruff 0.14.5)
- parity goldens **untouched**
- 24 new tests in `test_sites_round1_block.py`

Vocabulary, the three norm rules, the `input_ids` rules and the per-layer `stream` rule are all written into `docs/intervention_protocol.md` §2.4.

Plan note: `notes/causalab-hookpoint-vocabulary-plan.md` §6 PR2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)